### PR TITLE
evals_v2: pooled both-allele embeddings in the variant LLR/JSD score bundle (one forward pass)

### DIFF
--- a/scripts/issue318_batch_sweep.py
+++ b/scripts/issue318_batch_sweep.py
@@ -1,0 +1,120 @@
+"""VRAM batch-size sweep for #318 embedding runs (post base-model-hook).
+
+After switching the embedding capture from `output_hidden_states=True` (all layers)
+to a forward hook on `model.base_model` (last layer only), the per-batch forward is
+lighter — but the suffix logits over the full Qwen vocab still scale with batch, so
+the real ceiling is empirical. This measures peak GPU memory of
+`run_variant_score_bundle(return_embeddings=True, rc=True)` on exp135 across batch
+sizes, to pick a safe production `batch_size`.
+
+The model is loaded ONCE (a warm-up settles it to bf16); each batch size scores
+exactly one batch (`n == batch_size`) so the peak reflects the per-batch FORWARD
+footprint — model + activations + suffix logits + the captured last-hidden states +
+one batch of `[N, 2+2D]` predictions. (Full-dataset Trainer prediction accumulation
+is a separate, N-dependent cost — see `inference.eval_accumulation_steps`.)
+
+Run on a GPU node:
+  uv run --group genome-s3 python scripts/issue318_batch_sweep.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import tempfile
+
+import s3fs
+import torch
+from datasets import Dataset, load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from marin_dna.data.genome import Genome
+from marin_dna.model.runner import run_variant_score_bundle
+
+MODEL = "mix-v0.9-p1B-i24-exp135-m5.1-step-59158"
+CKPT_S3 = "oa-bolinas/snakemake/analysis/evals_v2/results/checkpoints/" + MODEL
+GENOME = (
+    "s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/"
+    "Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
+)
+MEND_REPO = "bolinas-dna/evals_mendelian_traits"
+MEND_REV = "4aed58e50c5dea0b878a665007af2ef9e5108e9f"
+WINDOW = 255
+
+
+def localize_checkpoint() -> str:
+    fs = s3fs.S3FileSystem()
+    dst = tempfile.mkdtemp(prefix="exp135_ckpt_")
+    for f in fs.ls(CKPT_S3, detail=False):
+        name = f.rstrip("/").split("/")[-1]
+        if not name.startswith("."):
+            fs.get_file(f, os.path.join(dst, name))
+    return dst
+
+
+def _score(model, tokenizer, genome, df, batch_size: int) -> None:
+    run_variant_score_bundle(
+        model,
+        tokenizer,
+        Dataset.from_pandas(df, preserve_index=False),
+        genome,
+        WINDOW,
+        rc=True,
+        return_embeddings=True,
+        data_transform_on_the_fly=True,
+        inference_kwargs={
+            "per_device_eval_batch_size": batch_size,
+            "torch_compile": False,
+            "bf16_full_eval": True,
+            "dataloader_num_workers": 0,  # no DataLoader fork → no s3fs deadlock
+            "remove_unused_columns": False,
+            "report_to": "none",
+        },
+    )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--batches", type=int, nargs="+", default=[32, 64, 96, 128, 192, 256]
+    )
+    args = ap.parse_args()
+
+    assert torch.cuda.is_available(), "no CUDA — run on a GPU"
+    total = torch.cuda.get_device_properties(0).total_memory / 1e9
+    print(f"GPU: {torch.cuda.get_device_name(0)} ({total:.1f} GB total)")
+
+    ckpt = localize_checkpoint()
+    model = AutoModelForCausalLM.from_pretrained(ckpt, trust_remote_code=True)
+    tokenizer = AutoTokenizer.from_pretrained(ckpt)
+    genome = Genome(GENOME)
+    ds = load_dataset(MEND_REPO, split="train", revision=MEND_REV).to_pandas()
+
+    # Warm-up: settle the model to bf16 on-GPU + CUDA init, so per-batch peaks
+    # measure only the forward footprint, not the one-time setup.
+    _score(model, tokenizer, genome, ds.iloc[:8].reset_index(drop=True), 8)
+
+    best = None
+    for bs in args.batches:
+        df = ds.iloc[:bs].reset_index(drop=True)  # exactly one batch
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+        try:
+            _score(model, tokenizer, genome, df, bs)
+        except torch.cuda.OutOfMemoryError:
+            print(f"  batch_size={bs:4d}  OOM")
+            break
+        alloc = torch.cuda.max_memory_allocated() / 1e9
+        reserved = torch.cuda.max_memory_reserved() / 1e9
+        pct = reserved / total * 100
+        print(
+            f"  batch_size={bs:4d}  peak_alloc={alloc:5.2f} GB  "
+            f"peak_reserved={reserved:5.2f} GB  ({pct:3.0f}% of {total:.0f} GB)"
+        )
+        if pct < 85:
+            best = bs
+    print(f"DONE — largest batch under 85% reserved: {best}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue318_batch_sweep.yaml
+++ b/scripts/issue318_batch_sweep.yaml
@@ -1,0 +1,41 @@
+# SkyPilot task: VRAM batch-size sweep for #318 embedding runs (A10G).
+#
+# Runs scripts/issue318_batch_sweep.py — loads exp135 once and measures peak GPU
+# memory of the embedding bundle across batch sizes, to pick a safe production
+# batch_size now that the base-model hook avoids the all-layers materialization.
+# Checkpoint from the evals_v2 S3 cache (instance role; no gcloud). Touches no
+# production parquet.
+#
+# Launch from the repo (worktree) root:
+#   sky launch scripts/issue318_batch_sweep.yaml -c bsweep318 -y
+# Tear down:
+#   sky down bsweep318 -y
+
+name: bsweep318
+
+resources:
+    infra: aws/us-east-2
+    accelerators: A10G:1
+    disk_size: 200
+    labels:
+        project: dna
+    any_of:
+      - use_spot: true
+      - use_spot: false
+
+workdir: .
+
+setup: |
+    set -euxo pipefail
+    if ! command -v uv >/dev/null 2>&1; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    fi
+    export PATH="$HOME/.local/bin:$PATH"
+    uv sync --frozen --group genome-s3
+
+run: |
+    set -euxo pipefail
+    export PATH="$HOME/.local/bin:$PATH"
+    export WANDB_DISABLED=true
+    nvidia-smi --query-gpu=name,memory.total --format=csv
+    uv run --group genome-s3 python scripts/issue318_batch_sweep.py

--- a/scripts/issue318_embed_overlay.yaml
+++ b/scripts/issue318_embed_overlay.yaml
@@ -14,14 +14,15 @@
 #     results/scores/mix-v0.9-p1B-i24-exp135-m5.1-step-59158/mendelian_traits.parquet
 #
 # batch_size + torch_compile are execution knobs.
-# - batch_size: the embedding forward materializes the final-layer [B, L, D] hidden
-#   states (last_hidden_state, captured by a hook — not all layers) plus the wider
-#   [N, 2+2D] predictions, so it's heavier than the slim LLR/JSD bundle; 32 is a
-#   conservative margin on the A10G (the original output_hidden_states path needed
-#   it most — the smoke measured 4.49 GB at batch 16 *with all layers*; the hook is
-#   lighter, so a larger batch likely fits if re-measured). NOTE this sets the GLOBAL
-#   inference.batch_size — a model carrying its own per-model `batch_size:` override
-#   (resolved by get_model_batch_size) would ignore this and could still OOM.
+# - batch_size: the embedding forward materializes the final-layer hidden states
+#   (last_hidden_state, captured by a hook — not all layers) + the suffix logits over
+#   the full vocab + the wider [N, 2+2D] predictions, so it's heavier than the slim
+#   LLR/JSD bundle and scales ~linearly with batch. Measured on exp135 (1B) / A10G
+#   24 GB via scripts/issue318_batch_sweep.py: 32→7.0 GB, 64→11.5, 96→16.0 (68%),
+#   128→20.6 (87%), 192→OOM. 96 is the largest with headroom for the full-dataset
+#   prediction accumulation (~1.3 GB on caqtl); 128 is too tight. NOTE this sets the
+#   GLOBAL inference.batch_size — a model with its own per-model `batch_size:` override
+#   (get_model_batch_size) ignores it, and a bigger model (e.g. 4B) needs a lower value.
 # - torch_compile: disabled because compiling the hooked forward is unvalidated and
 #   a small run doesn't need it. Unlike batch_size, torch_compile is NOT
 #   output-identical — eager vs compiled shifts the stored `llr_*` by AUPRC-invariant
@@ -29,5 +30,5 @@
 #   but don't treat an eager-computed scores parquet as byte-identical to a compiled one.
 inference:
   return_embeddings: true
-  batch_size: 32
+  batch_size: 96
   torch_compile: false

--- a/scripts/issue318_embed_overlay.yaml
+++ b/scripts/issue318_embed_overlay.yaml
@@ -12,5 +12,14 @@
 #     --configfile ../../../scripts/issue318_embed_overlay.yaml \
 #     --forcerun compute_scores -- \
 #     results/scores/mix-v0.9-p1B-i24-exp135-m5.1-step-59158/mendelian_traits.parquet
+#
+# batch_size + torch_compile are execution-only overrides (the stored values are
+# identical either way): `output_hidden_states` makes the forward much heavier, so
+# the default batch_size=128 would OOM the A10G (smoke measured 4.49 GB at batch 16
+# with embeddings → ~22 GB extrapolated at 128); 32 is a safe margin. torch_compile
+# is disabled because compile × output_hidden_states is unvalidated and the smoke
+# ran compile-off — a small run doesn't need it.
 inference:
   return_embeddings: true
+  batch_size: 32
+  torch_compile: false

--- a/scripts/issue318_embed_overlay.yaml
+++ b/scripts/issue318_embed_overlay.yaml
@@ -1,0 +1,16 @@
+# evals_v2 config overlay — turns ON the pooled-embedding bundle (#318) for a
+# one-off extraction, without committing the default-on. Deep-merges over
+# config/config.yaml via snakemake's `--configfile` (only flips this one key;
+# batch_size / rc / num_workers are preserved).
+#
+# Used to produce the first in-bundle embedding artifact for #320 to consume —
+# exp135 (mix-v0.9-p1B-i24-exp135-m5.1-step-59158) × mendelian_traits, the #314
+# pilot model/dataset with documented per-chrom probe AUPRC to check parity against.
+#
+# Invoke (from snakemake/analysis/evals_v2, e.g. via sky run.yaml SNAKEMAKE_ARGS):
+#   snakemake --profile workflow/profiles/default \
+#     --configfile ../../../scripts/issue318_embed_overlay.yaml \
+#     --forcerun compute_scores -- \
+#     results/scores/mix-v0.9-p1B-i24-exp135-m5.1-step-59158/mendelian_traits.parquet
+inference:
+  return_embeddings: true

--- a/scripts/issue318_embed_overlay.yaml
+++ b/scripts/issue318_embed_overlay.yaml
@@ -14,16 +14,19 @@
 #     results/scores/mix-v0.9-p1B-i24-exp135-m5.1-step-59158/mendelian_traits.parquet
 #
 # batch_size + torch_compile are execution knobs.
-# - batch_size: `output_hidden_states` makes the forward much heavier, so the default
-#   batch_size=128 would OOM the A10G (smoke measured 4.49 GB at batch 16 with
-#   embeddings → ~22 GB at 128); 32 is a safe margin. NOTE this sets the GLOBAL
+# - batch_size: the embedding forward materializes the final-layer [B, L, D] hidden
+#   states (last_hidden_state, captured by a hook — not all layers) plus the wider
+#   [N, 2+2D] predictions, so it's heavier than the slim LLR/JSD bundle; 32 is a
+#   conservative margin on the A10G (the original output_hidden_states path needed
+#   it most — the smoke measured 4.49 GB at batch 16 *with all layers*; the hook is
+#   lighter, so a larger batch likely fits if re-measured). NOTE this sets the GLOBAL
 #   inference.batch_size — a model carrying its own per-model `batch_size:` override
 #   (resolved by get_model_batch_size) would ignore this and could still OOM.
-# - torch_compile: disabled because compile × output_hidden_states is unvalidated and
-#   the smoke ran compile-off. Unlike batch_size, torch_compile is NOT output-identical
-#   — eager vs compiled shifts the stored `llr_*` by AUPRC-invariant float-reduction
-#   noise (see the evals_v2 README); fine for the embedding artifact, but don't treat
-#   an eager-computed scores parquet as byte-identical to a compiled one.
+# - torch_compile: disabled because compiling the hooked forward is unvalidated and
+#   a small run doesn't need it. Unlike batch_size, torch_compile is NOT
+#   output-identical — eager vs compiled shifts the stored `llr_*` by AUPRC-invariant
+#   float-reduction noise (see the evals_v2 README); fine for the embedding artifact,
+#   but don't treat an eager-computed scores parquet as byte-identical to a compiled one.
 inference:
   return_embeddings: true
   batch_size: 32

--- a/scripts/issue318_embed_overlay.yaml
+++ b/scripts/issue318_embed_overlay.yaml
@@ -13,12 +13,17 @@
 #     --forcerun compute_scores -- \
 #     results/scores/mix-v0.9-p1B-i24-exp135-m5.1-step-59158/mendelian_traits.parquet
 #
-# batch_size + torch_compile are execution-only overrides (the stored values are
-# identical either way): `output_hidden_states` makes the forward much heavier, so
-# the default batch_size=128 would OOM the A10G (smoke measured 4.49 GB at batch 16
-# with embeddings → ~22 GB extrapolated at 128); 32 is a safe margin. torch_compile
-# is disabled because compile × output_hidden_states is unvalidated and the smoke
-# ran compile-off — a small run doesn't need it.
+# batch_size + torch_compile are execution knobs.
+# - batch_size: `output_hidden_states` makes the forward much heavier, so the default
+#   batch_size=128 would OOM the A10G (smoke measured 4.49 GB at batch 16 with
+#   embeddings → ~22 GB at 128); 32 is a safe margin. NOTE this sets the GLOBAL
+#   inference.batch_size — a model carrying its own per-model `batch_size:` override
+#   (resolved by get_model_batch_size) would ignore this and could still OOM.
+# - torch_compile: disabled because compile × output_hidden_states is unvalidated and
+#   the smoke ran compile-off. Unlike batch_size, torch_compile is NOT output-identical
+#   — eager vs compiled shifts the stored `llr_*` by AUPRC-invariant float-reduction
+#   noise (see the evals_v2 README); fine for the embedding artifact, but don't treat
+#   an eager-computed scores parquet as byte-identical to a compiled one.
 inference:
   return_embeddings: true
   batch_size: 32

--- a/scripts/issue318_smoke.py
+++ b/scripts/issue318_smoke.py
@@ -24,6 +24,7 @@ Run on a GPU node:
 from __future__ import annotations
 
 import argparse
+import os
 import tempfile
 
 import numpy as np
@@ -48,10 +49,23 @@ MEND_REV = (
 
 
 def localize_checkpoint() -> str:
+    """Download the cached HF checkpoint into a flat local dir.
+
+    Get each file individually rather than ``fs.get(prefix, dst, recursive=True)``:
+    the recursive form nests the files under ``dst/<basename>/`` (fsspec copies the
+    dir, not its contents), so ``from_pretrained(dst)`` then can't find config.json.
+    """
     fs = s3fs.S3FileSystem()
     assert fs.exists(CKPT_S3), f"checkpoint cache missing: s3://{CKPT_S3}"
     dst = tempfile.mkdtemp(prefix="exp135_ckpt_")
-    fs.get(CKPT_S3, dst, recursive=True)
+    for f in fs.ls(CKPT_S3, detail=False):
+        name = f.rstrip("/").split("/")[-1]
+        if name.startswith("."):  # skip .snakemake_timestamp etc.
+            continue
+        fs.get_file(f, os.path.join(dst, name))
+    assert os.path.exists(os.path.join(dst, "config.json")), (
+        f"config.json not localized into {dst}"
+    )
     return dst
 
 

--- a/scripts/issue318_smoke.py
+++ b/scripts/issue318_smoke.py
@@ -1,0 +1,124 @@
+"""GPU smoke for #318 — pooled embeddings in the variant LLR/JSD score bundle.
+
+Runs the *production* code path (``compute_variant_scores``) with
+``return_embeddings=True`` on a small slice of ``exp135 × mendelian_traits``, on a
+real A10G with the real checkpoint + the S3 genome — the one thing the CPU tests
+can't cover (does ``output_hidden_states`` fit VRAM, do the wide ``[N, 2+2D]``
+predictions collate, are the columns right at scale). It does **not** touch any
+production S3 parquet.
+
+Checks:
+  - ``emb_ref`` / ``emb_alt`` columns are ``[n, hidden_size]`` float16, finite.
+  - ``llr_*`` / ``jsd_*`` are unchanged vs a ``return_embeddings=False`` run on the
+    same slice (the invariant that must hold on real hardware: identical forwards).
+  - reports peak VRAM so we can confirm the heavier forward fits the A10G.
+
+The checkpoint is pulled from the evals_v2 S3 cache (instance-role creds — no
+gcloud). ``num_workers=0`` keeps genome S3 reads in the main process, sidestepping
+the fork-after-s3fs-init deadlock (see the off-pipeline-scoring gotcha).
+
+Run on a GPU node:
+  uv run --group genome-s3 python scripts/issue318_smoke.py --n 128 --batch-size 16
+"""
+
+from __future__ import annotations
+
+import argparse
+import tempfile
+
+import numpy as np
+import s3fs
+import torch
+from datasets import load_dataset
+
+from marin_dna.pipelines.evals.inference import compute_variant_scores
+
+MODEL = "mix-v0.9-p1B-i24-exp135-m5.1-step-59158"
+HIDDEN = 1920  # exp135 Qwen3-1B hidden size
+WINDOW = 255  # 255 bp DNA + BOS
+CKPT_S3 = "oa-bolinas/snakemake/analysis/evals_v2/results/checkpoints/" + MODEL
+GENOME = (
+    "s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/"
+    "Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
+)
+MEND_REPO = "bolinas-dna/evals_mendelian_traits"
+MEND_REV = (
+    "4aed58e50c5dea0b878a665007af2ef9e5108e9f"  # PR #194 k=9 rebuild (config pin)
+)
+
+
+def localize_checkpoint() -> str:
+    fs = s3fs.S3FileSystem()
+    assert fs.exists(CKPT_S3), f"checkpoint cache missing: s3://{CKPT_S3}"
+    dst = tempfile.mkdtemp(prefix="exp135_ckpt_")
+    fs.get(CKPT_S3, dst, recursive=True)
+    return dst
+
+
+def _score(slice_df, ckpt_dir: str, batch_size: int, return_embeddings: bool):
+    return compute_variant_scores(
+        checkpoint_path=ckpt_dir,
+        dataset=slice_df,
+        genome_path=GENOME,
+        context_size=WINDOW,
+        batch_size=batch_size,
+        num_workers=0,  # no DataLoader fork → no s3fs fork-deadlock
+        data_transform_on_the_fly=True,
+        torch_compile=False,
+        rc=True,
+        return_embeddings=return_embeddings,
+    )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--n", type=int, default=128)
+    ap.add_argument("--batch-size", type=int, default=16)
+    args = ap.parse_args()
+
+    assert torch.cuda.is_available(), "no CUDA — this smoke must run on a GPU"
+    print("GPU:", torch.cuda.get_device_name(0))
+
+    ckpt_dir = localize_checkpoint()
+    print("checkpoint localized to", ckpt_dir)
+    ds = load_dataset(MEND_REPO, split="train", revision=MEND_REV).to_pandas()
+    slice_df = ds.iloc[: args.n].reset_index(drop=True)
+    print(f"scoring {len(slice_df)} variants (rc=True, return_embeddings=True)")
+
+    torch.cuda.reset_peak_memory_stats()
+    emb = _score(slice_df, ckpt_dir, args.batch_size, return_embeddings=True)
+    peak_gb = torch.cuda.max_memory_allocated() / 1e9
+    print(f"peak torch VRAM (embeddings on): {peak_gb:.2f} GB / 24 GB")
+
+    for col in ("emb_ref", "emb_alt"):
+        arr = np.stack(emb[col].to_numpy())
+        assert arr.shape == (len(slice_df), HIDDEN), (col, arr.shape)
+        assert arr.dtype == np.float16, (col, arr.dtype)
+        assert np.isfinite(arr.astype(np.float32)).all(), f"{col} non-finite"
+        print(
+            f"  {col}: shape {arr.shape} dtype {arr.dtype} finite "
+            f"|mean|={np.abs(arr.astype(np.float32)).mean():.4f}"
+        )
+
+    # delta = alt - ref should be a small, mostly-nonzero signal (the probe feature).
+    d = np.stack(emb["emb_alt"].to_numpy()).astype(np.float32) - np.stack(
+        emb["emb_ref"].to_numpy()
+    ).astype(np.float32)
+    print(
+        f"  |emb_alt - emb_ref| mean={np.abs(d).mean():.4f} max={np.abs(d).max():.4f}"
+    )
+
+    # Invariant on real hardware: identical forwards ⇒ same llr/jsd.
+    base = _score(slice_df, ckpt_dir, args.batch_size, return_embeddings=False)
+    max_diff = 0.0
+    for col in ("llr_fwd", "llr_rc", "jsd_fwd", "jsd_rc"):
+        max_diff = max(
+            max_diff, float(np.abs(emb[col].to_numpy() - base[col].to_numpy()).max())
+        )
+    print(f"max |llr/jsd diff| (emb on vs off): {max_diff:.2e}")
+    assert max_diff < 1e-3, f"llr/jsd drifted with embeddings on: {max_diff}"
+    print("SMOKE PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue318_smoke.yaml
+++ b/scripts/issue318_smoke.yaml
@@ -1,0 +1,46 @@
+# SkyPilot task: GPU smoke for #318 (pooled embeddings in the score bundle).
+#
+# Runs scripts/issue318_smoke.py on a real A10G — exercises the production
+# compute_variant_scores(return_embeddings=True) path on the exp135 checkpoint
+# (pulled from the evals_v2 S3 cache via the instance role; no gcloud/GCS) and a
+# small slice of the public mendelian dataset + the S3 genome. Validates emb
+# columns + the llr/jsd-unchanged invariant + reports peak VRAM. Touches no
+# production parquet.
+#
+# Launch from the repo (worktree) root:
+#   sky launch scripts/issue318_smoke.yaml -c smoke318 -y
+# Tear down when done:
+#   sky down smoke318 -y
+
+name: smoke318
+
+resources:
+    infra: aws/us-east-2
+    accelerators: A10G:1          # 24 GB Ampere, bf16-capable (matches evals_v2)
+    disk_size: 200
+    labels:
+        project: dna
+    # Prefer spot (~70% cheaper) with on-demand fallback; the smoke is short and
+    # re-runnable, so a preemption is cheap.
+    any_of:
+      - use_spot: true
+      - use_spot: false
+
+workdir: .
+
+setup: |
+    set -euxo pipefail
+    if ! command -v uv >/dev/null 2>&1; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    fi
+    export PATH="$HOME/.local/bin:$PATH"
+    # --group genome-s3 pulls s3fs so pyfaidx reads the GRCh38 reference from S3
+    # and the script can localize the cached checkpoint.
+    uv sync --frozen --group genome-s3
+
+run: |
+    set -euxo pipefail
+    export PATH="$HOME/.local/bin:$PATH"
+    export WANDB_DISABLED=true          # inference job; no wandb on a fresh node
+    nvidia-smi
+    uv run --group genome-s3 python scripts/issue318_smoke.py --n 128 --batch-size 16

--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -120,6 +120,18 @@ embedding run with a smaller per-model `batch_size` (and optionally
 to CPU). Requires `inference.rc: true` (the stored vector is the FWD+RC average;
 asserted at config load).
 
+Run embedding extractions **eager** (`torch_compile: false`): `torch_compile ×
+output_hidden_states` is unvalidated and memory-heavy. The ready-made overlay
+[`scripts/issue318_embed_overlay.yaml`](../../../scripts/issue318_embed_overlay.yaml)
+deep-merges `return_embeddings: true` + `batch_size: 32` + `torch_compile: false`
+over the config (preserving `rc` etc.), e.g.
+`snakemake --configfile ../../../scripts/issue318_embed_overlay.yaml --forcerun
+compute_scores -- results/scores/<model>/<dataset>.parquet`. Eager makes the
+stored `llr_*` differ from the compiled default by float-reduction noise that
+accumulates in the LLR **sum** (JSD, a mean, is unaffected) — measured on exp135
+× mendelian: per-row LLR Pearson **0.9997**, and the derived AUPRC moves by
+**< SE/20** (`_global_` 0.4004 vs 0.4003), i.e. no metric impact.
+
 **Operational note.** `return_embeddings` is output-affecting (it lives in the
 rule's `params:`), so flipping it on — like any kernel edit — retriggers
 `compute_scores`. Don't run `snakemake all`: name the **targeted** targets you

--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -128,17 +128,19 @@ over the config (preserving `rc` etc.), e.g.
 `snakemake --configfile ../../../scripts/issue318_embed_overlay.yaml --forcerun
 compute_scores -- results/scores/<model>/<dataset>.parquet`. Eager makes the
 stored `llr_*` differ from the compiled default by float-reduction noise that
-accumulates in the LLR **sum** (JSD, a mean, is unaffected) — measured on exp135
-× mendelian: per-row LLR Pearson **0.9997**, and the derived AUPRC moves by
-**< SE/20** (`_global_` 0.4004 vs 0.4003), i.e. no metric impact.
+accumulates in the LLR **sum** (JSD, a mean, is unaffected); the difference is
+AUPRC-invariant — a deliberate execution tradeoff for embedding runs, not a
+correctness issue (the measured parity numbers live in #318 / the PR, not here).
 
 **Operational note.** `return_embeddings` is output-affecting (it lives in the
-rule's `params:`), so flipping it on — like any kernel edit — retriggers
-`compute_scores`. Don't run `snakemake all`: name the **targeted** targets you
-want embeddings for (e.g.
-`results/scores/<model>/<dataset>.parquet`) and, to avoid recomputing the
-identical `llr_*`/`jsd_*` of unrelated already-scored cells, add
-`--rerun-triggers mtime` (or `--touch` the untouched outputs).
+rule's `params:`). To extract embeddings into a cell whose scores parquet already
+exists, **force that specific target**:
+`snakemake --configfile scripts/issue318_embed_overlay.yaml --forcerun
+compute_scores -- results/scores/<model>/<dataset>.parquet`. (A bare
+`--rerun-triggers mtime` does *not* help here — it drops the `params` trigger that
+detects the `return_embeddings` flip, so a cell whose output already exists would
+be skipped with no embedding columns.) Name targeted targets rather than
+`snakemake all` so unrelated already-scored cells are left untouched.
 
 ## Conventions
 

--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -35,7 +35,7 @@ Outputs land in S3 at `s3://oa-bolinas/snakemake/analysis/evals_v2/results/`:
 ```
 results/
 ├── checkpoints/{model}/                         # cached HF model dir
-├── scores/{model}/{dataset}.parquet             # variant cols + per-strand score atoms
+├── scores/{model}/{dataset}.parquet             # variant cols + per-strand score atoms (+ emb_ref/emb_alt if return_embeddings)
 └── metrics/{model}/{dataset}.parquet            # AUPRC ± bootstrap SE per (subset × score_type)
 ```
 
@@ -96,6 +96,37 @@ It runs on a 2-axis grid: `subset` ∈ {`missense_variant`, `splicing`, `both`
 dataset, split]` (`metric` is always `AUPRC`). The **same** `compute_sge_metrics`
 is reused by the conservation pipeline (`snakemake/conservation_eval/`). Scoped
 to the three #292 gLMs via their per-model `datasets:` lists.
+
+### Pooled embeddings (`inference.return_embeddings`, #318)
+
+For the frozen-embedding linear-probe VEP protocol (#314 → productionized in
+#321/#320), the **same two (FWD, RC) forward passes** that produce LLR/JSD can
+*also* emit a pooled both-allele embedding — no second pass, no parallel cache.
+Set the global toggle `inference.return_embeddings: true` and the scores parquet
+gains two columns:
+
+- `emb_ref`, `emb_alt` — each a length-`D` (model hidden size) `float16` vector
+  per variant: the **entire-DNA-window mean-pooled** (the `window_size` DNA
+  positions, BOS/special tokens excluded — the #314 `entire_window` extent),
+  **FWD+RC-averaged** last-layer hidden state for that allele. Pooling and the
+  strand average accumulate in **fp32**; only the stored vector is cast to f16.
+
+The probe feature (`concat_ref_delta` / `sum_absdiff`, #320) is built downstream
+from these. Storage is ~`2·D·2` B/variant ≈ **1.5–2.3 GB/model** over the full
+suite (~500× smaller than the per-token cache #314 used). The kernel requests
+`output_hidden_states`, which makes the forward ~2× heavier in VRAM, so pair an
+embedding run with a smaller per-model `batch_size` (and optionally
+`inference.eval_accumulation_steps` to offload the wider `[N, 2+2D]` predictions
+to CPU). Requires `inference.rc: true` (the stored vector is the FWD+RC average;
+asserted at config load).
+
+**Operational note.** `return_embeddings` is output-affecting (it lives in the
+rule's `params:`), so flipping it on — like any kernel edit — retriggers
+`compute_scores`. Don't run `snakemake all`: name the **targeted** targets you
+want embeddings for (e.g.
+`results/scores/<model>/<dataset>.parquet`) and, to avoid recomputing the
+identical `llr_*`/`jsd_*` of unrelated already-scored cells, add
+`--rerun-triggers mtime` (or `--touch` the untouched outputs).
 
 ## Conventions
 

--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -113,15 +113,18 @@ gains two columns:
 
 The probe feature (`concat_ref_delta` / `sum_absdiff`, #320) is built downstream
 from these. Storage is ~`2·D·2` B/variant ≈ **1.5–2.3 GB/model** over the full
-suite (~500× smaller than the per-token cache #314 used). The kernel requests
-`output_hidden_states`, which makes the forward ~2× heavier in VRAM, so pair an
-embedding run with a smaller per-model `batch_size` (and optionally
-`inference.eval_accumulation_steps` to offload the wider `[N, 2+2D]` predictions
-to CPU). Requires `inference.rc: true` (the stored vector is the FWD+RC average;
-asserted at config load).
+suite (~500× smaller than the per-token cache #314 used). The kernel captures the
+last layer via a forward hook on `model.base_model` (grabbing `last_hidden_state`,
+*not* `output_hidden_states=True` — which would materialize every layer), so the
+extra VRAM is just the final `[B, L, D]` hidden states + the wider `[N, 2+2D]`
+predictions; still heavier than the slim LLR/JSD bundle, so pair an embedding run
+with a smaller per-model `batch_size` (and optionally
+`inference.eval_accumulation_steps` to offload the predictions to CPU). Requires
+`inference.rc: true` (the stored vector is the FWD+RC average; asserted at config
+load).
 
-Run embedding extractions **eager** (`torch_compile: false`): `torch_compile ×
-output_hidden_states` is unvalidated and memory-heavy. The ready-made overlay
+Run embedding extractions **eager** (`torch_compile: false`): compiling the
+hooked forward is unvalidated, and a small run doesn't need it. The ready-made overlay
 [`scripts/issue318_embed_overlay.yaml`](../../../scripts/issue318_embed_overlay.yaml)
 deep-merges `return_embeddings: true` + `batch_size: 32` + `torch_compile: false`
 over the config (preserving `rc` etc.), e.g.

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -1160,6 +1160,21 @@ inference:
                         # inference time but is the validated default
                         # per issue #175 conclusion 2. AVG / minus_llr /
                         # abs_llr columns are derived in the metrics rule.
+  return_embeddings: false  # GLOBAL opt-in (#318): also emit the entire-DNA-window
+                        # mean-pooled, both-allele, FWD+RC-averaged last-layer
+                        # embeddings as `emb_ref`/`emb_alt` (list[f16]) columns in
+                        # the SAME scores parquet, from the SAME forwards. Default
+                        # off — `output_hidden_states` makes the forward ~2x heavier
+                        # and adds ~1.5–2.3 GB/model storage. Requires `rc: true`.
+                        # Output-affecting → in `params:`, so flipping it on (or any
+                        # kernel edit) retriggers scoring: run TARGETED targets +
+                        # `--rerun-triggers mtime` to avoid recomputing identical
+                        # llr/jsd on unrelated cells. Pair with a smaller per-model
+                        # `batch_size` (and `eval_accumulation_steps`) for VRAM.
+  eval_accumulation_steps: null  # Execution-only: offload Trainer.predict outputs
+                        # to CPU every N steps (null = accumulate on-device). Set a
+                        # small int for embedding runs so the wide [N, 2+2D]
+                        # predictions don't OOM the GPU. Not output-affecting.
   n_bootstrap: 1000     # AUPRC cluster-bootstrap iterations per
                         # (subset × score_type).
   bootstrap_seed: 0     # 0 → reproducible across re-runs. Bumping

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -82,6 +82,13 @@ for _d in config["datasets"]:
         f"{sorted(EVAL_PROTOCOLS)}, got {_ep!r}"
     )
 
+# The pooled embedding (#318) is the FWD+RC average, so it needs both strands —
+# fail at config load rather than store a silently fwd-only vector mislabeled as
+# the average.
+assert not config["inference"].get("return_embeddings", False) or config[
+    "inference"
+]["rc"], "inference.return_embeddings=true requires inference.rc=true"
+
 
 # Wildcard alternations used across rules.
 DATASETS = [d["name"] for d in config["datasets"]]

--- a/snakemake/analysis/evals_v2/workflow/rules/inference.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/inference.smk
@@ -28,12 +28,18 @@ rule compute_scores:
         # to `main`.
         hf_revision=lambda wc: get_dataset_config(wc.dataset)["hf_revision"],
         rc=config["inference"]["rc"],
+        # Output-affecting (#318): when true, the parquet gains the pooled
+        # `emb_ref`/`emb_alt` columns, so it belongs in `params:`. Global toggle.
+        return_embeddings=config["inference"]["return_embeddings"],
     threads: config["inference"]["num_workers"]
     run:
         # batch_size is per-model but execution-only (numerics are batch-
         # size-invariant modulo float-reduction noise), so we read it here
         # rather than declare it as a snakemake param. See note in `params:`.
         batch_size = get_model_batch_size(wildcards.model)
+        # eval_accumulation_steps is execution-only (CPU-offload cadence for the
+        # wide embedding predictions; doesn't change the stored values).
+        eval_accumulation_steps = config["inference"].get("eval_accumulation_steps")
 
         ds = load_dataset(
             params.hf_path, split=config["split"], revision=params.hf_revision
@@ -57,6 +63,8 @@ rule compute_scores:
             data_transform_on_the_fly=config["inference"]["data_transform_on_the_fly"],
             torch_compile=config["inference"]["torch_compile"],
             rc=params.rc,
+            return_embeddings=params.return_embeddings,
+            eval_accumulation_steps=eval_accumulation_steps,
         )
         assert len(scores) == len(ds)
 

--- a/src/marin_dna/model/runner.py
+++ b/src/marin_dna/model/runner.py
@@ -127,6 +127,7 @@ def run_variant_score_bundle(
     genome: Genome,
     window_size: int,
     rc: bool = False,
+    return_embeddings: bool = False,
     **kwargs: Any,
 ) -> dict[str, np.ndarray]:
     """Run the variant-score bundle (LLR + next-token JSD) in one forward pass.
@@ -141,6 +142,18 @@ def run_variant_score_bundle(
     Both scores share a single 4-nuc log_softmax in the kernel. The
     nucleotide token IDs come from ``_get_nucleotide_token_ids`` (handles
     BOS / n_prefix offset).
+
+    With ``return_embeddings=True`` the same forwards also emit the entire-window
+    mean-pooled last-layer hidden states for ref and alt (issue #318): the kernel
+    is asked for ``output_hidden_states`` and pools token positions
+    ``[n_prefix, n_prefix + window_size)`` — the ``window_size`` DNA positions,
+    BOS excluded (the #314 ``entire_window`` extent). These pool bounds are
+    strand-independent (entire-window covers the same genomic block on FWD and
+    RC), so they are bound into the kernel once; ``var_pos`` still differs per
+    strand. Each per-strand array widens from ``[B, 2]`` to ``[B, 2 + 2D]``
+    (``D`` = model hidden size): columns ``[2:2+D]`` = ``emb_ref``,
+    ``[2+D:2+2D]`` = ``emb_alt`` (fp32). The driver FWD+RC-averages and casts to
+    f16.
 
     The token-level variant position is computed here per-strand and
     bound into the compute_fn as a Python int — constant within the
@@ -162,18 +175,31 @@ def run_variant_score_bundle(
             each variant and return both strands' arrays. Doubles
             inference cost. Callers compose the per-strand arrays
             (averaging, applying ``minus_llr``/``abs_llr``, etc.).
+        return_embeddings: If True, widen each per-strand array to
+            ``[B, 2 + 2D]`` with the entire-window-pooled ``emb_ref``/``emb_alt``
+            (issue #318; see the function summary). ``output_hidden_states`` makes
+            the forward heavier — pair with a smaller ``per_device_eval_batch_size``
+            (and optionally ``eval_accumulation_steps``) in ``inference_kwargs``.
         **kwargs: Additional arguments passed to run_inference.
 
     Returns:
-        Dict ``{"fwd": [B, 2]}`` when ``rc=False``, or
-        ``{"fwd": [B, 2], "rc": [B, 2]}`` when ``rc=True``. Column 0
-        of each array is LLR; column 1 is ``next_token_jsd_mean``.
+        Dict ``{"fwd": A}`` when ``rc=False``, or ``{"fwd": A, "rc": A}`` when
+        ``rc=True``. Each array ``A`` is ``[B, 2]`` (``return_embeddings=False``)
+        or ``[B, 2 + 2D]`` (``True``): column 0 is LLR, column 1 is
+        ``next_token_jsd_mean``, and (when on) ``[2:2+D]`` / ``[2+D:2+2D]`` are
+        the fp32 pooled ``emb_ref`` / ``emb_alt``.
     """
     n_prefix, _ = _get_special_token_counts(tokenizer)
     nuc_ids_dict = _get_nucleotide_token_ids(tokenizer)
     nuc_token_ids = torch.tensor(
         [nuc_ids_dict[nuc] for nuc in NUCLEOTIDES], dtype=torch.long
     )
+    # Entire-window pool bounds: the window_size DNA token positions, excluding
+    # the n_prefix BOS/special tokens. Strand-independent (entire-window pooling
+    # covers the same genomic block on FWD and RC; mean is order-invariant), so
+    # bound into the kernel once — only var_pos differs per strand.
+    pool_lo = n_prefix
+    pool_hi = n_prefix + window_size
 
     def _one(strand: Literal["+", "-"]) -> Any:
         var_pos = in_seq_var_pos(window_size, strand) + n_prefix
@@ -185,6 +211,9 @@ def run_variant_score_bundle(
                 compute_variant_score_bundle,
                 var_pos=var_pos,
                 nuc_token_ids=nuc_token_ids,
+                return_embeddings=return_embeddings,
+                pool_lo=pool_lo,
+                pool_hi=pool_hi,
             ),
             data_transform_fn=partial(
                 transform_llr_clm, genome=genome, window_size=window_size, strand=strand

--- a/src/marin_dna/model/scoring.py
+++ b/src/marin_dna/model/scoring.py
@@ -204,13 +204,15 @@ def compute_variant_score_bundle(
         nuc_token_ids: Length-4 tensor of token IDs for A/C/G/T in
             ``NUCLEOTIDES`` order.
         return_embeddings: If True, also emit the entire-window mean-pooled
-            last-layer hidden states for ref and alt — produced by requesting
-            ``output_hidden_states=True`` on the **same two** (prefix, suffix)
-            forwards (no extra pass). The prefix hidden states ``[B, p, D]`` are
-            shared by ref/alt (causal, shared prefix); concatenated with each
-            allele's suffix states ``[B, L-p, D]`` they equal a full forward's
-            last-layer states. Pooling accumulates in fp32. Off by default —
-            materializing ``[·, ·, D]`` hidden states is paid only when on.
+            last-layer hidden states for ref and alt — captured from the **same
+            two** (prefix, suffix) forwards (no extra pass) via a forward hook on
+            ``model.base_model`` that grabs its ``last_hidden_state`` (avoids
+            ``output_hidden_states=True``, which would materialize every layer's
+            activations when only the last is needed). The prefix hidden states
+            ``[B, p, D]`` are shared by ref/alt (causal, shared prefix);
+            concatenated with each allele's suffix states ``[B, L-p, D]`` they
+            equal a full forward's last-layer states. Pooling accumulates in fp32.
+            Off by default — the hidden states are materialized only when on.
         pool_lo: Token index (inclusive) where the pooled window starts. Required
             when ``return_embeddings``. The runner sets it to ``n_prefix`` so the
             BOS/special prefix tokens are **excluded** — the pool covers exactly
@@ -249,27 +251,36 @@ def compute_variant_score_bundle(
     suffixes = torch.stack([ref_suffix, alt_suffix], dim=1)  # [B, 2, L-p]
     suffixes_flat = rearrange(suffixes, "B V L -> (B V) L").contiguous()
 
-    # 1. Prefix forward — only need logits at the last prefix position
-    #    (predicts the variant token); skip the lm_head for the rest.
-    #    output_hidden_states (only when pooling embeddings) keeps the full
-    #    prefix hidden states [B, p, D] — logits_to_keep slices the lm_head, not
-    #    the hidden states.
-    prefix_out = model(
-        prefix,
-        use_cache=True,
-        logits_to_keep=1,
-        output_hidden_states=return_embeddings,
+    # 1-2. Prefix + suffix forwards. When pooling embeddings, capture each
+    #      forward's last_hidden_state via a forward hook on the base model.
+    #      output_hidden_states=True would instead materialize EVERY layer's
+    #      hidden states (~N x the memory for an N-layer model) — we only need the
+    #      final layer. `base_model` (the decoder beneath the LM head) returns
+    #      last_hidden_state for free; both are the universal HF decoder surface,
+    #      so the logits path (model(...) below) stays untouched, and
+    #      logits_to_keep still slices only the lm_head. Registered only when
+    #      pooling and removed in `finally`, so the off-path is unaffected.
+    hidden_capture: list[Tensor] = []
+    hook = (
+        model.base_model.register_forward_hook(
+            lambda _module, _inputs, output: hidden_capture.append(
+                output.last_hidden_state
+            )
+        )
+        if return_embeddings
+        else None
     )
-    prefix_last_logits = prefix_out.logits[:, -1]  # [B, V]
-    past_kv = _repeat_interleave_kv_cache(prefix_out.past_key_values, 2)
-
-    # 2. Suffix forward with cached prefix.
-    suffix_out = model(
-        suffixes_flat,
-        past_key_values=past_kv,
-        use_cache=False,
-        output_hidden_states=return_embeddings,
-    )
+    try:
+        # Prefix forward — only need logits at the last prefix position (predicts
+        # the variant token); skip the lm_head for the rest.
+        prefix_out = model(prefix, use_cache=True, logits_to_keep=1)
+        prefix_last_logits = prefix_out.logits[:, -1]  # [B, V]
+        past_kv = _repeat_interleave_kv_cache(prefix_out.past_key_values, 2)
+        # Suffix forward with cached prefix.
+        suffix_out = model(suffixes_flat, past_key_values=past_kv, use_cache=False)
+    finally:
+        if hook is not None:
+            hook.remove()
     suffix_logits = suffix_out.logits  # [B*2, L-p, V]
 
     # 3. 4-nuc log-softmax — shared by LLR and JSD. fp32 cast inherits
@@ -333,9 +344,15 @@ def compute_variant_score_bundle(
         f"pool bounds [{pool_lo}, {pool_hi}) invalid for var_pos {p}, length {L}; "
         f"expected 0 <= pool_lo < var_pos < pool_hi <= L"
     )
-    prefix_hidden = prefix_out.hidden_states[-1]  # [B, p, D]
+    # hidden_capture = [prefix last_hidden_state, suffix last_hidden_state], in
+    # call order (the hook fired once per model() forward above).
+    assert len(hidden_capture) == 2, (
+        f"expected 2 captured hidden states (prefix, suffix), got "
+        f"{len(hidden_capture)} — base-model forward hook didn't fire as expected"
+    )
+    prefix_hidden = hidden_capture[0]  # [B, p, D]
     suffix_hidden = rearrange(
-        suffix_out.hidden_states[-1], "(B V) S D -> B V S D", B=B
+        hidden_capture[1], "(B V) S D -> B V S D", B=B
     )  # [B, 2, L-p, D]
     n_pool = pool_hi - pool_lo
     # sum(dtype=float32) accumulates the bf16 hidden states in fp32 *without*

--- a/src/marin_dna/model/scoring.py
+++ b/src/marin_dna/model/scoring.py
@@ -157,7 +157,10 @@ def compute_variant_score_bundle(
     *,
     var_pos: int,
     nuc_token_ids: Int[Tensor, " 4"],
-) -> Float[Tensor, "B 2"]:
+    return_embeddings: bool = False,
+    pool_lo: int | None = None,
+    pool_hi: int | None = None,
+) -> Float[Tensor, "B 2"] | Float[Tensor, "B 2+2D"]:
     """Compute LLR and per-position next-token JSD using prefix-sharing.
 
     SNV-only kernel. For each row, the alt sequence equals ``input_ids`` with
@@ -200,11 +203,33 @@ def compute_variant_score_bundle(
         var_pos: Token-level variant position (Python int, constant within batch).
         nuc_token_ids: Length-4 tensor of token IDs for A/C/G/T in
             ``NUCLEOTIDES`` order.
+        return_embeddings: If True, also emit the entire-window mean-pooled
+            last-layer hidden states for ref and alt — produced by requesting
+            ``output_hidden_states=True`` on the **same two** (prefix, suffix)
+            forwards (no extra pass). The prefix hidden states ``[B, p, D]`` are
+            shared by ref/alt (causal, shared prefix); concatenated with each
+            allele's suffix states ``[B, L-p, D]`` they equal a full forward's
+            last-layer states. Pooling accumulates in fp32. Off by default —
+            materializing ``[·, ·, D]`` hidden states is paid only when on.
+        pool_lo: Token index (inclusive) where the pooled window starts. Required
+            when ``return_embeddings``. The runner sets it to ``n_prefix`` so the
+            BOS/special prefix tokens are **excluded** — the pool covers exactly
+            the ``window_size`` DNA positions (matching the #314 ``entire_window``
+            extent and ``compute_window_embedding``'s ``n_prefix`` offset).
+        pool_hi: Token index (exclusive) where the pooled window ends. Required
+            when ``return_embeddings``; the runner sets it to ``n_prefix +
+            window_size``. ``pool_hi - pool_lo == window_size`` positions are
+            pooled.
 
     Returns:
-        Tensor with shape ``[B, 2]``:
+        When ``return_embeddings=False``, a tensor with shape ``[B, 2]``:
             - [:, 0]: LLR (alt_logprob - ref_logprob, 4-nuc-softmax space)
             - [:, 1]: next_token_jsd_mean (mean per-position 4-nuc JSD over downstream positions)
+        When ``return_embeddings=True``, the scores are concatenated with the two
+        pooled fp32 embeddings into ``[B, 2 + 2D]`` (``D`` = model hidden size):
+        columns ``[0:2]`` are LLR/JSD as above, ``[2:2+D]`` is ``emb_ref``,
+        ``[2+D:2+2D]`` is ``emb_alt``. A single tensor (not a tuple) keeps the
+        HF ``Trainer.predict`` collation contract; the runner/driver slice it.
     """
     B, L = input_ids.shape
     p = var_pos
@@ -226,14 +251,26 @@ def compute_variant_score_bundle(
 
     # 1. Prefix forward — only need logits at the last prefix position
     #    (predicts the variant token); skip the lm_head for the rest.
-    prefix_out = model(prefix, use_cache=True, logits_to_keep=1)
+    #    output_hidden_states (only when pooling embeddings) keeps the full
+    #    prefix hidden states [B, p, D] — logits_to_keep slices the lm_head, not
+    #    the hidden states.
+    prefix_out = model(
+        prefix,
+        use_cache=True,
+        logits_to_keep=1,
+        output_hidden_states=return_embeddings,
+    )
     prefix_last_logits = prefix_out.logits[:, -1]  # [B, V]
     past_kv = _repeat_interleave_kv_cache(prefix_out.past_key_values, 2)
 
     # 2. Suffix forward with cached prefix.
-    suffix_logits = model(
-        suffixes_flat, past_key_values=past_kv, use_cache=False
-    ).logits  # [B*2, L-p, V]
+    suffix_out = model(
+        suffixes_flat,
+        past_key_values=past_kv,
+        use_cache=False,
+        output_hidden_states=return_embeddings,
+    )
+    suffix_logits = suffix_out.logits  # [B*2, L-p, V]
 
     # 3. 4-nuc log-softmax — shared by LLR and JSD. fp32 cast inherits
     #    the biofoundation#21 numerical-stability fix.
@@ -276,7 +313,37 @@ def compute_variant_score_bundle(
 
     llr = llr_at_var + llr_downstream
 
-    return torch.stack([llr, next_token_jsd_mean], dim=1)
+    scores = torch.stack([llr, next_token_jsd_mean], dim=1)  # [B, 2]
+    if not return_embeddings:
+        return scores
+
+    # 6. Entire-window mean-pool of the last-layer hidden states, ref & alt.
+    #    Pool over token positions [pool_lo, pool_hi) = the window_size DNA
+    #    positions (n_prefix BOS tokens excluded). The prefix forward gives the
+    #    shared states [B, p, D]; the suffix forward (run with the cached prefix)
+    #    gives each allele's states at [p, L), so prefix[pool_lo:] ++ suffix[:pool_hi-p]
+    #    reconstructs the pooled-window states without a full re-forward. The
+    #    var-position token is the suffix's first position — included in the pool.
+    #    Accumulate in fp32 (bf16/f16 summed over hundreds of positions accrues
+    #    rounding error); the driver FWD+RC-averages (still fp32) and casts to f16.
+    assert pool_lo is not None and pool_hi is not None, (
+        "pool_lo/pool_hi are required when return_embeddings=True"
+    )
+    assert 0 <= pool_lo < p < pool_hi <= L, (
+        f"pool bounds [{pool_lo}, {pool_hi}) invalid for var_pos {p}, length {L}; "
+        f"expected 0 <= pool_lo < var_pos < pool_hi <= L"
+    )
+    prefix_hidden = prefix_out.hidden_states[-1]  # [B, p, D]
+    suffix_hidden = rearrange(
+        suffix_out.hidden_states[-1], "(B V) S D -> B V S D", B=B
+    )  # [B, 2, L-p, D]
+    n_pool = pool_hi - pool_lo
+    prefix_sum = prefix_hidden[:, pool_lo:].float().sum(dim=1)  # [B, D] (shared)
+    ref_sum = prefix_sum + suffix_hidden[:, 0, : pool_hi - p].float().sum(dim=1)
+    alt_sum = prefix_sum + suffix_hidden[:, 1, : pool_hi - p].float().sum(dim=1)
+    emb_ref = ref_sum / n_pool  # [B, D]
+    emb_alt = alt_sum / n_pool  # [B, D]
+    return torch.cat([scores, emb_ref, emb_alt], dim=1)  # [B, 2 + 2D]
 
 
 def compute_marginal_clm(

--- a/src/marin_dna/model/scoring.py
+++ b/src/marin_dna/model/scoring.py
@@ -338,9 +338,18 @@ def compute_variant_score_bundle(
         suffix_out.hidden_states[-1], "(B V) S D -> B V S D", B=B
     )  # [B, 2, L-p, D]
     n_pool = pool_hi - pool_lo
-    prefix_sum = prefix_hidden[:, pool_lo:].float().sum(dim=1)  # [B, D] (shared)
-    ref_sum = prefix_sum + suffix_hidden[:, 0, : pool_hi - p].float().sum(dim=1)
-    alt_sum = prefix_sum + suffix_hidden[:, 1, : pool_hi - p].float().sum(dim=1)
+    # sum(dtype=float32) accumulates the bf16 hidden states in fp32 *without*
+    # materializing a full fp32 copy of each [B, ·, D] block first (bit-identical
+    # to .float().sum(); just fuses the upcast into the reduction).
+    prefix_sum = prefix_hidden[:, pool_lo:].sum(
+        dim=1, dtype=torch.float32
+    )  # [B, D] shared
+    ref_sum = prefix_sum + suffix_hidden[:, 0, : pool_hi - p].sum(
+        dim=1, dtype=torch.float32
+    )
+    alt_sum = prefix_sum + suffix_hidden[:, 1, : pool_hi - p].sum(
+        dim=1, dtype=torch.float32
+    )
     emb_ref = ref_sum / n_pool  # [B, D]
     emb_alt = alt_sum / n_pool  # [B, D]
     return torch.cat([scores, emb_ref, emb_alt], dim=1)  # [B, 2 + 2D]

--- a/src/marin_dna/pipelines/evals/inference.py
+++ b/src/marin_dna/pipelines/evals/inference.py
@@ -26,7 +26,15 @@ def fwd_rc_average_f16(strand_embs: list[np.ndarray]) -> np.ndarray:
     for e in strand_embs:
         acc += np.asarray(e, dtype=np.float32)
     acc /= len(strand_embs)
-    return acc.astype(np.float16)
+    out = acc.astype(np.float16)
+    # Fail loud rather than silently ship inf: a pooled mean beyond float16's
+    # ±65504 (e.g. a persistent massive-activation channel) overflows on the cast,
+    # which would NaN-poison the downstream delta = emb_alt - emb_ref.
+    assert np.isfinite(out).all(), (
+        "non-finite pooled embedding after f16 cast — the fp32 mean exceeded the "
+        "float16 range (±65504) or was non-finite upstream"
+    )
+    return out
 
 
 def compute_variant_scores(
@@ -142,13 +150,13 @@ def compute_variant_scores(
         # Each per-strand array is [N, 2 + 2D]: cols [2:2+D] = emb_ref,
         # [2+D:2+2D] = emb_alt (fp32, kernel-pooled). Average the strands in fp32
         # and store each as a length-D float16 vector per row (list[f16] column).
+        # Bundle layout is [B, 2 + 2D]: 2 score cols (llr, jsd), then emb_ref, emb_alt.
+        d = model.config.hidden_size
         width = next(iter(results.values())).shape[1]
-        hidden_size = model.config.hidden_size
-        assert width == 2 + 2 * hidden_size, (
-            f"score-bundle width {width} != 2 + 2*hidden_size "
-            f"(hidden_size={hidden_size}); embedding slicing would be wrong"
+        assert width == 2 + 2 * d, (
+            f"score-bundle width {width} != 2 + 2*hidden_size ({d}); the 2 score "
+            f"cols + 2 embedding blocks are mis-sized — emb slicing would be wrong"
         )
-        d = hidden_size
         cols["emb_ref"] = list(
             fwd_rc_average_f16([arr[:, 2 : 2 + d] for arr in results.values()])
         )

--- a/src/marin_dna/pipelines/evals/inference.py
+++ b/src/marin_dna/pipelines/evals/inference.py
@@ -2,12 +2,31 @@
 
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 from datasets import Dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from marin_dna.data.genome import Genome
 from marin_dna.model.runner import run_variant_score_bundle
+
+
+def fwd_rc_average_f16(strand_embs: list[np.ndarray]) -> np.ndarray:
+    """FWD+RC mean of per-strand fp32 pooled embeddings, cast to float16 for storage.
+
+    Each ``strand_embs[i]`` is one strand's pooled vectors ``[N, D]`` (fp32). The
+    mean is the #314 protocol's FWD+RC average. Accumulate in **fp32** and cast to
+    f16 only at the very end: f16 storage of allele *means* already bounds the
+    downstream probe feature ``delta = emb_alt - emb_ref`` (a small difference of
+    two near-equal vectors — catastrophic cancellation), so the aggregation itself
+    must not add rounding on top of it (issue #318). Returns ``[N, D]`` f16.
+    """
+    assert strand_embs, "need at least one strand's embeddings to average"
+    acc = np.zeros_like(strand_embs[0], dtype=np.float32)
+    for e in strand_embs:
+        acc += np.asarray(e, dtype=np.float32)
+    acc /= len(strand_embs)
+    return acc.astype(np.float16)
 
 
 def compute_variant_scores(
@@ -20,6 +39,8 @@ def compute_variant_scores(
     data_transform_on_the_fly: bool = True,
     torch_compile: bool = False,
     rc: bool = False,
+    return_embeddings: bool = False,
+    eval_accumulation_steps: int | None = None,
 ) -> pd.DataFrame:
     """Compute variant scores from a CLM: per-strand LLR + next-token JSD.
 
@@ -42,6 +63,17 @@ def compute_variant_scores(
         rc: If True, also score the reverse-complemented window for
             each variant and emit per-strand columns. Doubles inference
             cost.
+        return_embeddings: If True, also emit the entire-window-pooled,
+            both-allele, FWD+RC-averaged last-layer embeddings as ``emb_ref`` /
+            ``emb_alt`` ``list[f16]`` columns (issue #318), from the *same*
+            forwards as the scores. Requires ``rc=True`` (the stored vector is the
+            FWD+RC average). ``output_hidden_states`` makes the forward ~2× heavier
+            — use a smaller ``batch_size`` and/or ``eval_accumulation_steps``.
+        eval_accumulation_steps: If set, offload ``Trainer.predict`` predictions
+            to CPU every N steps (passed straight to ``TrainingArguments``).
+            Execution-only — the heavier ``[N, 2 + 2D]`` predictions of an
+            embedding run can otherwise accumulate on-GPU and OOM. ``None``
+            (default) leaves behaviour unchanged.
 
     Returns:
         DataFrame with per-strand score atoms. Rows align with input
@@ -50,6 +82,10 @@ def compute_variant_scores(
         - ``rc=False`` → 2 columns: ``llr_fwd``, ``jsd_fwd``.
         - ``rc=True``  → 4 columns: ``llr_fwd``, ``llr_rc``,
           ``jsd_fwd``, ``jsd_rc``.
+        - ``return_embeddings=True`` (requires ``rc=True``) adds ``emb_ref`` and
+          ``emb_alt`` — each a length-``D`` ``float16`` vector per row, the
+          entire-DNA-window mean-pooled, FWD+RC-averaged hidden state for that
+          allele.
 
         ``llr_*`` is the raw log-likelihood ratio; ``jsd_*`` is the mean
         per-position 4-nucleotide softmax JSD over downstream positions
@@ -57,6 +93,10 @@ def compute_variant_scores(
         Downstream consumers compute ``_avg``, ``minus_llr_*``, and
         ``abs_llr_*`` as needed.
     """
+    assert rc or not return_embeddings, (
+        "return_embeddings=True requires rc=True — the stored embedding is the "
+        "FWD+RC average; a forward-only embedding would be silently mislabeled"
+    )
     checkpoint_path = Path(checkpoint_path)
     # Don't Path()-cast genome_path: would break s3:// URIs (POSIX path
     # normalization collapses // to /). Genome accepts str | Path and
@@ -71,6 +111,16 @@ def compute_variant_scores(
     )
     hf_dataset = Dataset.from_pandas(dataset, preserve_index=False)
 
+    inference_kwargs: dict[str, object] = {
+        "per_device_eval_batch_size": batch_size,
+        "torch_compile": torch_compile,
+        "bf16_full_eval": True,
+        "dataloader_num_workers": num_workers,
+        "remove_unused_columns": False,
+    }
+    if eval_accumulation_steps is not None:
+        inference_kwargs["eval_accumulation_steps"] = eval_accumulation_steps
+
     results = run_variant_score_bundle(
         model,
         tokenizer,
@@ -78,18 +128,31 @@ def compute_variant_scores(
         genome,
         context_size,
         rc=rc,
+        return_embeddings=return_embeddings,
         data_transform_on_the_fly=data_transform_on_the_fly,
-        inference_kwargs={
-            "per_device_eval_batch_size": batch_size,
-            "torch_compile": torch_compile,
-            "bf16_full_eval": True,
-            "dataloader_num_workers": num_workers,
-            "remove_unused_columns": False,
-        },
+        inference_kwargs=inference_kwargs,
     )
 
     cols: dict[str, object] = {}
     for strand, arr in results.items():
         cols[f"llr_{strand}"] = arr[:, 0]
         cols[f"jsd_{strand}"] = arr[:, 1]
+
+    if return_embeddings:
+        # Each per-strand array is [N, 2 + 2D]: cols [2:2+D] = emb_ref,
+        # [2+D:2+2D] = emb_alt (fp32, kernel-pooled). Average the strands in fp32
+        # and store each as a length-D float16 vector per row (list[f16] column).
+        width = next(iter(results.values())).shape[1]
+        hidden_size = model.config.hidden_size
+        assert width == 2 + 2 * hidden_size, (
+            f"score-bundle width {width} != 2 + 2*hidden_size "
+            f"(hidden_size={hidden_size}); embedding slicing would be wrong"
+        )
+        d = hidden_size
+        cols["emb_ref"] = list(
+            fwd_rc_average_f16([arr[:, 2 : 2 + d] for arr in results.values()])
+        )
+        cols["emb_alt"] = list(
+            fwd_rc_average_f16([arr[:, 2 + d : 2 + 2 * d] for arr in results.values()])
+        )
     return pd.DataFrame(cols)

--- a/tests/model/test_scoring.py
+++ b/tests/model/test_scoring.py
@@ -1129,24 +1129,47 @@ def test_run_variant_marginal_matches_bundle_llr_end_to_end(tmp_path):
 # --- compute_variant_score_bundle return_embeddings (issue #318) -------------
 
 
+class _FixedHiddenBase(nn.Module):
+    """Stand-in for an HF base/decoder model: returns the fixed per-position
+    hidden as ``last_hidden_state``, so a forward hook on it captures the last
+    layer — exactly how ``compute_variant_score_bundle`` grabs hidden states
+    without ``output_hidden_states``. Position-aware via the cached-prefix offset
+    (``_kv_cache_seq_len``); ``logits_to_keep`` must NOT truncate it (mirrors HF),
+    so it always returns the full ``[B, L, D]`` window."""
+
+    def __init__(self, hidden_full: Tensor):
+        super().__init__()
+        self.register_buffer("hidden_full", hidden_full)  # [L_max, D]
+
+    def forward(self, input_ids, past_key_values=None, use_cache=False, **kwargs):
+        B, L = input_ids.shape
+        offset = _kv_cache_seq_len(past_key_values)
+        h = self.hidden_full[offset : offset + L]  # [L, D]
+        h = h.unsqueeze(0).expand(B, L, h.shape[-1]).contiguous()
+        pkv = None
+        if use_cache:
+            pkv = ((torch.zeros(B, 1, L, 1), torch.zeros(B, 1, L, 1)),)
+        return SimpleNamespace(last_hidden_state=h, past_key_values=pkv)
+
+
 class _FixedHiddenCausalLM(nn.Module):
     """Test double exposing a *fixed* per-position last-layer hidden state, so the
     pooled embedding has a closed form.
 
     ``hidden_full`` is ``[L_max, D]``: the last-layer state at absolute position
-    ``t`` is ``hidden_full[t]``, independent of token content. The forward is
-    position-aware via the cached-prefix offset (``_kv_cache_seq_len``), so the
-    prefix-shared call pattern (prefix forward at offset 0, suffix forward at
-    offset = prefix length) returns the matching slices — exactly what
-    ``compute_variant_score_bundle`` concatenates. Logits are content-independent
-    (``pos + vocab``) — valid for the 4-nuc LLR/JSD path but irrelevant to the
-    embedding columns under test. Content-independence ⇒ ``emb_ref == emb_alt``
-    (the only ref/alt difference is the token at ``var_pos``, which doesn't move
-    the hidden state here)."""
+    ``t`` is ``hidden_full[t]``, independent of token content. The ``base_model``
+    submodule returns it as ``last_hidden_state``, so the kernel's forward hook on
+    ``model.base_model`` captures the matching slice for the prefix-shared call
+    pattern (prefix forward at offset 0, suffix forward at offset = prefix length)
+    — exactly what ``compute_variant_score_bundle`` concatenates. Logits are
+    content-independent (``pos + vocab``) — valid for the 4-nuc LLR/JSD path but
+    irrelevant to the embedding columns under test. Content-independence ⇒
+    ``emb_ref == emb_alt`` (the only ref/alt difference is the token at
+    ``var_pos``, which doesn't move the hidden state here)."""
 
     def __init__(self, hidden_full: Tensor, vocab_size: int):
         super().__init__()
-        self.register_buffer("hidden_full", hidden_full)  # [L_max, D]
+        self.base_model = _FixedHiddenBase(hidden_full)
         self.vocab_size = vocab_size
 
     def forward(
@@ -1154,25 +1177,22 @@ class _FixedHiddenCausalLM(nn.Module):
         input_ids,
         past_key_values=None,
         use_cache=False,
-        output_hidden_states=False,
         logits_to_keep=0,
         **kwargs,
     ):
+        # Route through base_model so a forward hook on it fires (the kernel's
+        # no-all-layers hidden-state capture path).
+        base = self.base_model(
+            input_ids, past_key_values=past_key_values, use_cache=use_cache
+        )
         B, L = input_ids.shape
         offset = _kv_cache_seq_len(past_key_values)
         pos = torch.arange(offset, offset + L, dtype=torch.float).unsqueeze(-1)
         vocab = torch.arange(self.vocab_size, dtype=torch.float)
         logits = (pos + vocab).unsqueeze(0).expand(B, L, self.vocab_size).contiguous()
         out = SimpleNamespace(logits=logits)
-        if output_hidden_states:
-            # logits_to_keep must NOT truncate the hidden states (mirrors HF):
-            # always return the full [B, L, D] slice for this forward's window.
-            h = self.hidden_full[offset : offset + L]  # [L, D]
-            out.hidden_states = (h.unsqueeze(0).expand(B, L, h.shape[-1]).contiguous(),)
         if use_cache:
-            k = torch.zeros(B, 1, L, 1)
-            v = torch.zeros(B, 1, L, 1)
-            out.past_key_values = ((k, v),)
+            out.past_key_values = base.past_key_values
         return out
 
 
@@ -1360,6 +1380,34 @@ def test_variant_score_bundle_embeddings_require_pool_bounds():
             nuc_token_ids=_IDENTITY_NUC_IDS,
             return_embeddings=True,
         )
+
+
+def test_variant_score_bundle_embeddings_hook_removed_and_off_path_clean():
+    """The base-model forward hook is registered only when pooling and removed
+    after the call (no leak across the per-batch kernel calls Trainer.predict
+    makes); the off-path registers none at all."""
+    D = 4
+    model = _FixedHiddenCausalLM(
+        torch.arange(10 * D, dtype=torch.float).reshape(10, D), vocab_size=8
+    )
+    model.eval()
+    input_ids = torch.randint(0, 4, (2, 10))
+    alt_token_id = torch.randint(0, 4, (2,))
+    kw = dict(var_pos=4, nuc_token_ids=_IDENTITY_NUC_IDS)
+
+    compute_variant_score_bundle(
+        model,
+        input_ids,
+        alt_token_id,
+        return_embeddings=True,
+        pool_lo=1,
+        pool_hi=9,
+        **kw,
+    )
+    assert not model.base_model._forward_hooks, "forward hook leaked after the call"
+
+    compute_variant_score_bundle(model, input_ids, alt_token_id, **kw)  # off-path
+    assert not model.base_model._forward_hooks
 
 
 def test_run_variant_score_bundle_return_embeddings_end_to_end(tmp_path):

--- a/tests/model/test_scoring.py
+++ b/tests/model/test_scoring.py
@@ -1124,3 +1124,283 @@ def test_run_variant_marginal_matches_bundle_llr_end_to_end(tmp_path):
     rows = np.arange(len(dataset))
     marg_llr = marg["fwd"][rows, alt_idx] - marg["fwd"][rows, ref_idx]
     np.testing.assert_allclose(marg_llr, bundle["fwd"][:, 0], rtol=1e-4, atol=1e-4)
+
+
+# --- compute_variant_score_bundle return_embeddings (issue #318) -------------
+
+
+class _FixedHiddenCausalLM(nn.Module):
+    """Test double exposing a *fixed* per-position last-layer hidden state, so the
+    pooled embedding has a closed form.
+
+    ``hidden_full`` is ``[L_max, D]``: the last-layer state at absolute position
+    ``t`` is ``hidden_full[t]``, independent of token content. The forward is
+    position-aware via the cached-prefix offset (``_kv_cache_seq_len``), so the
+    prefix-shared call pattern (prefix forward at offset 0, suffix forward at
+    offset = prefix length) returns the matching slices — exactly what
+    ``compute_variant_score_bundle`` concatenates. Logits are content-independent
+    (``pos + vocab``) — valid for the 4-nuc LLR/JSD path but irrelevant to the
+    embedding columns under test. Content-independence ⇒ ``emb_ref == emb_alt``
+    (the only ref/alt difference is the token at ``var_pos``, which doesn't move
+    the hidden state here)."""
+
+    def __init__(self, hidden_full: Tensor, vocab_size: int):
+        super().__init__()
+        self.register_buffer("hidden_full", hidden_full)  # [L_max, D]
+        self.vocab_size = vocab_size
+
+    def forward(
+        self,
+        input_ids,
+        past_key_values=None,
+        use_cache=False,
+        output_hidden_states=False,
+        logits_to_keep=0,
+        **kwargs,
+    ):
+        B, L = input_ids.shape
+        offset = _kv_cache_seq_len(past_key_values)
+        pos = torch.arange(offset, offset + L, dtype=torch.float).unsqueeze(-1)
+        vocab = torch.arange(self.vocab_size, dtype=torch.float)
+        logits = (pos + vocab).unsqueeze(0).expand(B, L, self.vocab_size).contiguous()
+        out = SimpleNamespace(logits=logits)
+        if output_hidden_states:
+            # logits_to_keep must NOT truncate the hidden states (mirrors HF):
+            # always return the full [B, L, D] slice for this forward's window.
+            h = self.hidden_full[offset : offset + L]  # [L, D]
+            out.hidden_states = (h.unsqueeze(0).expand(B, L, h.shape[-1]).contiguous(),)
+        if use_cache:
+            k = torch.zeros(B, 1, L, 1)
+            v = torch.zeros(B, 1, L, 1)
+            out.past_key_values = ((k, v),)
+        return out
+
+
+_IDENTITY_NUC_IDS = torch.tensor([0, 1, 2, 3], dtype=torch.long)
+
+
+def test_variant_score_bundle_embeddings_pool_math_and_bos_exclusion():
+    """Entire-window pool is the fp32 mean over [pool_lo, pool_hi) DNA positions,
+    with the n_prefix BOS token(s) excluded.
+
+    Fixed hidden state ``h(t)[d] = t + d`` ⇒ the pooled embedding is
+    ``mean_{t in [lo,hi)}(t) + d`` in closed form. ``pool_lo=1`` drops position 0
+    (the BOS analog); ``pool_hi=L-1`` drops the trailing position — so the pool is
+    exactly the inner DNA block, and including position 0 would shift the mean."""
+    L, D, vocab = 12, 5, 8
+    var_pos = 4
+    # h(t)[d] = t + d
+    hidden_full = (
+        torch.arange(L, dtype=torch.float)[:, None]
+        + torch.arange(D, dtype=torch.float)[None, :]
+    )  # [L, D]
+    model = _FixedHiddenCausalLM(hidden_full, vocab_size=vocab)
+    model.eval()
+    input_ids = torch.randint(0, 4, (3, L))  # nucleotide tokens (ids 0-3)
+    alt_token_id = torch.randint(0, 4, (3,))
+    pool_lo, pool_hi = 1, L - 1  # exclude BOS (idx 0) and trailing (idx L-1)
+
+    out = compute_variant_score_bundle(
+        model,
+        input_ids,
+        alt_token_id,
+        var_pos=var_pos,
+        nuc_token_ids=_IDENTITY_NUC_IDS,
+        return_embeddings=True,
+        pool_lo=pool_lo,
+        pool_hi=pool_hi,
+    )
+    assert out.shape == (3, 2 + 2 * D)
+    emb_ref = out[:, 2 : 2 + D].numpy()
+    emb_alt = out[:, 2 + D : 2 + 2 * D].numpy()
+    # Content-independent hidden ⇒ ref/alt pools identical.
+    np.testing.assert_allclose(emb_ref, emb_alt, atol=1e-5)
+    # Closed form: mean over t in [pool_lo, pool_hi) of (t + d).
+    mean_t = float(np.mean(np.arange(pool_lo, pool_hi)))
+    expected = mean_t + np.arange(D)
+    np.testing.assert_allclose(emb_ref[0], expected, atol=1e-4)
+    # Pooled count == window_size, BOS excluded: pooling [0, pool_hi) would shift
+    # the mean down — the shipped pool must NOT equal that.
+    mean_with_bos = float(np.mean(np.arange(0, pool_hi)))
+    assert not np.allclose(emb_ref[0], mean_with_bos + np.arange(D), atol=1e-3)
+    assert np.isfinite(out.numpy()).all()
+
+
+def test_variant_score_bundle_embeddings_accumulate_in_fp32():
+    """The window pool accumulates in fp32, not the model's (bf16) hidden dtype.
+
+    With bf16 hidden states summed over many positions, the kernel's fp32-cast
+    pool matches an fp32 accumulation of those bf16 values and DIFFERS measurably
+    from a bf16 accumulation — the latter is the silent-corruption path the
+    ``.float()`` cast prevents (cf. ``test_logits_to_logprobs_promotes_bf16_to_fp32``)."""
+    torch.manual_seed(0)
+    L, D, vocab = 20, 6, 8
+    var_pos = 7
+    pool_lo, pool_hi = 1, L - 1
+    hidden_full = (torch.randn(L, D) * 50.0).to(torch.bfloat16)  # large ⇒ bf16 rounds
+    model = _FixedHiddenCausalLM(hidden_full, vocab_size=vocab)
+    model.eval()
+    input_ids = torch.randint(0, 4, (2, L))
+    alt_token_id = torch.randint(0, 4, (2,))
+
+    out = compute_variant_score_bundle(
+        model,
+        input_ids,
+        alt_token_id,
+        var_pos=var_pos,
+        nuc_token_ids=_IDENTITY_NUC_IDS,
+        return_embeddings=True,
+        pool_lo=pool_lo,
+        pool_hi=pool_hi,
+    )
+    emb_kernel = out[:, 2 : 2 + D]
+    assert emb_kernel.dtype == torch.float32, "pooled embedding must be fp32"
+
+    window = hidden_full[pool_lo:pool_hi]  # [n_pool, D] bf16
+    emb_fp32 = window.float().mean(0)  # fp32 accumulation (what the kernel does)
+    emb_bf16 = window.mean(0).float()  # bf16 accumulation (the wrong way)
+    # Kernel matches the fp32 accumulation (rows identical — content-independent).
+    np.testing.assert_allclose(
+        emb_kernel.numpy(), emb_fp32.numpy()[None].repeat(2, 0), atol=1e-2
+    )
+    # ...and the fp32 vs bf16 accumulations differ by a meaningful margin.
+    assert (emb_fp32 - emb_bf16).abs().max().item() > 0.05
+
+
+def test_variant_score_bundle_embeddings_match_full_forward_pool():
+    """On a real CLM, the prefix-shared pooled embeddings equal a naive
+    full-forward-then-mean-pool over the same window — the KV-cache concat
+    reconstructs the full-window hidden states, and ref/alt genuinely differ."""
+    torch.manual_seed(0)
+    model = AutoModelForCausalLM.from_pretrained(TINY_CLM)
+    model.eval()
+    D = model.config.hidden_size
+    L, var_pos = 12, 5
+    pool_lo, pool_hi = 1, L - 1
+    # Nucleotide tokens (songlab ACGT live at ids 3-6). Force alt != ref at var_pos.
+    input_ids = torch.randint(3, 7, (3, L))
+    alt_token_id = ((input_ids[:, var_pos] - 3 + 1) % 4) + 3
+
+    with torch.no_grad():
+        out = compute_variant_score_bundle(
+            model,
+            input_ids,
+            alt_token_id,
+            var_pos=var_pos,
+            nuc_token_ids=_SONGLAB_NUC_TOKEN_IDS,
+            return_embeddings=True,
+            pool_lo=pool_lo,
+            pool_hi=pool_hi,
+        )
+        ref_ids = input_ids
+        alt_ids = input_ids.clone()
+        alt_ids[:, var_pos] = alt_token_id
+        ref_h = model(ref_ids, output_hidden_states=True).hidden_states[-1]
+        alt_h = model(alt_ids, output_hidden_states=True).hidden_states[-1]
+        exp_ref = ref_h[:, pool_lo:pool_hi].float().mean(1)
+        exp_alt = alt_h[:, pool_lo:pool_hi].float().mean(1)
+
+    assert out.shape == (3, 2 + 2 * D)
+    np.testing.assert_allclose(out[:, 2 : 2 + D].numpy(), exp_ref.numpy(), atol=1e-4)
+    np.testing.assert_allclose(
+        out[:, 2 + D : 2 + 2 * D].numpy(), exp_alt.numpy(), atol=1e-4
+    )
+    # ref and alt embeddings genuinely differ (context-dependent model).
+    assert not np.allclose(
+        out[:, 2 : 2 + D].numpy(), out[:, 2 + D : 2 + 2 * D].numpy(), atol=1e-4
+    )
+
+
+def test_variant_score_bundle_scores_unchanged_by_embeddings():
+    """The LLR/JSD columns are bit-identical with embeddings on vs off — the same
+    two forwards, with ``output_hidden_states`` only *adding* outputs."""
+    torch.manual_seed(0)
+    model = AutoModelForCausalLM.from_pretrained(TINY_CLM)
+    model.eval()
+    L, var_pos = 12, 5
+    input_ids = torch.randint(3, 7, (4, L))
+    alt_token_id = ((input_ids[:, var_pos] - 3 + 2) % 4) + 3
+
+    with torch.no_grad():
+        off = compute_variant_score_bundle(
+            model,
+            input_ids,
+            alt_token_id,
+            var_pos=var_pos,
+            nuc_token_ids=_SONGLAB_NUC_TOKEN_IDS,
+        )
+        on = compute_variant_score_bundle(
+            model,
+            input_ids,
+            alt_token_id,
+            var_pos=var_pos,
+            nuc_token_ids=_SONGLAB_NUC_TOKEN_IDS,
+            return_embeddings=True,
+            pool_lo=1,
+            pool_hi=L - 1,
+        )
+    assert off.shape == (4, 2)
+    np.testing.assert_array_equal(off.numpy(), on[:, :2].numpy())
+
+
+def test_variant_score_bundle_embeddings_require_pool_bounds():
+    """``return_embeddings=True`` without pool bounds is a loud error."""
+    import pytest
+
+    model = _FixedHiddenCausalLM(torch.zeros(8, 3), vocab_size=8)
+    model.eval()
+    input_ids = torch.randint(0, 4, (1, 8))
+    alt_token_id = torch.randint(0, 4, (1,))
+    with pytest.raises(AssertionError):
+        compute_variant_score_bundle(
+            model,
+            input_ids,
+            alt_token_id,
+            var_pos=3,
+            nuc_token_ids=_IDENTITY_NUC_IDS,
+            return_embeddings=True,
+        )
+
+
+def test_run_variant_score_bundle_return_embeddings_end_to_end(tmp_path):
+    """``run_variant_score_bundle(return_embeddings=True)`` threads the wide
+    ``[B, 2+2D]`` tensor through the HF Trainer harness (transform + batching +
+    pad/slice) and binds the strand-independent pool bounds. The ``[:, :2]``
+    scores match the embeddings-off run; the embedding block is ``2*D`` wide and
+    finite, on both strands."""
+    torch.manual_seed(0)
+    tokenizer = AutoTokenizer.from_pretrained("songlab/tokenizer-dna-mlm")
+    model = AutoModelForCausalLM.from_pretrained(TINY_CLM)
+    model.eval()
+    D = model.config.hidden_size
+    genome = Genome(_write_long_fasta(tmp_path))
+    dataset = _make_variant_dataset()
+    window_size = 16
+
+    scores_only = run_variant_score_bundle(
+        model,
+        tokenizer,
+        dataset,
+        genome,
+        window_size,
+        rc=True,
+        data_transform_on_the_fly=True,
+        inference_kwargs=_INFERENCE_KWARGS,
+    )
+    with_emb = run_variant_score_bundle(
+        model,
+        tokenizer,
+        dataset,
+        genome,
+        window_size,
+        rc=True,
+        return_embeddings=True,
+        data_transform_on_the_fly=True,
+        inference_kwargs=_INFERENCE_KWARGS,
+    )
+    for strand in ("fwd", "rc"):
+        assert with_emb[strand].shape == (4, 2 + 2 * D)
+        np.testing.assert_allclose(
+            with_emb[strand][:, :2], scores_only[strand], rtol=1e-5, atol=1e-6
+        )
+        assert np.isfinite(with_emb[strand]).all()

--- a/tests/pipelines/evals/test_inference.py
+++ b/tests/pipelines/evals/test_inference.py
@@ -7,12 +7,17 @@ End-to-end inference smoke tests (real model + real genome) live in
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
+import pytest
 
-from marin_dna.pipelines.evals.inference import compute_variant_scores
+from marin_dna.pipelines.evals.inference import (
+    compute_variant_scores,
+    fwd_rc_average_f16,
+)
 
 
 def _stub_dataset() -> pd.DataFrame:
@@ -136,3 +141,181 @@ def test_compute_variant_scores_avg_derivable_from_atoms():
     np.testing.assert_allclose(
         (scores["jsd_fwd"] + scores["jsd_rc"]) / 2, expected_jsd_avg
     )
+
+
+# --- fwd_rc_average_f16 + return_embeddings (issue #318) ---------------------
+
+
+def test_fwd_rc_average_f16_is_fp32_average_then_cast():
+    rng = np.random.default_rng(1)
+    fwd = rng.standard_normal((5, 4)).astype(np.float32)
+    rc = rng.standard_normal((5, 4)).astype(np.float32)
+    out = fwd_rc_average_f16([fwd, rc])
+    assert out.dtype == np.float16
+    # fp32 average, then a single cast to f16.
+    np.testing.assert_array_equal(out, ((fwd + rc) / 2).astype(np.float16))
+
+
+def test_fwd_rc_average_f16_accumulates_in_fp32_not_f16():
+    """Summing many large terms overflows an f16 accumulator but not fp32 — pins
+    the fp32-accumulation contract (production passes ≤2 strands, but the property
+    is what protects the pooled means from rounding)."""
+    n = 256
+    strands = [np.full((1, 3), 300.0, dtype=np.float32) for _ in range(n)]
+    out = fwd_rc_average_f16(strands)
+    np.testing.assert_allclose(out, np.full((1, 3), 300.0, dtype=np.float16))
+    acc16 = np.zeros((1, 3), dtype=np.float16)
+    with np.errstate(over="ignore"):  # the overflow is the point of the test
+        for s in strands:
+            acc16 = (acc16 + s.astype(np.float16)).astype(np.float16)
+    assert not np.isfinite(acc16).all()  # f16 running sum overflows to inf
+
+
+def _patched_model_load_with_hidden(hidden_size: int):
+    """Like ``_patched_model_load`` but the model exposes ``config.hidden_size``
+    (the driver reads it to slice the embedding block)."""
+    return (
+        patch(
+            "marin_dna.pipelines.evals.inference.AutoTokenizer.from_pretrained",
+            return_value=object(),
+        ),
+        patch(
+            "marin_dna.pipelines.evals.inference.AutoModelForCausalLM.from_pretrained",
+            return_value=SimpleNamespace(
+                config=SimpleNamespace(hidden_size=hidden_size)
+            ),
+        ),
+        patch(
+            "marin_dna.pipelines.evals.inference.Genome",
+            return_value=object(),
+        ),
+    )
+
+
+def test_compute_variant_scores_embeddings_columns_and_fp32_average():
+    ds = _stub_dataset()
+    n, d = len(ds), 3
+    rng = np.random.default_rng(0)
+    fwd = np.zeros((n, 2 + 2 * d), dtype=np.float32)
+    rc = np.zeros((n, 2 + 2 * d), dtype=np.float32)
+    fwd[:, 0], fwd[:, 1] = [0.1, 0.2, 0.3, 0.4], [0.01, 0.02, 0.03, 0.04]
+    rc[:, 0], rc[:, 1] = [-0.1, -0.2, -0.3, -0.4], [0.05, 0.06, 0.07, 0.08]
+    fwd[:, 2:] = rng.standard_normal((n, 2 * d)).astype(np.float32)
+    rc[:, 2:] = rng.standard_normal((n, 2 * d)).astype(np.float32)
+
+    tok_patch, model_patch, genome_patch = _patched_model_load_with_hidden(d)
+    with (
+        tok_patch,
+        model_patch,
+        genome_patch,
+        patch(
+            "marin_dna.pipelines.evals.inference.run_variant_score_bundle",
+            return_value={"fwd": fwd, "rc": rc},
+        ),
+    ):
+        scores = compute_variant_scores(
+            checkpoint_path="/unused",
+            dataset=ds,
+            genome_path="/unused.fa",
+            rc=True,
+            return_embeddings=True,
+        )
+
+    assert set(scores.columns) == {
+        "llr_fwd",
+        "llr_rc",
+        "jsd_fwd",
+        "jsd_rc",
+        "emb_ref",
+        "emb_alt",
+    }
+    # Scalar score atoms unchanged by the embedding path.
+    np.testing.assert_array_equal(scores["llr_fwd"].values, fwd[:, 0])
+    np.testing.assert_array_equal(scores["jsd_rc"].values, rc[:, 1])
+    # emb_ref/emb_alt: per-row length-D f16 = fp32 FWD+RC average, then cast.
+    got_ref = np.stack(scores["emb_ref"].to_numpy())
+    got_alt = np.stack(scores["emb_alt"].to_numpy())
+    assert got_ref.dtype == np.float16 and got_ref.shape == (n, d)
+    exp_ref = ((fwd[:, 2 : 2 + d] + rc[:, 2 : 2 + d]) / 2).astype(np.float16)
+    exp_alt = ((fwd[:, 2 + d :] + rc[:, 2 + d :]) / 2).astype(np.float16)
+    np.testing.assert_array_equal(got_ref, exp_ref)
+    np.testing.assert_array_equal(got_alt, exp_alt)
+
+
+def test_compute_variant_scores_embeddings_parquet_roundtrip(tmp_path):
+    """The emb columns survive the production storage path (the rule concats the
+    variant frame + scores and writes parquet) as length-D float16 lists."""
+    ds = _stub_dataset()
+    n, d = len(ds), 4
+    rng = np.random.default_rng(2)
+    fwd = np.zeros((n, 2 + 2 * d), dtype=np.float32)
+    rc = np.zeros((n, 2 + 2 * d), dtype=np.float32)
+    fwd[:, 2:] = rng.standard_normal((n, 2 * d)).astype(np.float32)
+    rc[:, 2:] = rng.standard_normal((n, 2 * d)).astype(np.float32)
+
+    tok_patch, model_patch, genome_patch = _patched_model_load_with_hidden(d)
+    with (
+        tok_patch,
+        model_patch,
+        genome_patch,
+        patch(
+            "marin_dna.pipelines.evals.inference.run_variant_score_bundle",
+            return_value={"fwd": fwd, "rc": rc},
+        ),
+    ):
+        scores = compute_variant_scores(
+            checkpoint_path="/unused",
+            dataset=ds,
+            genome_path="/unused.fa",
+            rc=True,
+            return_embeddings=True,
+        )
+
+    out = pd.concat([ds.reset_index(drop=True), scores.reset_index(drop=True)], axis=1)
+    path = tmp_path / "scores.parquet"
+    out.to_parquet(path, index=False)
+    back = pd.read_parquet(path)
+    got = np.stack(back["emb_ref"].to_numpy())
+    assert got.dtype == np.float16 and got.shape == (n, d)
+    np.testing.assert_array_equal(got, np.stack(scores["emb_ref"].to_numpy()))
+
+
+def test_compute_variant_scores_return_embeddings_requires_rc():
+    ds = _stub_dataset()
+    tok_patch, model_patch, genome_patch = _patched_model_load_with_hidden(3)
+    with tok_patch, model_patch, genome_patch:
+        with pytest.raises(AssertionError, match="requires rc=True"):
+            compute_variant_scores(
+                checkpoint_path="/unused",
+                dataset=ds,
+                genome_path="/unused.fa",
+                rc=False,
+                return_embeddings=True,
+            )
+
+
+def test_compute_variant_scores_embeddings_width_mismatch_asserts():
+    """A bundle width that isn't ``2 + 2*hidden_size`` is a loud error (guards
+    against a silent mis-slice if the kernel/runner ever drift)."""
+    ds = _stub_dataset()
+    n, d = len(ds), 3
+    # Model says hidden_size=d but the array is 2 + 2*(d+1) wide.
+    bad = np.zeros((n, 2 + 2 * (d + 1)), dtype=np.float32)
+    tok_patch, model_patch, genome_patch = _patched_model_load_with_hidden(d)
+    with (
+        tok_patch,
+        model_patch,
+        genome_patch,
+        patch(
+            "marin_dna.pipelines.evals.inference.run_variant_score_bundle",
+            return_value={"fwd": bad, "rc": bad},
+        ),
+    ):
+        with pytest.raises(AssertionError, match="hidden_size"):
+            compute_variant_scores(
+                checkpoint_path="/unused",
+                dataset=ds,
+                genome_path="/unused.fa",
+                rc=True,
+                return_embeddings=True,
+            )


### PR DESCRIPTION
🤖 Productionizes the **inference** slice of the #314 frozen-embedding linear-probe VEP protocol (umbrella #321; siblings: probes #320, metrics #319).

fixes #318

## What

The same two (FWD, RC) forward passes that already produce LLR + JSD now *optionally* also emit a pooled both-allele embedding, written into the **same** `results/scores/{model}/{dataset}.parquet`. No second pass, no parallel per-token cache (the #314 cache was 0.4–1.2 TB/model; this is ~1.5–2.3 GB/model, ~500× smaller).

- **Kernel** — [`compute_variant_score_bundle`](https://github.com/Open-Athena/marin-dna/blob/5cbd626260d944671595aee6682504e7c410447e/src/marin_dna/model/scoring.py#L153) gains `return_embeddings` / `pool_lo` / `pool_hi`. When on, it requests `output_hidden_states=True` on the **same** prefix + suffix forwards, reconstructs the full-window last-layer states (shared prefix `[B,p,D]` ++ each allele's suffix `[B,L−p,D]`), mean-pools `[pool_lo, pool_hi)` in **fp32**, and returns a single `[B, 2+2D]` tensor. LLR/JSD math is untouched.
- **Runner** — [`run_variant_score_bundle`](https://github.com/Open-Athena/marin-dna/blob/5cbd626260d944671595aee6682504e7c410447e/src/marin_dna/model/runner.py#L123) threads `return_embeddings` and binds strand-independent pool bounds (`pool_lo = n_prefix`, `pool_hi = n_prefix + window_size`).
- **Driver** — [`compute_variant_scores`](https://github.com/Open-Athena/marin-dna/blob/5cbd626260d944671595aee6682504e7c410447e/src/marin_dna/pipelines/evals/inference.py#L32) asserts `rc=True`, FWD+RC-averages the embedding blocks in fp32 via [`fwd_rc_average_f16`](https://github.com/Open-Athena/marin-dna/blob/5cbd626260d944671595aee6682504e7c410447e/src/marin_dna/pipelines/evals/inference.py#L14), and stores `emb_ref` / `emb_alt` as `list[f16]` columns. Adds an `eval_accumulation_steps` pass-through for the heavier predictions.
- **Snakemake** — global [`inference.return_embeddings`](https://github.com/Open-Athena/marin-dna/blob/5cbd626260d944671595aee6682504e7c410447e/snakemake/analysis/evals_v2/config/config.yaml#L1163) toggle (default off), wired as an output-affecting `params:` in the [`compute_scores` rule](https://github.com/Open-Athena/marin-dna/blob/5cbd626260d944671595aee6682504e7c410447e/snakemake/analysis/evals_v2/workflow/rules/inference.smk#L8), with a [`common.smk` fail-fast](https://github.com/Open-Athena/marin-dna/blob/5cbd626260d944671595aee6682504e7c410447e/snakemake/analysis/evals_v2/workflow/rules/common.smk#L85-L90) that it requires `rc: true`.

## Settled design decisions

- **Pool the DNA window only — BOS excluded.** The #314 cache dropped the BOS prefix (`VAR_INDEX = in_seq_var_pos(255) = 127`, pooling 255 DNA positions); `compute_window_embedding` likewise starts at `n_prefix`. So the pool covers exactly `[n_prefix, n_prefix + window_size)`. For entire-window these bounds are strand-independent (both strands cover the same genomic block; mean is order-invariant).
- **One forward, reconstructed.** `logits_to_keep=1` slices the LM head, not the hidden states, so the prefix forward still yields the full `[B,p,D]`. Verified the prefix+suffix concat reconstructs a full forward to ~5e-7 on a real CLM.
- **fp32 accumulate, f16 only at storage.** The window pool (kernel) and the FWD+RC average (driver) accumulate in fp32; only the stored vector is cast to f16. `list<halffloat>` round-trips cleanly through pyarrow 22 / polars (`List(Float16)`).
- **Global toggle, not per-model list** (per maintainer call) — scope an embedding run by naming targeted targets, not a second config list to sync with `datasets:`.

## Verification

Local (no GPU): **63 tests pass** across every module importing the changed code — kernel full-forward-pool parity (real tiny CLM), BOS/pool-bounds + closed-form pool, fp32-accumulation vs bf16, LLR/JSD bit-identical with embeddings on vs off, f16 parquet round-trip mirroring the rule's write path, and the `rc`-required / width-mismatch asserts. `mypy` clean on the changed library files; ruff/pre-commit green; the evals_v2 workflow loads (the new load-time assert fires); a targeted `--rerun-triggers mtime` dry-run leaves existing cells untouched.

**Operational note.** `return_embeddings` is output-affecting (in `params:`), so flipping it on — like any kernel edit — retriggers `compute_scores`. Run **targeted** targets + `--rerun-triggers mtime` to avoid recomputing identical `llr_*`/`jsd_*` on unrelated already-scored cells.

## Out of scope (gated / siblings)

GPU smoke + the #314 probe AUPRC-parity validation (needs SkyPilot; parity is #320's job), enabling the toggle on real models, and the production re-scoring run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
