### PR TITLE
ci: bump deprecated Node-20 GitHub Actions to current majors

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -69,16 +69,16 @@ jobs:
     env:
       AWS_REGION: us-east-2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Assume AWS role via GitHub OIDC
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-2
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           version: latest
 
@@ -89,7 +89,7 @@ jobs:
         run: uv sync --frozen
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: npm
@@ -104,7 +104,7 @@ jobs:
         run: npx observable build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dashboard/dist
 
@@ -126,4 +126,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## What

GitHub is forcing Node-20 JavaScript actions onto Node 24 (deprecation **active as of 2026-06-16** — the new `test.yml` run in #322 surfaced the warning). This bumps the affected actions in the two workflows on `main` to their current Node-24 majors.

Version tags only — no input, step, or logic changes.

| File | Action | Old → New | Runtime |
|---|---|---|---|
| dashboard.yml + claude.yml | `actions/checkout` | v4 → **v6** | node24 |
| dashboard.yml | `aws-actions/configure-aws-credentials` | v4 → **v6** | node24 |
| dashboard.yml | `astral-sh/setup-uv` | v3 → **v7** | node24 |
| dashboard.yml | `actions/setup-node` | v4 → **v5** | node24 |
| dashboard.yml | `actions/upload-pages-artifact` | v3 → **v5** | composite |
| dashboard.yml | `actions/deploy-pages` | v4 → **v5** | node24 |

Each target was verified against the action's `action.yml` `runs.using` field. Notably `aws-actions/configure-aws-credentials` is still `node20` through **v5**, so it needs **v6** — a v4→v5 bump would *not* have cleared the deprecation.

`anthropics/claude-code-action@v1` is intentionally left untouched (functional action, not a Node-20 deprecation target).

Split out from #322 (the CPU pytest gate) per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
