### PR TITLE
exp326: curated cCRE/enhancer datasets + training script (de-contaminate the v4 enhancer arm)

### DIFF
--- a/experiments/exp326_curated_enhancers.py
+++ b/experiments/exp326_curated_enhancers.py
@@ -1,0 +1,552 @@
+# Copyright The Marin Authors / Bolinas Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Curated-enhancer Qwen3-0.25B gLMs on de-contaminated cCRE subsets (issue #326).
+
+Trains the two *curated* cCRE/enhancer arms — de-contaminated derivations of the
+v4 ``ccre_non_promoter`` partition — to test whether removing exon-overlap
+contamination (#283 H1) and non-enhancer cCRE heterogeneity (#283 H2) unsticks
+distal VEP. Held byte-for-byte identical to exp232 (the per-region v4/0.25B run)
+*except* ``TRAIN_DATASETS`` — same Qwen3-0.25B geometry, optimizer, 5K steps ×
+8192 batch, val recipes (incl. ``val_enhancer``), mendelian AUPRC eval, and
+``v5p-8`` hardware — so each arm's offline **distal** AUPRC + ``val_enhancer``
+LL-gap drop straight into exp232's heatmap/scatter for comparison against the
+baseline ``v4_ccre_non_promoter`` arm (distal AUPRC ~0.127, flat; LL-gap↔AUPRC
+correlation −0.10).
+
+Two arms (``SWEEP_DATASETS`` selects which run in a given iris job):
+  * ``v4_ccre_noexon`` — ccre windows with zero overlap of any other functional
+    element (H1). Prediction: the off-diagonal coding leak (splicing 0.238 /
+    synonymous 0.179 in exp232) collapses toward the 0.10 floor.
+  * ``v4_ccre_noexon_enhancer`` — the above + enhancer-dominant (dELS+pELS),
+    population-matched to ``val_enhancer`` (H1+H2). Prediction: distal AUPRC
+    lifts off the floor and the LL-gap↔AUPRC correlation turns positive.
+
+Dataset build: ``snakemake/zoonomia_projection_dataset`` (rules
+``derive_subset_v4_ccre_*`` → ``select_ccre_noexon{,_enhancer}`` in
+``region_labels.py``); upload via ``sky/upload.yaml --env UPLOAD_MODE=curated_ccre``.
+
+In-training validation:
+  * 5 region-specific ``zoonomia-v1-val_*`` recipes (LL gap) from PR #171,
+    each tokenized functional + nonfunctional. Drops ``val_utr5`` / ``val_promoter``
+    in favor of the gene-centric ``val_tss_pc``.
+  * ``mendelian_traits_255`` lm-eval task (PR #186) — per consequence subset +
+    Global + Macro Avg + FWD/RC strand averaging. The online metric migrated to
+    AUPRC + per-variant FWD/RC averaging in #226 (was a broken PairwiseAccuracy
+    that read flat-at-chance in exp187); the in-training headline scalar is now
+    ``_global_/avg/auprc``, and the offline evals_v2 leaderboard uses
+    ``_macro_avg_/avg/auprc`` (per #161).
+
+HF checkpoint saving is enabled by setting ``hf_save_steps`` to match the
+eval cadence (every 500 steps). ``hf_save_path`` is auto-set by marin's
+``_update_config_to_use_out_path`` to ``<output_path>/hf`` whenever
+``TrainLmOnPodConfig.output_path`` is set, so we don't pass it explicitly.
+``hf_save_dtype`` stays at the default ``None``, preserving the param dtype
+(fp32 under our ``jmp.get_policy("p=f32,c=bfloat16")`` policy) — losslessly
+downstream-loadable at bf16 via ``torch_dtype=torch.bfloat16``.
+
+This is new vs exp160_parity, whose HF saves never landed because it left
+``hf_save_steps`` at the default 10_000 (= the final step, which doesn't
+trigger the callback because of the skip-step-0 guard). The mechanism is
+inherited from exp187, which verified it end-to-end in its smoke test.
+
+Hardware: ``v5p-8`` in ``us-east5-a`` (matches #166's actual stack per marin
+PR #5530's current code, despite that PR body's stale ``v6e-4``). At 0.25B each
+arm is ~4× cheaper in FLOPs than exp187's 1B; ``v6e-4`` would also fit now (it
+OOM'd the 1B/4B in exp166) but ``v5p-8`` is the de-risked default.
+
+Download/tokenize pattern: option 1 (``HfTokenizeConfig(id=<hf-name>)``), same
+as exp135 / exp160 / exp166 / exp187 / exp232. The 5 val recipes reuse exp232's
+tokenizations (identical names); only the 2 curated training subsets tokenize anew.
+
+Launch from a CPU box with an iris tunnel open (see ``experiments/README.md``):
+
+    SWEEP_DATASETS=v4_ccre_noexon uv run iris --cluster=marin job run \\
+        --no-wait --user gonzalo --job-name exp326-ccre-noexon \\
+        --cpu 1 --memory 2g --extra marin --region us-east5 \\
+        -e WANDB_API_KEY "$(grep -A2 api.wandb.ai ~/.netrc | grep password | awk '{print $2}')" \\
+        -e HF_HUB_DOWNLOAD_TIMEOUT 120 -e UV_LOCK_TIMEOUT 7200 \\
+        -e SWEEP_DATASETS v4_ccre_noexon \\
+        -- python experiments/exp326_curated_enhancers.py
+
+Reference templates:
+  * Direct parent — ``experiments/exp232_per_region.py`` (this is a clone
+    with only the ``TRAIN_DATASETS`` swapped to the two curated subsets).
+  * Eval-task wiring — ``experiments/parity/exp179_eval_only.py``.
+  * Geometry ladder — marin ``exp109`` (``SCALING_HIDDEN_SIZES``) /
+    ``exp166_zoonomia_1ep_scaling.py`` (``CompletedAdamHHeuristic``).
+"""
+
+import logging
+import os
+from datetime import timedelta
+from functools import lru_cache
+
+import jmp
+from fray.cluster import ResourceConfig
+from levanter.checkpoint import CheckpointerConfig
+from levanter.data.text.datasets import LmDataConfig
+from levanter.eval_harness import LmEvalHarnessConfig
+from levanter.layers.rotary import Llama3RotaryEmbeddingsConfig
+from levanter.main.train_lm import TrainLmConfig
+from levanter.models.qwen import Qwen3Config
+from levanter.optim import AdamConfig
+from levanter.tracker.wandb import WandbConfig
+from levanter.trainer import TrainerConfig
+from levanter.utils.mesh import MeshConfig
+from marin.evaluation.evaluation_config import convert_to_levanter_task_config
+from marin.execution import (
+    ExecutorStep,
+    ensure_versioned,
+    executor_main,
+    this_output_path,
+)
+from marin.execution.remote import remote
+from marin.processing.tokenize import lm_mixture_data_config, tokenize
+from marin.processing.tokenize.tokenize import HfTokenizeConfig
+from marin.training.training import TrainLmOnPodConfig, run_levanter_train_lm
+
+from marin_dna.levanter.defaults import dna_effective_seq_len
+from marin_dna.levanter.formats import DNALmDatasetFormat
+from marin_dna.pipelines.evals.lm_eval.task_configs import MENDELIAN_TRAITS_255
+
+# =============================================================================
+# Constants — issue #326 curated-enhancer experiment.
+# =============================================================================
+
+EXP_ISSUE = 326
+VERSION = "v0.1"
+TOKENIZER = "bolinas-dna/tokenizer-char-bos"
+DNA_BASE_SEQ_LEN = 255  # bp (256 - 1 for BOS)
+
+# Two curated cCRE/enhancer sub-filters of v4_ccre_non_promoter (issue #326),
+# built by snakemake/zoonomia_projection_dataset (derive_subset_v4_ccre_* →
+# select_ccre_noexon{,_enhancer}). NOT the six-way v4 partition — these are the
+# de-contaminated arms under test. SWEEP_DATASETS selects which to launch.
+TRAIN_DATASETS: dict[str, str] = {
+    "v4_ccre_noexon": "bolinas-dna/zoonomia-v1-v4_ccre_noexon",
+    "v4_ccre_noexon_enhancer": "bolinas-dna/zoonomia-v1-v4_ccre_noexon_enhancer",
+}
+
+# Five region-specific validation recipes from PR #171, tokenized functional +
+# nonfunctional for the LL-gap signal. Drops val_utr5 / val_promoter (both
+# subsumed by the gene-centric ±255 bp val_tss_pc); keeps val_enhancer
+# (chromatin-side, not subsumed).
+VAL_DATASETS: tuple[tuple[str, str], ...] = (
+    ("val_cds", "bolinas-dna/zoonomia-v1-val_cds"),
+    ("val_utr3", "bolinas-dna/zoonomia-v1-val_utr3"),
+    ("val_ncrna", "bolinas-dna/zoonomia-v1-val_ncrna"),
+    ("val_enhancer", "bolinas-dna/zoonomia-v1-val_enhancer"),
+    ("val_tss_pc", "bolinas-dna/zoonomia-v1-val_tss_pc"),
+)
+
+# Training masks lowercase positions to 1% loss weight. Zoonomia datasets use
+# ``sequence`` as the text field (vs the older ``seq`` default for genomes-v5).
+TRAIN_FORMAT = DNALmDatasetFormat(text_key="sequence", lowercase_weight=0.01)
+
+# Validation tokenization specs — the two terms of the LL gap (matches exp160 /
+# exp166; deliberately skips the "default" matched-to-training variant).
+VAL_SPECS: tuple[tuple[str, DNALmDatasetFormat], ...] = (
+    ("functional", DNALmDatasetFormat(uppercase_weight=1.0, lowercase_weight=0.0)),
+    ("nonfunctional", DNALmDatasetFormat(uppercase_weight=0.0, lowercase_weight=1.0)),
+)
+
+# Qwen3-0.25B head_dim=128 (1152 / 9 = 128). The ``~255M`` rung of exp109's
+# calibrated scaling ladder (1152→255M, 1408→476M, 1920→1.12B); the 1B that
+# exp187 ran sits two rungs up at hidden=1920. Geometry from marin's
+# ``CompletedAdamHHeuristic._build_model_config(1152)``: num_layers=12,
+# intermediate=hidden×4, n_heads=hidden//128.
+HIDDEN_DIM = 1152
+INTERMEDIATE_DIM = HIDDEN_DIM * 4  # 4608
+NUM_HEADS = HIDDEN_DIM // 128  # 9
+NUM_LAYERS = 12
+
+BATCH_SIZE = 8192
+# TPU type is env-overridable (``TPU_TYPE``, comma-separated for flexible
+# alternatives) so we can re-route between pools without editing the script —
+# e.g. ``TPU_TYPE=v4-8`` to escape a ``v5p-us-east5`` provisioning outage. v4-8
+# and v5p-8 share the same 8-chip / 2-VM topology, so the mesh + ram request and
+# a saved checkpoint carry over unchanged (v4 lives in us-central2-b, so launch
+# such arms with ``--region us-central2``; data stays cross-region in us-east5).
+TPU_TYPES: tuple[str, ...] = tuple(
+    t.strip() for t in os.getenv("TPU_TYPE", "v5p-8").split(",") if t.strip()
+)
+
+# Per-device microbatch (`per_device_parallelism`), env-overridable via ``PDP``.
+# -1 (default) = full per-chip batch in one microbatch (no grad accum). levanter
+# already runs ``gradient_checkpointing=True`` by default, yet on v6e (~31 GB HBM)
+# the full per-chip batch of 8192/4 = 2048 still OOMs at ~43 GB. Set ``PDP=1024``
+# to grad-accumulate (2 microbatches of 1024/chip on a 4-chip slice) → same
+# activation memory as the v6e-8 run (~24 GB, fits) while the **effective batch
+# stays 8192** (train_batch_size unchanged → mathematically identical step).
+PER_DEVICE_PARALLELISM: int = int(os.getenv("PDP", "-1"))
+
+# 5K steps × 8192 batch × 256 tokens/seq ≈ 10.5B tokens per arm (same data
+# schedule as exp187). Asymmetric epoch counts across arms are by design (we
+# hold compute fixed, not data); v4 post-RC rows shift the counts vs v3:
+# v4_ccre_non_promoter 0.47 ep, v4_cds 0.71, v4_bg 1.08, v4_ncrna_exon 2.51,
+# v4_utr3 3.25, v4_tss_region_and_utr5 3.63.
+NUM_TRAIN_STEPS = 5_000
+
+# Optimizer hparams from marin PR #5530's exp166 transferred-hparam table
+# (resolved by ``CompletedAdamHHeuristic`` for B=8192, T=5.73e10 — exp166's
+# full-epoch horizon).
+#
+# **CAVEAT** — our T = 5_000 × 8192 × 256 ≈ 1.05e10, ~5× smaller than exp166's
+# horizon. The DNA-calibrated heuristic would resolve slightly different lr /
+# beta2 / epsilon for our regime. We use exp166's values here as a deliberate
+# starting point; the AdamH heuristic is size-independent (keyed on (B, T), both
+# unchanged at 0.25B), so per-region runs share exp187's / exp166's optimizer
+# config — only the model is smaller. If reviewers want regime-correct hparams,
+# re-resolve via marin's CompletedAdamHHeuristic for (B=8192, T=1.05e10) and pin
+# the resolved values here (this applies equally to the 1B). Tracked as Q1.
+LEARNING_RATE = 0.00430097
+BETA1 = 0.66756
+BETA2 = 0.952222
+EPSILON = 6.77142e-15
+MAX_GRAD_NORM = 0.995188
+Z_LOSS_WEIGHT = 4.312883184368223e-06
+INITIALIZER_RANGE = 0.02
+WEIGHT_DECAY = 0.1  # exp160 / exp135 default; the heuristic doesn't tune WD
+WARMUP_FRACTION = 0.1
+DECAY_FRACTION = 0.2
+LR_SCHEDULE = "linear"
+MIN_LR_RATIO = 0.0
+
+# Eval + checkpoint cadence. EVALS_PER_RUN = 10 → first eval at step 500. We
+# match HF-checkpoint cadence to eval cadence so every in-training eval has a
+# reloadable HF artifact for offline analysis (e.g. re-running mendelian eval
+# against a specific step).
+EVALS_PER_RUN = 10
+CHECKPOINTS_PER_RUN = 10
+CHECKPOINT_TIME_INTERVAL = timedelta(hours=1)
+
+WANDB_PROJECT = "marin"
+WANDB_GROUP = f"dna-exp{EXP_ISSUE}-{VERSION}"
+
+_EXPECTED_VOCAB_SIZE_WARNING = (
+    f"Tokenizer {TOKENIZER!r} not found in _KNOWN_VOCAB_SIZES"
+)
+logging.getLogger("marin.processing.tokenize.data_configs").addFilter(
+    lambda record: _EXPECTED_VOCAB_SIZE_WARNING not in record.getMessage()
+)
+
+
+# =============================================================================
+# Environment overrides
+# =============================================================================
+
+
+def _selected_datasets() -> dict[str, str]:
+    """Return the subset of TRAIN_DATASETS named in SWEEP_DATASETS (or all)."""
+    raw = os.getenv("SWEEP_DATASETS")
+    if not raw:
+        return dict(TRAIN_DATASETS)
+    requested = tuple(s.strip() for s in raw.split(","))
+    invalid = [n for n in requested if n not in TRAIN_DATASETS]
+    if invalid:
+        raise ValueError(
+            f"Invalid SWEEP_DATASETS {invalid}; available: {sorted(TRAIN_DATASETS)}"
+        )
+    return {n: TRAIN_DATASETS[n] for n in requested}
+
+
+# =============================================================================
+# Builders
+# =============================================================================
+
+
+@lru_cache(maxsize=1)
+def _model_seq_len() -> int:
+    """Model context size = base DNA seq len + special tokens (BOS)."""
+    return dna_effective_seq_len(DNA_BASE_SEQ_LEN, TOKENIZER)
+
+
+# Inherited verbatim from exp160 — small orchestrator footprint for the
+# tokenize step (heavy work runs on zephyr workers).
+_TOKENIZE_RESOURCES = ResourceConfig.with_cpu(cpu=1, ram="12g", disk="10g")
+
+
+def _tokenize(
+    name: str, dataset: str, dataset_format: DNALmDatasetFormat
+) -> ExecutorStep:
+    """Tokenize one HF dataset (option-1 path, same as exp160/exp166)."""
+    config = HfTokenizeConfig(
+        id=dataset,
+        cache_path=this_output_path(),
+        tokenizer=ensure_versioned(TOKENIZER),
+        format=dataset_format,
+    )
+    return ExecutorStep(
+        name=os.path.join("tokenized", name),
+        description=f"Tokenize {dataset!r} with the {TOKENIZER} tokenizer.",
+        fn=remote(
+            tokenize,
+            resources=_TOKENIZE_RESOURCES,
+            # bolinas-dna doesn't define a ``cpu`` extra; route to ``marin``
+            # which transitively installs marin + jax + jmp + tokenizers.
+            pip_dependency_groups=["marin"],
+            env_vars={
+                "TRANSFORMERS_NO_TORCH": "1",
+                "TRANSFORMERS_NO_TORCHVISION": "1",
+                "USE_TORCH": "0",
+                "TORCH_DISABLE_GLOBAL_DEPS": "1",
+                # huggingface_hub's default read_timeout=10s is too short for
+                # bigger parquet manifests; bump to 120s.
+                "HF_HUB_DOWNLOAD_TIMEOUT": "120",
+                # Many concurrent zephyr workers share a uv cache; first build
+                # serializes lm-eval (URL dep). Default 300s isn't enough.
+                "UV_LOCK_TIMEOUT": "7200",
+            },
+        ),
+        config=config,
+    )
+
+
+def _build_data_mixture(strategy: str, dataset: str) -> LmDataConfig:
+    """One training component + cross-product of validation recipes × specs."""
+    components: dict[str, ExecutorStep] = {
+        strategy: _tokenize(
+            f"marin_dna-zoonomia-v1-{strategy}-char-bos", dataset, TRAIN_FORMAT
+        ),
+    }
+    for region, val_dataset in VAL_DATASETS:
+        for suffix, fmt in VAL_SPECS:
+            key = f"{region}_{suffix}"
+            components[key] = _tokenize(
+                f"marin_dna-zoonomia-v1-{key}-char-bos", val_dataset, fmt
+            )
+    return lm_mixture_data_config(
+        components=components,
+        weights={strategy: 1.0},
+    )
+
+
+def _build_model_config() -> Qwen3Config:
+    """Qwen3-0.25B head_dim=128 (hidden=1152, layers=12, heads=9).
+
+    The ~255M rung of exp109's calibrated ladder; geometry from marin's
+    ``CompletedAdamHHeuristic._build_model_config(1152)`` (num_layers=12,
+    intermediate=4608, n_heads=9).
+    """
+    return Qwen3Config(
+        hidden_dim=HIDDEN_DIM,
+        intermediate_dim=INTERMEDIATE_DIM,
+        num_layers=NUM_LAYERS,
+        num_heads=NUM_HEADS,
+        num_kv_heads=NUM_HEADS,
+        max_seq_len=_model_seq_len(),
+        rope=Llama3RotaryEmbeddingsConfig(),
+        initializer_range=INITIALIZER_RANGE,
+    )
+
+
+def _build_optimizer() -> AdamConfig:
+    return AdamConfig(
+        learning_rate=LEARNING_RATE,
+        weight_decay=WEIGHT_DECAY,
+        beta1=BETA1,
+        beta2=BETA2,
+        epsilon=EPSILON,
+        max_grad_norm=MAX_GRAD_NORM,
+        warmup=WARMUP_FRACTION,
+        decay=DECAY_FRACTION,
+        lr_schedule=LR_SCHEDULE,
+        min_lr_ratio=MIN_LR_RATIO,
+    )
+
+
+def _eval_harness_config() -> LmEvalHarnessConfig:
+    """Wire the mendelian eval (AUPRC + Global + Macro Avg + FWD/RC strand
+    averaging; online metric migrated from PA in #226). Same shape as exp179_eval_only.py."""
+    return LmEvalHarnessConfig(
+        task_spec=convert_to_levanter_task_config([MENDELIAN_TRAITS_255]),
+    )
+
+
+def _checkpointer(num_train_steps: int) -> CheckpointerConfig:
+    return CheckpointerConfig(
+        save_interval=CHECKPOINT_TIME_INTERVAL,
+        keep=[dict(every=max(1, num_train_steps // CHECKPOINTS_PER_RUN))],
+    )
+
+
+def _hf_save_steps(num_train_steps: int) -> int:
+    """Match HF-checkpoint cadence to eval cadence — every eval has a paired
+    reloadable HF artifact under ``<this_output_path>/hf/step-<N>/``."""
+    return max(1, num_train_steps // EVALS_PER_RUN)
+
+
+def _run_train_with_marin_dna_imports(pod_config: TrainLmOnPodConfig) -> None:
+    """Wrap ``run_levanter_train_lm`` with the in-function marin_dna imports the
+    TPU worker needs.
+
+    Iris's ``Entrypoint.from_callable`` cloudpickles ``__main__`` by-value,
+    capturing function bytecode but NOT re-importing modules on the worker.
+    Module-top imports in this script (``marin_dna.levanter.formats``,
+    ``marin_dna.pipelines.evals.lm_eval.task_configs``) never fire on the TPU
+    pod, so the side-effecting registrations (``@register_subclass("dna")``
+    for ``DNALmDatasetFormat``; the lm-eval task-manager patch) never
+    install. Trainer init then fails with
+    ``ValueError: Unknown format DNALmDatasetFormat(...)`` when deserializing
+    the data config (smoke5 confirmed this).
+
+    Exp179_eval_only.py:91-96 has the same pattern for the eval path. The
+    fix is the same here: bake the imports into the function body that the
+    TPU worker actually runs.
+    """
+    import marin_dna.levanter.formats  # noqa: F401  # registers "dna" LmDatasetFormat
+    import marin_dna.pipelines.evals.lm_eval  # noqa: F401  # patches lm_eval TaskManager
+
+    run_levanter_train_lm(pod_config)
+
+
+def _train_remote_env_vars() -> dict[str, str]:
+    """Env vars baked into the train ``remote()`` call.
+
+    Iris workers don't inherit ``-e`` flags from the launcher's ``iris job run``
+    command — the orchestrator passes them to its own process tree, but child
+    tasks (the TPU pod running ``run_levanter_train_lm``) get a fresh env.
+    Per ``experiments/README.md:59-67`` and the working pattern in
+    ``experiments/parity/exp179_eval_only.py:124-130``, capture the key vars
+    from the launcher env here and bake them into the remote spec.
+
+    Missing ``WANDB_API_KEY`` here was the cause of ``/gonzalo/exp187-smoke2``
+    failing with ``wandb.UsageError: No API key configured`` after ~45 min of
+    successful tokenize work.
+    """
+    env: dict[str, str] = {
+        "HF_HUB_DOWNLOAD_TIMEOUT": "120",
+        "UV_LOCK_TIMEOUT": "7200",
+    }
+    # Reject empty WANDB_API_KEY — the launch command's shell ordering can
+    # silently substitute an empty value (``VAR=$(...) cmd -e VAR "$VAR"``
+    # resolves ``$VAR`` *before* the prefix assignment). Wandb's UsageError
+    # in that case is delayed until trainer init on the TPU pod, after ~45
+    # min of tokenize work has succeeded — costly. Fail loud at launch time
+    # instead.
+    wandb_key = os.environ.get("WANDB_API_KEY", "")
+    if wandb_key:
+        env["WANDB_API_KEY"] = wandb_key
+    else:
+        raise RuntimeError(
+            "WANDB_API_KEY is not set in the launcher's environment "
+            "(or is empty). The recommended launch pattern is to use "
+            "inline ``$(...)`` substitution in ``-e WANDB_API_KEY ...`` "
+            "per experiments/README.md — not a ``VAR=... cmd`` prefix, "
+            "which has a shell-ordering bug."
+        )
+    return env
+
+
+def _build_train_step(strategy: str, dataset: str) -> ExecutorStep:
+    steps_per_eval = max(1, NUM_TRAIN_STEPS // EVALS_PER_RUN)
+    run_name = f"dna-exp{EXP_ISSUE}-zoonomia-v1-0p25b-{strategy}-{VERSION}"
+    # Optional suffix for an intentional clean re-train. Suffixing run_name yields
+    # a fresh output path (=> fresh checkpoint dir => trains from scratch) AND a
+    # fresh wandb run-id — the id derives from replicate_path=output_path (below),
+    # NOT the display name, so this is the only way to escape a prior run's wandb
+    # step-barrier (levanter "cowardly refuses" to log a step below a resumed
+    # run's max; a from-scratch retrain at the old path collides with a crashed
+    # run's history). Empty by default → no effect on normal runs.
+    _run_suffix = os.environ.get("RUN_NAME_SUFFIX", "")
+    if _run_suffix:
+        run_name = f"{run_name}-{_run_suffix}"
+    tags = (
+        "dna",
+        "marin_dna",
+        f"exp{EXP_ISSUE}",
+        "curated-enhancer",
+        "zoonomia_v1_v4",
+        VERSION,
+        f"region={strategy}",
+        "scale=0.25b",
+        f"bs={BATCH_SIZE}",
+        f"steps={NUM_TRAIN_STEPS}",
+    )
+
+    # iris's Entrypoint.from_callable cloudpickles __main__ by-value, so a
+    # module-top import of marin_dna.pipelines.evals.lm_eval doesn't fire on the
+    # TPU pod. Per the eval-task wiring pattern in exp179_eval_only.py:91-96,
+    # the in-function noqa import on the train worker happens inside
+    # marin.training.training.run_levanter_train_lm — see that function for the
+    # lm-eval task-manager monkeypatch's installation. We don't need to do
+    # anything special here; the convert_to_levanter_task_config([MENDELIAN_TRAITS_255])
+    # call serializes the task name + class path, which run_levanter_train_lm
+    # resolves on the worker after it imports our task module.
+
+    inner = TrainLmConfig(
+        data=_build_data_mixture(strategy, dataset),
+        model=_build_model_config(),
+        train_seq_len=_model_seq_len(),
+        z_loss_weight=Z_LOSS_WEIGHT,
+        optimizer=_build_optimizer(),
+        eval_harness=_eval_harness_config(),
+        eval_harness_steps=steps_per_eval,
+        # HF checkpoint cadence — one save per eval step. ``hf_save_path`` is
+        # auto-set by marin's ``_update_config_to_use_out_path`` to
+        # ``<output_path>/hf`` (since ``output_path`` is set on the pod config
+        # below); we only need to override the default ``hf_save_steps=10_000``.
+        # ``hf_save_dtype`` stays None → preserves param dtype (fp32 under our
+        # ``p=f32,c=bfloat16`` jmp policy); downstream consumers can cast at
+        # load time via ``from_pretrained(..., torch_dtype=torch.bfloat16)``.
+        hf_save_steps=_hf_save_steps(NUM_TRAIN_STEPS),
+        trainer=TrainerConfig(
+            tracker=WandbConfig(
+                project=WANDB_PROJECT,
+                tags=list(tags),
+                group=WANDB_GROUP,
+                name=run_name,
+                replicate_path=this_output_path(),
+            ),
+            mp=jmp.get_policy("p=f32,c=bfloat16"),
+            train_batch_size=BATCH_SIZE,
+            per_device_parallelism=PER_DEVICE_PARALLELISM,
+            num_train_steps=NUM_TRAIN_STEPS,
+            steps_per_eval=steps_per_eval,
+            checkpointer=_checkpointer(NUM_TRAIN_STEPS),
+            mesh=MeshConfig(axes={"replica": 1, "data": -1, "model": 1}),
+            allow_nondivisible_batch_size=True,
+        ),
+    )
+    pod_config = TrainLmOnPodConfig(
+        train_config=inner,
+        resources=ResourceConfig.with_tpu(TPU_TYPES, ram="300g"),
+        output_path=this_output_path(),
+    )
+    # The remote() call here IS the TPU worker — Fray's RemoteCallable submits
+    # the job with these resources verbatim. exp179_eval_only.py:140-145 mirrors
+    # this pattern; the old exp160_parity / exp166 pattern of CPU-orchestrator +
+    # TPU-pod-config relies on marin executor magic that no longer fires after
+    # the PR #182 / #186 rebase (smoke4 ran on a CPU worker and JAX raised
+    # "No accelerator found" at trainer.initialize). pip_dependency_groups
+    # explicitly installs ``tpu`` so libtpu is present — without it JAX
+    # silently falls back to CPU and we get the same error.
+    return ExecutorStep(
+        name=os.path.join("checkpoints", run_name),
+        fn=remote(
+            _run_train_with_marin_dna_imports,
+            resources=ResourceConfig.with_tpu(TPU_TYPES, ram="300g"),
+            pip_dependency_groups=["marin", "tpu"],
+            env_vars=_train_remote_env_vars(),
+        ),
+        config=pod_config,
+    )
+
+
+def main() -> None:
+    selected = _selected_datasets()
+    steps = [
+        _build_train_step(strategy, dataset) for strategy, dataset in selected.items()
+    ]
+    executor_main(
+        steps=steps,
+        description=(
+            f"DNA Bolinas exp{EXP_ISSUE} curated-enhancer Qwen3-0.25B sweep — "
+            f"{len(selected)}/{len(TRAIN_DATASETS)} arms {VERSION}"
+        ),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/snakemake/zoonomia_projection_dataset/README.md
+++ b/snakemake/zoonomia_projection_dataset/README.md
@@ -162,12 +162,18 @@ issue #221 scheme; see "v4 region labels" below).
 | `bolinas-dna/zoonomia-v1-v4_tss_region_and_utr5` | v1       | v4_tss_region_and_utr5  | `results/projection/min0.20/subsets/v4_tss_region_and_utr5.parquet`         |
 | `bolinas-dna/zoonomia-v1-v4_ccre_non_promoter`   | v1       | v4_ccre_non_promoter    | `results/projection/min0.20/subsets/v4_ccre_non_promoter.parquet`           |
 | `bolinas-dna/zoonomia-v1-v4_bg`                  | v1       | v4_bg                   | `results/projection/min0.20/subsets/v4_bg.parquet`                          |
+| `bolinas-dna/zoonomia-v1-v4_ccre_noexon`         | v1       | v4_ccre_noexon          | `results/projection/min0.20/subsets/v4_ccre_noexon.parquet`                 |
+| `bolinas-dna/zoonomia-v1-v4_ccre_noexon_enhancer`| v1       | v4_ccre_noexon_enhancer | `results/projection/min0.20/subsets/v4_ccre_noexon_enhancer.parquet`        |
 
 Each v3/v4 repo ships with its own auto-generated dataset card (README.md,
-written by `region_labels.write_subset_hf_readme` for v3 and
-`write_subset_hf_readme_v4` for v4); v1/v2 are card-less by design (semantics
+written by `region_labels.write_subset_hf_readme` for v3,
+`write_subset_hf_readme_v4` for v4, and `write_curated_ccre_hf_readme` for the
+two #326 curated cCRE sub-filters); v1/v2 are card-less by design (semantics
 live in this pipeline README rather than per-repo). v3 and v4 are **two
 different partitions of the same v1 anchors** — see "v4 region labels" below.
+The last two rows (`v4_ccre_noexon{,_enhancer}`) are **not** part of the v4
+partition — they are de-contaminated *sub-filters* of `v4_ccre_non_promoter`
+for issue #326; see "Curated cCRE/enhancer sub-filters" below.
 
 **Two-axis versioning.** `pipeline_version` (in `config/config.yaml`) snapshots species set, conservation cutoff (`project_min_p`), alignment backend, and resize/length-filter params — bump it and re-run the projection. `intervals_versions` lists the post-projection subset definitions; bumps are cheap (one new derivation rule + cheap re-runs of `subset_dataset_derived` + sharding + upload).
 
@@ -183,6 +189,7 @@ different partitions of the same v1 anchors** — see "v4 region labels" below.
 - `v2` — window overlaps `[TSS − 256, TSS + 256]` for any Ensembl protein_coding transcript
 - `v3_<label>` — per-anchor region-type partition of v1 (`cds` / `utr3` / `ncrna_exon` / `tss_region_and_utr5` / `ccre_non_promoter` / `bg`). Each anchor is assigned exactly one label by the priority-walk in `regions.smk`; the six v3 subsets sum to v1 at the anchor level. See the "Region-type annotation" section below for label definitions and the partition stats.
 - `v4_<label>` — the same six labels, re-derived with the issue #227 labeling scheme (bp-priority + window-majority, PC-only TSS band, `ccre_flank=0`, `tss_region_and_utr5` above `ncrna_exon`). A different partition of the same v1 anchors; see "v4 region labels" below.
+- `v4_ccre_noexon` / `v4_ccre_noexon_enhancer` — de-contaminated **sub-filters** of `v4_ccre_non_promoter` (issue #326), *not* part of the six-way partition. See "Curated cCRE/enhancer sub-filters" below.
 
 **HF dataset schema** (single `train` split per repo; JSONL.zst-sharded at `data/train/shard_NNNN.jsonl.zst`):
 
@@ -395,6 +402,25 @@ uv run snakemake --profile workflow/profiles/default \
 ```
 
 The v4 subset → shard → HF-upload step reuses the existing cross-mammal projection (`all_species_with_sequence.parquet`); it does **not** re-run halLiftover. On a fresh checkout where the projection's `local()` intermediates are absent, Snakemake may still *plan* to re-derive the projection for any new subset — run the subset/upload step where the projection outputs + metadata are intact (e.g. the projection cluster), as the v3 subsets were built.
+
+## Curated cCRE/enhancer sub-filters (`v4_ccre_noexon{,_enhancer}`) — issue #326
+
+Two **de-contaminated sub-filters** of the v4 `ccre_non_promoter` arm — *not* part of the six-way v4 partition — built to test whether cleaning the enhancer training set unsticks distal (enhancer) variant-effect prediction ([#283](https://github.com/Open-Athena/marin-dna/issues/283) H1/H2). Each is a new `query_names` filter over the v4 region-labels parquet (`derive_subset_v4_ccre_*` in `regions.smk` → `select_ccre_noexon{,_enhancer}` in `region_labels.py`):
+
+- **`v4_ccre_noexon`** — every `ccre_non_promoter` window whose four higher-priority disjoint fracs (`cds_frac` / `utr3_frac` / `ncrna_exon_frac` / `tss_region_and_utr5_frac`) are all 0, i.e. its functional content is *purely* cCRE. Drops the ~13% of windows that span an exon edge (mostly CDS) — the H1 contamination that lets the enhancer arm leak coding/splice skill.
+- **`v4_ccre_noexon_enhancer`** — the above, further restricted to **enhancer-dominant** windows (dELS+pELS basepair coverage ≥ the other non-PLS cCRE classes), population-matching the `val_enhancer` LL-gap probe and removing the ~17% non-enhancer (CA/CTCF/TF) heterogeneity (H2). Needs the cCRE parquet for per-class membership (the disjoint region-labels fracs don't carry cCRE subclass).
+
+These ship a minimal per-repo card (`write_curated_ccre_hf_readme`) stating provenance + a commit-pinned permalink; they are strict subsets of `v4_ccre_non_promoter`, so concatenating them does **not** reconstruct v1.
+
+```bash
+# query_names lists only (cheap; needs the v4 labels parquet + cCRE + defined on disk/S3):
+uv run snakemake --profile workflow/profiles/default all_curated_ccre_subsets
+
+# Assemble + upload both HF datasets (reuses the v1 projection; run where the
+# projection outputs are intact — the upload cluster):
+sky launch -c zoonomia-upload-ccre sky/upload.yaml \
+    --env UPLOAD_MODE=curated_ccre --env COMMIT_SHA=$(git rev-parse HEAD)
+```
 
 ## Run
 

--- a/snakemake/zoonomia_projection_dataset/config/config.yaml
+++ b/snakemake/zoonomia_projection_dataset/config/config.yaml
@@ -75,6 +75,15 @@ intervals_versions:
    "v4_tss_region_and_utr5", "v4_ccre_non_promoter", "v4_bg",
    "v4_ccre_noexon", "v4_ccre_noexon_enhancer"]
 
+# Single source of truth for which intervals_versions are the #326 curated
+# cCRE sub-filters (experimental probes, not partition members). Read by
+# dataset.smk (excluded from the bare `all_hf` aggregate — built on demand via
+# their explicit targets / `sky/upload.yaml --env UPLOAD_MODE=curated_ccre`),
+# regions.smk (the all_curated_ccre_subsets target), and sky/upload.yaml
+# (curated_ccre mode + region-mode exclusion). Must be a subset of
+# intervals_versions.
+curated_ccre_subsets: ["v4_ccre_noexon", "v4_ccre_noexon_enhancer"]
+
 hf_owner: "bolinas-dna"
 
 # ===== Species-subset datasets (third axis; issue #233) =====

--- a/snakemake/zoonomia_projection_dataset/config/config.yaml
+++ b/snakemake/zoonomia_projection_dataset/config/config.yaml
@@ -64,12 +64,16 @@ pipeline_version: "v1"
 # v4_<label> = re-derived partition with the issue #221 labeling scheme
 #              (bp-priority/window-majority + PC-only TSS + ccre_flank=0); see
 #              region_label_*_v4 below. Also six disjoint subsets summing to v1.
+# v4_ccre_noexon{,_enhancer} = curated sub-filters of v4_ccre_non_promoter
+#              (issue #326); NOT part of the six-way partition. Built by
+#              derive_subset_v4_ccre_* (regions.smk) → select_ccre_noexon{,_enhancer}.
 intervals_versions:
   ["v1", "v2",
    "v3_cds", "v3_utr3", "v3_ncrna_exon",
    "v3_tss_region_and_utr5", "v3_ccre_non_promoter", "v3_bg",
    "v4_cds", "v4_utr3", "v4_ncrna_exon",
-   "v4_tss_region_and_utr5", "v4_ccre_non_promoter", "v4_bg"]
+   "v4_tss_region_and_utr5", "v4_ccre_non_promoter", "v4_bg",
+   "v4_ccre_noexon", "v4_ccre_noexon_enhancer"]
 
 hf_owner: "bolinas-dna"
 

--- a/snakemake/zoonomia_projection_dataset/sky/upload.yaml
+++ b/snakemake/zoonomia_projection_dataset/sky/upload.yaml
@@ -83,8 +83,10 @@ run: |
     pv = cfg['pipeline_version']
     mode = os.environ['UPLOAD_MODE']
     # The #326 curated cCRE sub-filters are NOT region partitions; keep them out
-    # of region mode and give them their own curated_ccre mode.
-    curated = [s for s in cfg['intervals_versions'] if s.startswith('v4_ccre_noexon')]
+    # of region mode and give them their own curated_ccre mode. Single source of
+    # truth = config's curated_ccre_subsets (shared with dataset.smk + regions.smk),
+    # not a name-prefix heuristic that could catch an unintended future name.
+    curated = list(cfg.get('curated_ccre_subsets', []))
     if mode == 'species_subset':
         for d in cfg.get('species_subset_datasets', []):
             print(f'results/upload.done/zoonomia-{pv}-{d[\"intervals\"]}-{d[\"species\"]}')

--- a/snakemake/zoonomia_projection_dataset/sky/upload.yaml
+++ b/snakemake/zoonomia_projection_dataset/sky/upload.yaml
@@ -29,10 +29,16 @@ file_mounts:
 # v4 (issue #227). Override at launch: `sky launch ... --env UPLOAD_VERSION=v4`.
 # UPLOAD_MODE selects WHICH datasets to push:
 #   region        (default) — the six v3_*/v4_* region partitions for
-#                  UPLOAD_VERSION (the default 108-family species cohort).
+#                  UPLOAD_VERSION (the default 108-family species cohort). The
+#                  curated cCRE sub-filters (below) are excluded — they are not
+#                  partitions.
 #   species_subset — the species_subset_datasets combos (issue #233), e.g.
 #                  zoonomia-v1-v4_cds-order. UPLOAD_VERSION is ignored.
 #                  Launch: `sky launch ... --env UPLOAD_MODE=species_subset`.
+#   curated_ccre  — the two #326 curated cCRE/enhancer sub-filters of
+#                  v4_ccre_non_promoter (v4_ccre_noexon{,_enhancer}).
+#                  UPLOAD_VERSION is ignored.
+#                  Launch: `sky launch ... --env UPLOAD_MODE=curated_ccre`.
 envs:
     COMMIT_SHA: ""
     UPLOAD_VERSION: v3
@@ -76,13 +82,19 @@ run: |
     cfg = yaml.safe_load(open('config/config.yaml'))
     pv = cfg['pipeline_version']
     mode = os.environ['UPLOAD_MODE']
+    # The #326 curated cCRE sub-filters are NOT region partitions; keep them out
+    # of region mode and give them their own curated_ccre mode.
+    curated = [s for s in cfg['intervals_versions'] if s.startswith('v4_ccre_noexon')]
     if mode == 'species_subset':
         for d in cfg.get('species_subset_datasets', []):
             print(f'results/upload.done/zoonomia-{pv}-{d[\"intervals\"]}-{d[\"species\"]}')
+    elif mode == 'curated_ccre':
+        for iv in curated:
+            print(f'results/upload.done/zoonomia-{pv}-{iv}')
     else:
         ver = os.environ['UPLOAD_VERSION']
         for iv in cfg['intervals_versions']:
-            if iv.startswith(ver + '_'):
+            if iv.startswith(ver + '_') and iv not in curated:
                 print(f'results/upload.done/zoonomia-{pv}-{iv}')
     ")
     test -n "$UPLOAD_TARGETS"  # fail loudly if the mode/version matched nothing
@@ -101,6 +113,12 @@ run: |
     # region-label / projection rules are deliberately absent so Snakemake errors
     # rather than walking back into them — their outputs (query_names,
     # composition, subset parquets' source) already exist in S3.
+    # EXCEPTION (#326): the two curated cCRE sub-filters are new, so their
+    # query_names do NOT yet exist in S3 — whitelist their derive rules (which
+    # read only the v4 region-labels parquet + cCRE + defined, all in S3, so
+    # they don't walk into the projection) and their minimal card rule. These
+    # fire only in curated_ccre mode; in region/species_subset mode the existing
+    # S3 outputs satisfy mtime and they stay dormant.
     ALLOWED_RULES=(
         subset_dataset_derived
         subset_species
@@ -109,6 +127,9 @@ run: |
         dataset_hf_readme_v3
         dataset_hf_readme_v4
         dataset_hf_readme_species_subset
+        derive_subset_v4_ccre_noexon
+        derive_subset_v4_ccre_noexon_enhancer
+        dataset_hf_readme_curated_ccre
         hf_upload_dataset
     )
 

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/dataset.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/dataset.smk
@@ -4,6 +4,15 @@ import re
 
 PIPELINE_VERSION = config["pipeline_version"]
 INTERVALS_VERSIONS = list(config["intervals_versions"])
+# #326 curated cCRE sub-filters — experimental probes, not partition members.
+# Kept in INTERVALS_SOURCES (buildable on demand) but excluded from the bare
+# `all_hf` aggregate below, mirroring sky/upload.yaml's region-mode exclusion;
+# they upload via their explicit targets / UPLOAD_MODE=curated_ccre.
+CURATED_CCRE_SUBSETS = list(config.get("curated_ccre_subsets", []))
+assert set(CURATED_CCRE_SUBSETS) <= set(INTERVALS_VERSIONS), (
+    f"curated_ccre_subsets {CURATED_CCRE_SUBSETS} must be a subset of "
+    f"intervals_versions"
+)
 HF_OWNER = config["hf_owner"]
 ADD_RC = bool(config.get("add_rc", True))
 N_SHARDS = int(config.get("n_shards", 64))
@@ -70,7 +79,9 @@ for _d in SPECIES_SUBSET_DATASETS:
     SPECIES_SUBSET_SLUGS.append(_slug)
 
 # Every dataset all_hf pushes: default-species intervals versions + cohort slugs.
-ALL_DATASETS = list(INTERVALS_VERSIONS) + SPECIES_SUBSET_SLUGS
+ALL_DATASETS = [
+    iv for iv in INTERVALS_VERSIONS if iv not in CURATED_CCRE_SUBSETS
+] + SPECIES_SUBSET_SLUGS
 
 
 # Pin pipeline_version so the zoonomia-{pipeline_version}-{dataset} repo slug

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/dataset.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/dataset.smk
@@ -260,6 +260,48 @@ rule dataset_hf_readme_v4:
         )
 
 
+# The curated-ccre card (below) and the v4 partition card both match v4_\w+;
+# prefer the curated card for the two #326 sub-filter names (the v4 card would
+# fail looking them up in the six-label composition TSV).
+ruleorder: dataset_hf_readme_curated_ccre > dataset_hf_readme_v4
+
+
+rule dataset_hf_readme_curated_ccre:
+    """Minimal HF dataset card for the #326 curated cCRE/enhancer subsets.
+
+    These sub-filters of v4_ccre_non_promoter are not part of the v4 partition,
+    so the card just states provenance (the filter, a commit-pinned pipeline
+    permalink, the row count, tags) rather than a composition story — disjoint
+    from dataset_hf_readme_v4 by the exact-name constraint + the ruleorder above.
+    """
+    input:
+        source=lambda wc: INTERVALS_SOURCES[wc.intervals_version],
+    output:
+        "results/dataset/zoonomia-{pipeline_version}-{intervals_version}/README.md",
+    wildcard_constraints:
+        pipeline_version=r"v\d+",
+        intervals_version=r"v4_ccre_noexon(?:_enhancer)?",
+    params:
+        commit_sha=GIT_COMMIT_SHA,
+        hf_owner=HF_OWNER,
+        add_rc=ADD_RC,
+    run:
+        from marin_dna.pipelines.zoonomia_projection_dataset.region_labels import (
+            write_curated_ccre_hf_readme,
+        )
+
+        n_rows = pl.scan_parquet(input.source).select(pl.len()).collect().item()
+        n_samples = n_rows * (2 if params.add_rc else 1)
+        write_curated_ccre_hf_readme(
+            wildcards.intervals_version,
+            output[0],
+            commit_sha=params.commit_sha,
+            hf_owner=params.hf_owner,
+            pipeline_version=wildcards.pipeline_version,
+            n_samples=n_samples,
+        )
+
+
 rule dataset_hf_readme_species_subset:
     """HF dataset card for a species-subset dataset (e.g. v4_cds-order; #233).
 

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/regions.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/regions.smk
@@ -344,6 +344,11 @@ rule all_region_labels_v4:
 # derive_subset_v4_region's REGION_LABEL_SUBSET_V4_RE constraint.
 # ============================================================================
 
+# Single source of truth (config/config.yaml) for which subsets are curated;
+# shared with dataset.smk's all_hf exclusion and sky/upload.yaml's curated_ccre
+# mode so the three never drift.
+CURATED_CCRE_SUBSETS = list(config.get("curated_ccre_subsets", []))
+
 
 rule derive_subset_v4_ccre_noexon:
     """Arm A (#326): v4 ccre windows with zero overlap of any other functional
@@ -393,5 +398,5 @@ rule all_curated_ccre_subsets:
         expand(
             "results/projection/min{min_p}/subsets_def/{subset}.query_names.txt",
             min_p=[f"{config['project_min_p']}"],
-            subset=["v4_ccre_noexon", "v4_ccre_noexon_enhancer"],
+            subset=CURATED_CCRE_SUBSETS,
         ),

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/regions.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/regions.smk
@@ -332,3 +332,66 @@ rule all_region_labels_v4:
             min_p=[f"{config['project_min_p']}"],
             subset=REGION_LABEL_SUBSETS_V4,
         ),
+
+
+# ============================================================================
+# Curated cCRE/enhancer subsets (issue #326): de-contaminated derivations of
+# the v4 ``ccre_non_promoter`` arm to test whether removing exon-overlap (H1)
+# and non-enhancer cCRE classes (H2) unsticks distal VEP (#283). These are
+# *sub-filters* of v4_ccre_non_promoter, NOT part of the six-way v4 partition,
+# so they live outside REGION_LABEL_SUBSETS_V4 with their own derive rules. The
+# explicit (non-wildcarded) subset names keep them disjoint from
+# derive_subset_v4_region's REGION_LABEL_SUBSET_V4_RE constraint.
+# ============================================================================
+
+
+rule derive_subset_v4_ccre_noexon:
+    """Arm A (#326): v4 ccre windows with zero overlap of any other functional
+    element (CDS / 3'UTR / ncRNA exon / TSS+5'UTR). select_ccre_noexon."""
+    input:
+        labels="results/human/intervals/region_labels/v4/min{min_p}.parquet",
+    output:
+        names="results/projection/min{min_p}/subsets_def/v4_ccre_noexon.query_names.txt",
+    run:
+        from marin_dna.pipelines.zoonomia_projection_dataset.region_labels import (
+            select_ccre_noexon,
+        )
+
+        df = select_ccre_noexon(pl.read_parquet(input.labels))
+        with open(output.names, "w") as fh:
+            for name in df["name"].to_list():
+                fh.write(f"{name}\n")
+
+
+rule derive_subset_v4_ccre_noexon_enhancer:
+    """Arm B (#326): arm A windows whose cCRE content is enhancer-dominant
+    (dELS+pELS ≥ other non-PLS classes). select_ccre_noexon_enhancer."""
+    input:
+        labels="results/human/intervals/region_labels/v4/min{min_p}.parquet",
+        cre="results/human/intervals/cre/all.parquet",
+        defined="results/human/intervals/defined.bed",
+    output:
+        names="results/projection/min{min_p}/subsets_def/v4_ccre_noexon_enhancer.query_names.txt",
+    run:
+        from marin_dna.data.intervals import GenomicSet
+        from marin_dna.pipelines.zoonomia_projection_dataset.region_labels import (
+            select_ccre_noexon_enhancer,
+        )
+
+        defined = GenomicSet.read_bed(input.defined)
+        df = select_ccre_noexon_enhancer(
+            pl.read_parquet(input.labels), input.cre, defined
+        )
+        with open(output.names, "w") as fh:
+            for name in df["name"].to_list():
+                fh.write(f"{name}\n")
+
+
+rule all_curated_ccre_subsets:
+    """Aggregate target: both #326 curated-ccre query_names lists."""
+    input:
+        expand(
+            "results/projection/min{min_p}/subsets_def/{subset}.query_names.txt",
+            min_p=[f"{config['project_min_p']}"],
+            subset=["v4_ccre_noexon", "v4_ccre_noexon_enhancer"],
+        ),

--- a/src/marin_dna/pipelines/zoonomia_projection_dataset/region_labels.py
+++ b/src/marin_dna/pipelines/zoonomia_projection_dataset/region_labels.py
@@ -32,6 +32,7 @@ import polars as pl
 
 from marin_dna.data.intervals import GenomicSet
 from marin_dna.data.utils import (
+    ENHANCER_CRE_CLASSES,
     get_cds,
     get_exons,
     get_promoters_from_exons,
@@ -485,6 +486,142 @@ def label_windows_bp_majority(
             "intergenic_frac": intergenic_frac,
         }
     )
+
+
+# ============================================================================
+# Curated cCRE/enhancer sub-filters (issue #326)
+#
+# Two *derived* subsets of the v4 ``ccre_non_promoter`` arm — NOT part of the
+# six-way v4 partition — built to test whether de-contaminating the enhancer
+# training set unsticks distal VEP (#283 H1/H2):
+#   * ``select_ccre_noexon``          — drop windows overlapping any other
+#     functional element (H1: CDS/exon-edge contamination).
+#   * ``select_ccre_noexon_enhancer`` — further keep only enhancer-dominant
+#     (dELS+pELS) windows (H2: heterogeneity; population-match ``val_enhancer``).
+# Both take the ``label_windows_bp_majority`` output (the v4 region-labels
+# parquet) and return a filtered copy, one row per surviving anchor.
+# ============================================================================
+
+CCRE_LABEL = "ccre_non_promoter"
+# The higher-priority functional labels whose disjoint coverage must be zero
+# for a window to be "pure cCRE" (no exon / coding / TSS sequence in it).
+_NON_CCRE_FUNCTIONAL_FRACS = (
+    "cds_frac",
+    "utr3_frac",
+    "ncrna_exon_frac",
+    "tss_region_and_utr5_frac",
+)
+
+
+def select_ccre_noexon(labels_df: pl.DataFrame) -> pl.DataFrame:
+    """Arm A (#326): ``ccre_non_promoter`` windows with no other functional bp.
+
+    Keeps every window labelled ``ccre_non_promoter`` whose four
+    higher-priority disjoint fractions (``cds_frac``, ``utr3_frac``,
+    ``ncrna_exon_frac``, ``tss_region_and_utr5_frac``) are all exactly 0 — i.e.
+    the window's functional content is *purely* cCRE. Because the
+    :func:`label_windows_bp_majority` fracs are disjoint and priority-resolved,
+    a ccre-labelled window with ``cds_frac > 0`` contains CDS bases (claimed by
+    the higher-priority ``cds`` set) → it spans an exon edge and carries coding
+    sequence + a splice site, the #283 H1 contamination. Such windows are
+    dropped here.
+
+    Args:
+        labels_df: a v4 region-labels frame (``label_windows_bp_majority``
+            output) with ``name, label`` + the disjoint ``*_frac`` columns.
+
+    Returns:
+        The filtered frame (same schema), one row per surviving anchor.
+    """
+    required = {"name", "label", *_NON_CCRE_FUNCTIONAL_FRACS}
+    missing = required - set(labels_df.columns)
+    assert not missing, f"labels_df missing columns: {sorted(missing)}"
+
+    out = labels_df.filter(
+        (pl.col("label") == CCRE_LABEL)
+        & (pl.col("cds_frac") == 0.0)
+        & (pl.col("utr3_frac") == 0.0)
+        & (pl.col("ncrna_exon_frac") == 0.0)
+        & (pl.col("tss_region_and_utr5_frac") == 0.0)
+    )
+    assert len(out) > 0, (
+        "select_ccre_noexon produced 0 windows — wrong parquet or all ccre "
+        "windows overlap another functional element (config/biology bug?)"
+    )
+    return out
+
+
+def select_ccre_noexon_enhancer(
+    labels_df: pl.DataFrame,
+    cre_parquet: str | Path,
+    defined: GenomicSet,
+) -> pl.DataFrame:
+    """Arm B (#326): :func:`select_ccre_noexon` windows that are enhancer-dominant.
+
+    Restricts arm A to windows whose cCRE content is dominated by the
+    enhancer-like classes ``dELS`` + ``pELS`` (``ENHANCER_CRE_CLASSES``): keeps
+    a window iff its enhancer-class basepair coverage is > 0 **and** ≥ its
+    coverage by the other non-PLS classes (``CA`` / ``CA-CTCF`` / ``CA-TF`` /
+    ``CA-H3K4me3`` / ``TF``). This removes the ~17% non-enhancer heterogeneity
+    (#283 H2) so the arm population-matches the ``val_enhancer`` LL-gap probe
+    (also dELS+pELS). cCRE sub-class isn't in the disjoint region-labels fracs,
+    so this needs the cCRE parquet for per-class membership.
+
+    Assumes the v4 labeler's ``ccre_flank == 0`` (the cCRE intervals are used
+    raw, matching how ``ccre_non_promoter`` was built in
+    :func:`build_region_beds`).
+
+    Args:
+        labels_df: v4 region-labels frame (see :func:`select_ccre_noexon`),
+            with ``chrom, start, end`` window coordinates.
+        cre_parquet: ENCODE cCRE V4 parquet (``chrom, start, end, cre_class``).
+        defined: ``genome − N`` GenomicSet, intersected into both cCRE sets so
+            coverage never counts unsequenceable masked bases (matches
+            :func:`build_region_beds`).
+
+    Returns:
+        The filtered frame (same schema), one row per surviving anchor.
+    """
+    base = select_ccre_noexon(labels_df)
+    for col in ("chrom", "start", "end"):
+        assert col in base.columns, f"labels_df missing window coord column {col!r}"
+
+    cre = pl.read_parquet(cre_parquet)
+    assert "cre_class" in cre.columns, f"{cre_parquet} has no cre_class column"
+    enhancer_set = (
+        GenomicSet(
+            cre.filter(pl.col("cre_class").is_in(list(ENHANCER_CRE_CLASSES))).select(
+                ["chrom", "start", "end"]
+            )
+        )
+        & defined
+    )
+    other_set = (
+        GenomicSet(
+            cre.filter(
+                (pl.col("cre_class") != "PLS")
+                & (~pl.col("cre_class").is_in(list(ENHANCER_CRE_CLASSES)))
+            ).select(["chrom", "start", "end"])
+        )
+        & defined
+    )
+
+    windows = (
+        base.select(["chrom", "start", "end"])
+        .to_pandas()
+        .astype({"chrom": str})
+        .reset_index(drop=True)
+    )
+    enhancer_bp = _coverage_bp(windows, enhancer_set.to_pandas())
+    other_bp = _coverage_bp(windows, other_set.to_pandas())
+    keep = (enhancer_bp > 0) & (enhancer_bp >= other_bp)
+
+    out = base.filter(pl.Series(name="_keep_enhancer", values=keep))
+    assert len(out) > 0, (
+        "select_ccre_noexon_enhancer produced 0 windows — no enhancer-dominant "
+        "pure-cCRE windows (wrong cCRE parquet / cre_class vocabulary?)"
+    )
+    return out
 
 
 def region_label_composition_table(df: pl.DataFrame) -> pl.DataFrame:
@@ -1011,6 +1148,108 @@ Same as [`{hf_owner}/zoonomia-{pipeline_version}-v1`](https://huggingface.co/dat
 - Region labeler library: `marin_dna.pipelines.zoonomia_projection_dataset.region_labels.label_windows_bp_majority`
 - Sister cross-mammal datasets: `{hf_owner}/zoonomia-{pipeline_version}-v1`, `{hf_owner}/zoonomia-{pipeline_version}-v2`
 - Sister validation datasets: `{hf_owner}/zoonomia-{pipeline_version}-val_*`
+"""
+    Path(output_path).write_text(body)
+
+
+# Curated cCRE/enhancer subsets (issue #326): provenance blurb per subset.
+_CURATED_CCRE_BLURBS: dict[str, str] = {
+    "v4_ccre_noexon": (
+        "the **v4 `ccre_non_promoter`** arm with every window that overlaps any "
+        "other functional element (CDS / 3′UTR / ncRNA exon / TSS+5′UTR) "
+        "removed — i.e. windows whose functional content is *purely* cCRE. "
+        "Drops the ~13% of `ccre_non_promoter` windows that span an exon edge "
+        "(mostly CDS), the #283 H1 contamination that lets the enhancer arm "
+        "leak coding/splice skill. Filter: "
+        "`region_labels.select_ccre_noexon`."
+    ),
+    "v4_ccre_noexon_enhancer": (
+        "`v4_ccre_noexon` further restricted to **enhancer-dominant** windows "
+        "(dELS+pELS basepair coverage ≥ the other non-PLS cCRE classes), "
+        "population-matching the `val_enhancer` LL-gap probe and removing the "
+        "~17% non-enhancer (CA / CTCF / TF) heterogeneity (#283 H2). Filter: "
+        "`region_labels.select_ccre_noexon_enhancer`."
+    ),
+}
+
+
+def write_curated_ccre_hf_readme(
+    subset: str,
+    output_path: str | Path,
+    *,
+    commit_sha: str,
+    hf_owner: str,
+    pipeline_version: str,
+    n_samples: int,
+    github_repo: str = _GITHUB_REPO,
+) -> None:
+    """Write the HF dataset card for a curated cCRE/enhancer subset (issue #326).
+
+    Deliberately minimal (vs :func:`write_subset_hf_readme_v4`): these are
+    experimental sub-filters of ``v4_ccre_non_promoter``, not part of the v4
+    partition, so the card just states provenance — what filter produced it, a
+    commit-pinned permalink to the pipeline, the row count, and the standard
+    tags — rather than re-deriving a partition/composition story.
+    """
+    if subset not in _CURATED_CCRE_BLURBS:
+        raise ValueError(
+            f"unknown curated subset {subset!r}; expected one of "
+            f"{sorted(_CURATED_CCRE_BLURBS)}"
+        )
+
+    repo_name = f"{hf_owner}/zoonomia-{pipeline_version}-{subset}"
+    pipeline_permalink = (
+        f"https://github.com/{github_repo}/tree/{commit_sha}/{_GITHUB_PIPELINE_PATH}"
+    )
+    pipeline_main_link = (
+        f"https://github.com/{github_repo}/tree/main/{_GITHUB_PIPELINE_PATH}"
+    )
+    parent_repo = f"{hf_owner}/zoonomia-{pipeline_version}-v4_ccre_non_promoter"
+    blurb = _CURATED_CCRE_BLURBS[subset]
+
+    body = f"""---
+tags:
+- biology
+- genomics
+- DNA
+---
+
+# `{repo_name}`
+
+A **curated enhancer training set** for issue
+[#326](https://github.com/{github_repo}/issues/326) — a de-contaminated
+derivation of the v4 `ccre_non_promoter` arm of
+[`{hf_owner}/zoonomia-{pipeline_version}-v1`](https://huggingface.co/datasets/{hf_owner}/zoonomia-{pipeline_version}-v1),
+built by the
+[`{_GITHUB_PIPELINE_PATH}`]({pipeline_permalink}) pipeline at commit
+[`{commit_sha[:12]}`]({pipeline_permalink}).
+
+## Provenance
+
+This subset is {blurb}
+
+It is a strict subset of
+[`{parent_repo}`](https://huggingface.co/datasets/{parent_repo}); concatenating
+the curated subsets does **not** reconstruct v1 (they are experimental probes,
+not a partition). Contains **{n_samples:,} training samples** (human anchors ×
+up to 108 Zoonomia mammals × reverse-complement augmentation) — the exact row
+count across all JSONL.zst shards.
+
+## Schema
+
+Identical to
+[`{hf_owner}/zoonomia-{pipeline_version}-v1`](https://huggingface.co/datasets/{hf_owner}/zoonomia-{pipeline_version}-v1)
+— a single `train` split of JSONL.zst shards at
+`data/train/shard_NNNN.jsonl.zst`; key field `sequence` is exactly 255 bp,
+strand-aware. See the parent card for the full column table.
+
+## Source code
+
+- Pipeline: [{_GITHUB_PIPELINE_PATH}]({pipeline_main_link}) (latest)
+- Pinned to this dataset's build: [commit `{commit_sha[:12]}`]({pipeline_permalink})
+- Filter library: `marin_dna.pipelines.zoonomia_projection_dataset.region_labels`
+  (`select_ccre_noexon` / `select_ccre_noexon_enhancer`)
+- Parent partition: [`{parent_repo}`](https://huggingface.co/datasets/{parent_repo})
 """
     Path(output_path).write_text(body)
 

--- a/src/marin_dna/pipelines/zoonomia_projection_dataset/region_labels.py
+++ b/src/marin_dna/pipelines/zoonomia_projection_dataset/region_labels.py
@@ -606,20 +606,29 @@ def select_ccre_noexon_enhancer(
         & defined
     )
 
+    # Coverage matches windows ↔ region by chrom-key equality (``_coverage_bp``
+    # groups both by ``chrom``), so both sides must share the chrom dtype AND
+    # naming convention. Cast both to ``str`` (the labels parquet uses bare
+    # Ensembl names like ``"1"``); a silent dtype/convention mismatch would zero
+    # all coverage and trip the assert below with a misleading message.
     windows = (
         base.select(["chrom", "start", "end"])
         .to_pandas()
         .astype({"chrom": str})
         .reset_index(drop=True)
     )
-    enhancer_bp = _coverage_bp(windows, enhancer_set.to_pandas())
-    other_bp = _coverage_bp(windows, other_set.to_pandas())
+    enhancer_df = enhancer_set.to_pandas().astype({"chrom": str})
+    other_df = other_set.to_pandas().astype({"chrom": str})
+    enhancer_bp = _coverage_bp(windows, enhancer_df)
+    other_bp = _coverage_bp(windows, other_df)
     keep = (enhancer_bp > 0) & (enhancer_bp >= other_bp)
 
     out = base.filter(pl.Series(name="_keep_enhancer", values=keep))
     assert len(out) > 0, (
         "select_ccre_noexon_enhancer produced 0 windows — no enhancer-dominant "
-        "pure-cCRE windows (wrong cCRE parquet / cre_class vocabulary?)"
+        "pure-cCRE windows. Check the cCRE parquet's cre_class vocabulary and "
+        "that its chrom convention matches the labels parquet (bare Ensembl "
+        "names, e.g. '1' not 'chr1')."
     )
     return out
 

--- a/tests/pipelines/zoonomia_projection_dataset/test_region_labels.py
+++ b/tests/pipelines/zoonomia_projection_dataset/test_region_labels.py
@@ -1280,3 +1280,151 @@ def test_write_species_subset_hf_readme_rejects_unknown_cohort(tmp_path: Path) -
             n_samples=1,
             species_tsv="config/whatever.tsv",
         )
+
+
+# ============================================================================
+# Curated cCRE/enhancer sub-filters (issue #326)
+# ============================================================================
+
+from marin_dna.pipelines.zoonomia_projection_dataset.region_labels import (  # noqa: E402
+    select_ccre_noexon,
+    select_ccre_noexon_enhancer,
+    write_curated_ccre_hf_readme,
+)
+
+
+def _ccre_labels_frame() -> pl.DataFrame:
+    """Synthetic v4 region-labels frame (the disjoint-frac columns the selectors
+    read): six ``ccre_non_promoter`` windows — w1/w2 pure, w3 clips CDS, w4
+    clips a TSS band, w5 clips a 3'UTR, w6 clips an ncRNA exon — plus one
+    genuinely ``cds``-labelled row.
+    """
+    return pl.DataFrame(
+        {
+            "name": ["w1", "w2", "w3", "w4", "w5", "w6", "c1"],
+            "chrom": ["1"] * 7,
+            "start": [0, 300, 600, 900, 1200, 1500, 1800],
+            "end": [255, 555, 855, 1155, 1455, 1755, 2055],
+            "label": ["ccre_non_promoter"] * 6 + ["cds"],
+            "cds_frac": [0.0, 0.0, 0.4, 0.0, 0.0, 0.0, 1.0],
+            "utr3_frac": [0.0, 0.0, 0.0, 0.0, 0.3, 0.0, 0.0],
+            "ncrna_exon_frac": [0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0],
+            "tss_region_and_utr5_frac": [0.0, 0.0, 0.0, 0.6, 0.0, 0.0, 0.0],
+            "ccre_non_promoter_frac": [0.8, 0.7, 0.6, 0.4, 0.7, 0.5, 0.0],
+        }
+    )
+
+
+def test_select_ccre_noexon_keeps_only_pure_ccre() -> None:
+    # Only w1/w2 are ccre-labelled with all four higher-priority fracs == 0;
+    # w3 (CDS), w4 (TSS), w5 (3'UTR), w6 (ncRNA) all clip another element.
+    out = select_ccre_noexon(_ccre_labels_frame())
+    assert out["name"].to_list() == ["w1", "w2"]
+
+
+def test_select_ccre_noexon_missing_column_asserts() -> None:
+    with pytest.raises(AssertionError, match="missing columns"):
+        select_ccre_noexon(_ccre_labels_frame().drop("cds_frac"))
+
+
+def test_select_ccre_noexon_all_contaminated_asserts() -> None:
+    # Every ccre window clips CDS → zero survivors → loud failure (not a silent
+    # empty subset that would surface as a 0-row HF dataset later).
+    df = _ccre_labels_frame().with_columns(
+        pl.when(pl.col("label") == "ccre_non_promoter")
+        .then(pl.lit(0.2))
+        .otherwise(pl.col("cds_frac"))
+        .alias("cds_frac")
+    )
+    with pytest.raises(AssertionError, match="0 windows"):
+        select_ccre_noexon(df)
+
+
+def _pure_ccre_pair() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "name": ["w1", "w2"],
+            "chrom": ["1", "1"],
+            "start": [0, 1000],
+            "end": [255, 1255],
+            "label": ["ccre_non_promoter", "ccre_non_promoter"],
+            "cds_frac": [0.0, 0.0],
+            "utr3_frac": [0.0, 0.0],
+            "ncrna_exon_frac": [0.0, 0.0],
+            "tss_region_and_utr5_frac": [0.0, 0.0],
+            "ccre_non_promoter_frac": [0.8, 0.6],
+        }
+    )
+
+
+def test_select_ccre_noexon_enhancer_keeps_enhancer_dominant(tmp_path: Path) -> None:
+    # w1: dELS 200 bp, no other → enhancer-dominant, kept.
+    # w2: pELS 50 bp vs CA 155 bp → CA-dominant, dropped.
+    cre = pl.DataFrame(
+        {
+            "chrom": ["1", "1", "1"],
+            "start": [0, 1000, 1100],
+            "end": [200, 1050, 1255],
+            "cre_class": ["dELS", "pELS", "CA"],
+        }
+    )
+    cre_path = tmp_path / "cre.parquet"
+    cre.write_parquet(cre_path)
+    defined = GenomicSet(pl.DataFrame({"chrom": ["1"], "start": [0], "end": [5000]}))
+    out = select_ccre_noexon_enhancer(_pure_ccre_pair(), cre_path, defined)
+    assert out["name"].to_list() == ["w1"]
+
+
+def test_select_ccre_noexon_enhancer_no_enhancer_asserts(tmp_path: Path) -> None:
+    # Only CA cCREs overlap → no enhancer-dominant window → loud failure.
+    cre = pl.DataFrame(
+        {
+            "chrom": ["1", "1"],
+            "start": [0, 1000],
+            "end": [200, 1200],
+            "cre_class": ["CA", "CA"],
+        }
+    )
+    cre_path = tmp_path / "cre.parquet"
+    cre.write_parquet(cre_path)
+    defined = GenomicSet(pl.DataFrame({"chrom": ["1"], "start": [0], "end": [5000]}))
+    with pytest.raises(AssertionError, match="0 windows"):
+        select_ccre_noexon_enhancer(_pure_ccre_pair(), cre_path, defined)
+
+
+def test_write_curated_ccre_hf_readme_renders(tmp_path: Path) -> None:
+    out = tmp_path / "README.md"
+    write_curated_ccre_hf_readme(
+        "v4_ccre_noexon_enhancer",
+        out,
+        commit_sha="a" * 40,
+        hf_owner="bolinas-dna",
+        pipeline_version="v1",
+        n_samples=12_345_678,
+    )
+    body = out.read_text()
+    assert "# `bolinas-dna/zoonomia-v1-v4_ccre_noexon_enhancer`" in body
+    assert "#326" in body
+    assert "enhancer-dominant" in body
+    assert f"{12_345_678:,}" in body
+    assert (
+        "https://github.com/Open-Athena/marin-dna/tree/" + "a" * 40 + "/"
+        "snakemake/zoonomia_projection_dataset" in body
+    )
+    # Parent partition referenced; the subsets are not a partition of v1.
+    assert "zoonomia-v1-v4_ccre_non_promoter" in body
+    # Exactly the three canonical tags (biology / genomics / DNA).
+    front_matter, _, _ = body.partition("---\n\n")
+    assert front_matter.count("- ") == 3
+
+
+def test_write_curated_ccre_hf_readme_rejects_unknown(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unknown curated subset"):
+        write_curated_ccre_hf_readme(
+            "v4_cds",
+            tmp_path / "bad.md",
+            commit_sha="a" * 40,
+            hf_owner="bolinas-dna",
+            pipeline_version="v1",
+            n_samples=1,
+        )


### PR DESCRIPTION
🤖 Implements the dataset + training scaffolding for the **#326** curated-enhancer experiment — two de-contaminated derivations of the v4 `ccre_non_promoter` arm to test whether removing exon-overlap (#283 **H1**) and non-enhancer cCRE heterogeneity (#283 **H2**) unsticks distal (enhancer) VEP. No experiment is run here; this is the code to build the datasets + train the arms.

## What this adds

Two new `intervals_versions`, both sub-filters of `v4_ccre_non_promoter` (NOT part of the six-way v4 partition):

| dataset | filter | tests |
|---|---|---|
| `v4_ccre_noexon` | ccre windows with **zero** overlap of any other functional element (CDS / 3′UTR / ncRNA exon / TSS+5′UTR), via the disjoint v4 `*_frac` columns | H1 contamination |
| `v4_ccre_noexon_enhancer` | the above **+** enhancer-dominant (dELS+pELS bp ≥ other non-PLS cCRE bp), population-matched to `val_enhancer` | H1 + H2 |

Falsifiable predictions, read against exp232's existing heatmap (the arms are held byte-identical to exp232 except `TRAIN_DATASETS`): **(P1)** the curated arm's off-diagonal splicing/synonymous AUPRC collapses toward the 0.10 floor (the coding leak was CDS contamination); **(P2)** distal AUPRC lifts off ~0.127 and the `val_enhancer` LL-gap↔AUPRC correlation flips from −0.10 to positive.

## Changes

**Library** (testable home) — `src/marin_dna/pipelines/zoonomia_projection_dataset/region_labels.py`
- [`select_ccre_noexon`](https://github.com/Open-Athena/marin-dna/blob/73cd04a0d42ce419fc9fef3d01f809ddef0959ea/src/marin_dna/pipelines/zoonomia_projection_dataset/region_labels.py#L516) — arm A filter.
- [`select_ccre_noexon_enhancer`](https://github.com/Open-Athena/marin-dna/blob/73cd04a0d42ce419fc9fef3d01f809ddef0959ea/src/marin_dna/pipelines/zoonomia_projection_dataset/region_labels.py#L554) — arm B filter (joins the cCRE parquet for per-class membership; assumes `ccre_flank=0`, the v4 setting).
- [`write_curated_ccre_hf_readme`](https://github.com/Open-Athena/marin-dna/blob/73cd04a0d42ce419fc9fef3d01f809ddef0959ea/src/marin_dna/pipelines/zoonomia_projection_dataset/region_labels.py#L1176) — minimal provenance card.
- 6 new tests; the full `test_region_labels.py` suite is **40/40 green**.

**Pipeline** — `snakemake/zoonomia_projection_dataset`
- [`derive_subset_v4_ccre_noexon`](https://github.com/Open-Athena/marin-dna/blob/73cd04a0d42ce419fc9fef3d01f809ddef0959ea/snakemake/zoonomia_projection_dataset/workflow/rules/regions.smk#L348) / [`_enhancer`](https://github.com/Open-Athena/marin-dna/blob/73cd04a0d42ce419fc9fef3d01f809ddef0959ea/snakemake/zoonomia_projection_dataset/workflow/rules/regions.smk#L366) emit the `query_names` lists from the v4 region-labels parquet (+ cCRE / defined for B).
- [`dataset_hf_readme_curated_ccre`](https://github.com/Open-Athena/marin-dna/blob/73cd04a0d42ce419fc9fef3d01f809ddef0959ea/snakemake/zoonomia_projection_dataset/workflow/rules/dataset.smk#L269) + a `ruleorder` so the minimal card wins over the v4 partition card (which would fail looking these up in the six-label composition TSV).
- `config.yaml`: both registered in `intervals_versions`.
- [`sky/upload.yaml`](https://github.com/Open-Athena/marin-dna/blob/73cd04a0d42ce419fc9fef3d01f809ddef0959ea/snakemake/zoonomia_projection_dataset/sky/upload.yaml#L38): new `UPLOAD_MODE=curated_ccre` (targets only the two) + the 3 rules whitelisted in `ALLOWED_RULES`.

**Training** — [`experiments/exp326_curated_enhancers.py`](https://github.com/Open-Athena/marin-dna/blob/73cd04a0d42ce419fc9fef3d01f809ddef0959ea/experiments/exp326_curated_enhancers.py): clone of `exp232_per_region.py` with only `TRAIN_DATASETS` swapped (geometry, optimizer, 5K×8192, val recipes incl. `val_enhancer`, mendelian eval, `v5p-8` all verbatim). `SWEEP_DATASETS` selects the arm.

**Docs** — pipeline README documents both datasets + the curation filters + the `curated_ccre` upload mode.

## Validation

<details><summary>query_names dry-run plans exactly the two new rules (no projection cascade); upload chain wires both datasets through the curated card (not the v4 card)</summary>

```
$ snakemake -n -- results/projection/min0.20/subsets_def/v4_ccre_noexon{,_enhancer}.query_names.txt
job                                      count
derive_subset_v4_ccre_noexon                 1
derive_subset_v4_ccre_noexon_enhancer        1
total                                        2

# full upload chain (…/upload.done/zoonomia-v1-v4_ccre_noexon{,_enhancer}):
subset_dataset_derived 2 · dataset_hf_readme_curated_ccre 2 · prepare_training_shards 2 ·
compress_shard 128 · hf_upload_dataset 2   (+ the known local()-FASTA projection
cascade, collapsed at build time by sky/upload.yaml's --allowed-rules)
```
</details>

- ruff + ruff-format clean on all changed files. (pre-commit `mypy` reports 18 **pre-existing** errors in `evals/leaderboard.py` + `evals/sge.py` — files untouched here; CI skips mypy.)

## Out of scope / next steps (run separately)

- **Build + upload** the two HF datasets: `sky launch … sky/upload.yaml --env UPLOAD_MODE=curated_ccre --env COMMIT_SHA=$(git rev-parse HEAD)`.
- **Train** the two arms via iris (one `SWEEP_DATASETS` per job), then read the distal column + P1/P2 vs exp232.

#326 stays open after this merges — it tracks the experiment's *result*, which lands once the arms run. Refs #283 (the H1/H2 diagnosis), #232 (the per-region run this is held identical to).
