### PR TITLE
evals_v2: per-subset nested-LOOC linear-probe training rule (#320)

### DIFF
--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -264,6 +264,65 @@ snakemake results/calibration/<model>/llr_neutral_mean_n100.parquet  # one model
   the per-cell `results/ll_gap/scores/{model}/{region}.parquet` targets, then
   gather with `snakemake ll_gap`.
 
+### Linear probe (frozen-embedding VEP, #320)
+
+`snakemake probe` trains a **frozen-embedding linear probe** per `(model,
+dataset)` — the productionized form of #314's settled protocol — also kept **off
+`rule all`**. It consumes the in-bundle pooled embeddings (`emb_ref`/`emb_alt`, the
+#318 columns), so the cell's scores parquet **must** have been produced with
+`inference.return_embeddings: true` (the rule fails fast otherwise). CPU-only — no
+GPU; the probe logic lives in
+`marin_dna.pipelines.evals.variant_probe.run_subset_probes`.
+
+The protocol is **one** approach, no sweeps:
+
+- **Feature** — `emb_ref`/`emb_alt` upcast f16→**f32** (a cancellation guard, #318),
+  then one per-dataset pair-feature: `concat_ref_delta = [ref, alt−ref]` for
+  directional datasets (`score_protocol: minus_llr`), `sum_absdiff = [ref+alt,
+  |alt−ref|]` for swap-invariant ones (`abs_llr`). Override per dataset with an
+  optional `probe_feature:`.
+- **Per consequence `subset`** (or one synthetic `all` group when the dataset has no
+  `subset`, e.g. caqtl/dsqtl), trained only if it clears `min_variants` **and**
+  `min_chroms`; smaller subsets get `NaN` `probe_score` and no classifier.
+- **Probe** — `StandardScaler → LogisticRegression(L2)`; the only tuned knob is the
+  L2 strength `C`.
+- **CV** — leave-one-chromosome-out predictions with an inner `GroupKFold`
+  `GridSearchCV` re-tuning `C` per fold (leakage-free, the TraitGym protocol); the
+  reusable classifier is the same pipeline fit on all the subset's variants.
+- **C-edge diagnostic (verified)** — `c_grid = logspace(-12, 4, 17)` is anchored at
+  both regularization limits: the high end (`1e4`) is a saturation cap whose ranking
+  equals the unregularized `C→∞` limit (no `inf` needed), and the low end (`1e-12`)
+  is a heavy-reg floor (as `C→0` the L2 fit shrinks to the scale-free mean-difference
+  direction — *not* a constant predictor, since AUPRC is rank-based). For each subset
+  the joblib `c_summary` records the pin counts **and verifies** them: from the
+  all-data inner-CV curve, `high_edge_gain` / `low_edge_gain` measure whether a
+  pinned edge is still improving vs its interior neighbor, and `truncation_risk`
+  fires only if it is (which the anchored grid avoids). So an edge pin is confirmed
+  *saturated/flat (benign)* rather than assumed.
+
+Two artifacts per cell:
+
+```
+results/probe/{model}/{dataset}.parquet   # variant cols (minus emb_ref/emb_alt) + probe_score (NaN for skipped subsets)
+results/probe/{model}/{dataset}.joblib    # {subset: {pipeline, C, feature, n, n_pos, c_summary}}
+```
+
+The predictions parquet (the LOOC `probe_score` per variant) is consumed by the
+**downstream metrics step** (a separate issue); the joblib classifiers are
+serialized for **reuse on other datasets**. Configured under `probe:` in
+`config.yaml` (`min_variants`, `min_chroms`, `c_grid` = `logspace(lo, hi, num)`,
+`inner_splits`, `n_jobs`, and `models: [{name, datasets}]` — datasets listed
+explicitly since embeddings are per-cell). Build:
+
+```bash
+snakemake probe                                          # all configured probe cells
+snakemake results/probe/<model>/<dataset>.parquet        # one cell
+
+# A cell whose scores parquet predates the embeddings must be re-scored first:
+snakemake --configfile ../../../scripts/issue318_embed_overlay.yaml --forcerun \
+  compute_scores -- results/scores/<model>/<dataset>.parquet
+```
+
 ### Parallel sky-cluster sweep (one cluster per target)
 
 For a grid of independent targets — e.g. all checkpoints of one model arm,

--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -315,8 +315,12 @@ serialized for **reuse on other datasets**. Configured under `probe:` in
 explicitly since embeddings are per-cell). Build:
 
 ```bash
-snakemake probe                                          # all configured probe cells
-snakemake results/probe/<model>/<dataset>.parquet        # one cell
+# `--rerun-triggers mtime` is required: the scores parquet was built with the #318
+# overlay (return_embeddings: true) but the committed default is false, so the default
+# `params` trigger would otherwise rebuild it — dropping the embeddings the rule needs
+# (and a rebuild needs a GPU the probe node doesn't have).
+snakemake probe --rerun-triggers mtime                              # all configured probe cells
+snakemake results/probe/<model>/<dataset>.parquet --rerun-triggers mtime   # one cell
 
 # A cell whose scores parquet predates the embeddings must be re-scored first:
 snakemake --configfile ../../../scripts/issue318_embed_overlay.yaml --forcerun \

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -1183,6 +1183,45 @@ inference:
 
 
 # ---------------------------------------------------------------------------
+# Frozen-embedding linear-probe VEP training (issue #320). Off `rule all`; build
+# with `snakemake probe` (or a single results/probe/<model>/<dataset>.parquet
+# target). Trains a per-consequence-subset, leave-one-chromosome-out (LOOC)
+# L2-logistic probe on the in-bundle pooled embeddings (emb_ref/emb_alt, #318) and
+# writes the per-variant LOOC predictions (`probe_score`) + the fitted per-subset
+# classifiers (joblib, for reuse on other datasets). The downstream metrics step
+# consumes the predictions parquet. REQUIRES each scored cell to have been produced
+# with `inference.return_embeddings: true`; the rule fails fast otherwise. See
+# rules/probe.smk.
+# ---------------------------------------------------------------------------
+probe:
+  min_variants: 300       # train a subset's probe only if it has >= this many
+                          # variants (1:9-matched ⇒ ~10% positives, so 300 ⇒ ~30
+                          # positives — enough for stable per-fold C selection).
+                          # Smaller subsets get NaN probe_score + no classifier.
+  min_chroms: 3           # and >= this many distinct chromosomes (nested LOOC needs
+                          # ≥3 groups: outer leave-one-chrom-out + inner CV).
+  c_grid: [-12, 4, 17]    # np.logspace(lo, hi, num) L2-strength grid, anchored at
+                          # both regularization regimes: low 1e-12 = practical
+                          # constant-predictor floor (below the ~1/p optimum for any
+                          # realistic model); high 1e4 = saturation cap whose ranking
+                          # matches the unregularized C→∞ limit (so no np.inf needed).
+                          # Edge-pinned C is recorded per subset as a diagnostic (low
+                          # = ~no signal, high = minimal reg), not a truncation.
+  inner_splits: 5         # inner GroupKFold splits for the per-fold C GridSearchCV.
+  n_jobs: 4               # GridSearchCV parallelism. Execution-only (not output-
+                          # affecting) → read via the rule's `threads`, so tuning it
+                          # never forces a re-run. The shared dev box is 4-vCPU; bump
+                          # on a roomier CPU instance.
+  models:
+    # Explicit per-model `datasets` (not derived): probing a cell needs its scores
+    # parquet to carry emb_ref/emb_alt, which is per-cell. Seeded with the #314
+    # headline generalist whose mendelian cell already has embeddings on S3; add
+    # entries here as more cells are re-scored with inference.return_embeddings.
+    - name: mix-v0.9-p1B-i24-exp135-m5.1-step-59158
+      datasets: [mendelian_traits]
+
+
+# ---------------------------------------------------------------------------
 # cLLR mutation-rate calibration tables (stage 3, #267/#270). Off `rule all`;
 # build with `snakemake calibration` (or a single
 # results/calibration/<model>/llr_neutral_mean_n{n}.parquet target). Scores the

--- a/snakemake/analysis/evals_v2/sky/probe.yaml
+++ b/snakemake/analysis/evals_v2/sky/probe.yaml
@@ -1,0 +1,64 @@
+# SkyPilot task: run the evals_v2 linear-probe rule (#320) on a CPU node.
+#
+# Unlike `run.yaml` (GPU inference: compute_scores), the probe is CPU-only —
+# it reads the in-bundle embeddings from the existing scores parquet on S3,
+# fits sklearn probes, and writes probe artifacts back to S3. No GPU, no GCS
+# checkpoint pull (so no gcloud / ADC mount). AWS creds for S3 come from the
+# instance role.
+#
+# Launch one (model, dataset) probe cell:
+#   sky launch snakemake/analysis/evals_v2/sky/probe.yaml -c evals-v2-probe \
+#     --env SNAKEMAKE_ARGS="--rerun-triggers mtime --set-threads compute_probe=8 \
+#       -- results/probe/<model>/<dataset>.parquet" -i 10 --down -y
+#
+# The input scores parquet must already carry emb_ref/emb_alt (scored with
+# inference.return_embeddings: true); the rule fails fast otherwise.
+
+name: evals-v2-probe
+
+resources:
+    infra: aws/us-east-2
+    cpus: 8+
+    memory: 16+
+    disk_size: 100
+    labels:
+        project: dna
+    # Prefer spot (≈70% cheaper) with an on-demand fallback. The probe is short
+    # and resumable (snakemake re-runs the cell), so a spot preemption is cheap.
+    any_of:
+      - use_spot: true
+      - use_spot: false
+
+workdir: .
+
+envs:
+    SNAKEMAKE_ARGS: ""           # e.g. "-- results/probe/<model>/<dataset>.parquet"
+
+setup: |
+    set -euxo pipefail
+
+    if ! command -v uv >/dev/null 2>&1; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    fi
+    export PATH="$HOME/.local/bin:$PATH"
+
+    # `--group genome-s3` matches run.yaml (s3fs + the snakemake S3 storage
+    # deps). The probe reads its scores parquet via the snakemake S3 storage
+    # plugin (boto3, staged to a local path), so it never inits s3fs itself.
+    uv sync --frozen --group genome-s3
+
+run: |
+    set -euxo pipefail
+
+    export PATH="$HOME/.local/bin:$PATH"
+    # common.smk imports the inference module (torch) at load; no training here.
+    export WANDB_DISABLED=true
+
+    cd snakemake/analysis/evals_v2
+
+    # $SNAKEMAKE_ARGS goes last so its trailing `-- <target>` stays positional.
+    uv run --project ../../.. --group genome-s3 snakemake \
+        --profile workflow/profiles/default \
+        --printshellcmds \
+        --rerun-incomplete \
+        $SNAKEMAKE_ARGS

--- a/snakemake/analysis/evals_v2/workflow/Snakefile
+++ b/snakemake/analysis/evals_v2/workflow/Snakefile
@@ -13,6 +13,7 @@ include: "rules/interpretation.smk"
 include: "rules/embedding_umap.smk"
 include: "rules/calibration.smk"
 include: "rules/ll_gap.smk"
+include: "rules/probe.smk"
 
 
 rule all:

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import joblib
 import numpy as np
 import pandas as pd
 from datasets import load_dataset
@@ -19,6 +20,7 @@ from marin_dna.pipelines.evals.metrics import (
     compute_qtl_metrics,
     compute_sge_metrics,
 )
+from marin_dna.pipelines.evals.variant_probe import PAIR_COMBOS, run_subset_probes
 
 # Per-dataset eval protocol. `matched_pair` (default) → per-subset AUPRC +
 # cluster bootstrap over `match_group` (mendelian/complex). `qtl_global` →
@@ -221,4 +223,50 @@ for _m in LL_GAP_MODELS:
 for _d in LL_GAP_CFG.get("datasets", []):
     assert "hf_repo" in _d and "hf_revision" in _d, (
         f"ll_gap dataset {_d.get('name')!r} needs `hf_repo` + `hf_revision`"
+    )
+
+
+# --- Linear probe (frozen-embedding VEP, issue #320) ------------------------
+# Optional `probe:` config section; targets kept OFF `rule all` (see
+# rules/probe.smk). Reuses the `models:` registry. Each probe entry is
+# `{name, datasets: [...]}` — datasets are listed explicitly (not derived) because
+# probing a cell requires its scores parquet to carry emb_ref/emb_alt
+# (inference.return_embeddings), which is per-cell, not per-model.
+PROBE_CFG = config.get("probe", {})
+PROBE_MODELS = PROBE_CFG.get("models", [])
+
+# Probe pair-feature per dataset: directional datasets (minus_llr) take the signed
+# `concat_ref_delta = [ref, alt−ref]`; swap-invariant ones (abs_llr) take the
+# symmetric `sum_absdiff = [ref+alt, |alt−ref|]` (issue #314 feature rule).
+PROBE_FEATURE_BY_PROTOCOL = {
+    "minus_llr": "concat_ref_delta",
+    "abs_llr": "sum_absdiff",
+}
+
+
+def get_probe_feature(name):
+    """Probe pair-feature combo for a dataset, from its `score_protocol`; an
+    explicit `probe_feature` on the dataset entry overrides."""
+    cfg = get_dataset_config(name)
+    if "probe_feature" in cfg:
+        return cfg["probe_feature"]
+    return PROBE_FEATURE_BY_PROTOCOL[cfg["score_protocol"]]
+
+
+# Fail fast: every probe entry names a known checkpoint and lists datasets that
+# model is actually evaluated on; any explicit `probe_feature` override is a known
+# combo. A typo would otherwise surface late inside the rule.
+for _pm in PROBE_MODELS:
+    assert _pm["name"] in MODELS, f"probe model {_pm['name']!r} not found in `models`"
+    _model_datasets = get_model_datasets(_pm["name"])
+    for _d in _pm["datasets"]:
+        assert _d in _model_datasets, (
+            f"probe model {_pm['name']!r} dataset {_d!r} not in its evaluated "
+            f"datasets {_model_datasets}"
+        )
+for _d in config["datasets"]:
+    _pf = _d.get("probe_feature")
+    assert _pf is None or _pf in PAIR_COMBOS, (
+        f"dataset {_d['name']!r} `probe_feature` must be one of {PAIR_COMBOS}, "
+        f"got {_pf!r}"
     )

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -243,6 +243,16 @@ PROBE_FEATURE_BY_PROTOCOL = {
     "abs_llr": "sum_absdiff",
 }
 
+# Fail fast: the feature map must cover every score protocol a dataset can declare
+# (config load already asserts each dataset's score_protocol ∈ SCORE_PROTOCOLS), so
+# get_probe_feature never raises a bare KeyError late at rule-eval — mirroring the
+# guard the metrics path already has on its own SCORE_PROTOCOLS lookup.
+_unmapped_protocols = sorted(set(SCORE_PROTOCOLS) - set(PROBE_FEATURE_BY_PROTOCOL))
+assert not _unmapped_protocols, (
+    f"PROBE_FEATURE_BY_PROTOCOL is missing entries for score protocols "
+    f"{_unmapped_protocols}; add them or get_probe_feature will KeyError"
+)
+
 
 def get_probe_feature(name):
     """Probe pair-feature combo for a dataset, from its `score_protocol`; an
@@ -257,6 +267,10 @@ def get_probe_feature(name):
 # model is actually evaluated on; any explicit `probe_feature` override is a known
 # combo. A typo would otherwise surface late inside the rule.
 for _pm in PROBE_MODELS:
+    assert isinstance(_pm, dict) and {"name", "datasets"} <= _pm.keys(), (
+        f"probe `models` entry must be a mapping with `name` + `datasets` keys "
+        f"(unlike the bare-string `models:` of calibration/umap), got {_pm!r}"
+    )
     assert _pm["name"] in MODELS, f"probe model {_pm['name']!r} not found in `models`"
     _model_datasets = get_model_datasets(_pm["name"])
     for _d in _pm["datasets"]:

--- a/snakemake/analysis/evals_v2/workflow/rules/probe.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/probe.smk
@@ -12,10 +12,15 @@ CPU-only (sklearn on cached embeddings — no GPU). Requires the input scores pa
 carry `emb_ref`/`emb_alt`, i.e. it must have been produced with
 `inference.return_embeddings: true` (the #318 overlay); the rule fails fast otherwise.
 
-Kept OFF `rule all` (a few-models analysis, like `calibration` / `umap`); build by name:
+Kept OFF `rule all` (a few-models analysis, like `calibration` / `umap`). Pass
+`--rerun-triggers mtime` on every invocation: the input scores parquet was built with
+the #318 overlay (`return_embeddings: true`), which differs from the committed default
+(`false`), so snakemake's default `params` trigger would otherwise try to rebuild it —
+and a rebuild on this CPU node (no GPU/gcloud) would drop the very `emb_ref`/`emb_alt`
+the rule asserts on. Build by name:
 
-    snakemake probe                                   # every configured probe cell
-    snakemake results/probe/<model>/<dataset>.parquet
+    snakemake probe --rerun-triggers mtime                              # every configured probe cell
+    snakemake results/probe/<model>/<dataset>.parquet --rerun-triggers mtime
 """
 
 

--- a/snakemake/analysis/evals_v2/workflow/rules/probe.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/probe.smk
@@ -1,0 +1,79 @@
+"""Frozen-embedding linear-probe training (issue #320).
+
+Per (model, dataset): train a per-subset, leave-one-chromosome-out (LOOC) L2-logistic
+probe on the in-bundle pooled embeddings (`emb_ref`/`emb_alt`, #318) and emit two
+artifacts — the **LOOC predictions** for every variant (`probe_score`, consumed by the
+downstream metrics step) and the **fitted per-subset classifiers** (serialized for
+reuse on other datasets). The protocol (feature rule, nested-C tuning, C-edge guard)
+lives in `marin_dna.pipelines.evals.variant_probe.run_subset_probes`; this rule is thin
+glue.
+
+CPU-only (sklearn on cached embeddings — no GPU). Requires the input scores parquet to
+carry `emb_ref`/`emb_alt`, i.e. it must have been produced with
+`inference.return_embeddings: true` (the #318 overlay); the rule fails fast otherwise.
+
+Kept OFF `rule all` (a few-models analysis, like `calibration` / `umap`); build by name:
+
+    snakemake probe                                   # every configured probe cell
+    snakemake results/probe/<model>/<dataset>.parquet
+"""
+
+
+rule compute_probe:
+    input:
+        "results/scores/{model}/{dataset}.parquet",
+    output:
+        predictions="results/probe/{model}/{dataset}.parquet",
+        classifiers="results/probe/{model}/{dataset}.joblib",
+    wildcard_constraints:
+        model="|".join(MODELS),
+        dataset="|".join(DATASETS),
+    params:
+        # Output-affecting → tracked by snakemake's `params` rerun trigger. The
+        # feature combo is dataset-derived (directional vs swap-invariant); the rest
+        # are the probe hyperparameters. `n_jobs` is execution-only (GridSearchCV
+        # parallelism) so it's read via `threads`, not declared here.
+        feature=lambda wc: get_probe_feature(wc.dataset),
+        min_variants=config["probe"]["min_variants"],
+        min_chroms=config["probe"]["min_chroms"],
+        c_grid=config["probe"]["c_grid"],
+        inner_splits=config["probe"]["inner_splits"],
+    threads: config["probe"]["n_jobs"]
+    run:
+        lo, hi, num = params.c_grid
+        c_grid = np.logspace(lo, hi, num)
+
+        df = pd.read_parquet(input[0])
+        assert "emb_ref" in df.columns and "emb_alt" in df.columns, (
+            f"{input[0]} lacks emb_ref/emb_alt — re-score {wildcards.model}/"
+            f"{wildcards.dataset} with inference.return_embeddings=true (#318 overlay)"
+        )
+
+        predictions, classifiers = run_subset_probes(
+            df,
+            feature_combo=params.feature,
+            c_grid=c_grid,
+            min_variants=params.min_variants,
+            min_chroms=params.min_chroms,
+            inner_splits=params.inner_splits,
+            n_jobs=threads,
+        )
+        predictions.to_parquet(output.predictions, index=False)
+        joblib.dump(classifiers, output.classifiers)
+        n_scored = int(predictions["probe_score"].notna().sum())
+        print(
+            f"[evals_v2] probe {wildcards.model} {wildcards.dataset} "
+            f"({params.feature}): {len(classifiers)} subset probes, "
+            f"n={len(predictions)} ({n_scored} scored)"
+        )
+
+
+rule probe:
+    """Aggregate convenience target: probe artifacts for every configured probe cell
+    (model × its listed datasets). Not part of `rule all`."""
+    input:
+        [
+            f"results/probe/{pm['name']}/{dataset}.parquet"
+            for pm in PROBE_MODELS
+            for dataset in pm["datasets"]
+        ],

--- a/src/marin_dna/pipelines/evals/variant_probe.py
+++ b/src/marin_dna/pipelines/evals/variant_probe.py
@@ -114,6 +114,9 @@ def pair_feature_from_bundle(df: pd.DataFrame, combo: str) -> np.ndarray:
         "scores parquet lacks emb_ref/emb_alt columns — re-score with "
         "inference.return_embeddings=true (the #318 overlay)"
     )
+    # Guard the empty frame: np.stack([]) raises an opaque "need at least one array
+    # to stack" before the shape assert below could give a domain message.
+    assert len(df) > 0, "empty frame — no variants to build a probe feature from"
     # f16 store -> f32 BEFORE the difference (cancellation guard).
     ref = np.stack(df["emb_ref"].to_numpy()).astype(np.float32)
     alt = np.stack(df["emb_alt"].to_numpy()).astype(np.float32)
@@ -125,15 +128,34 @@ def pair_feature_from_bundle(df: pd.DataFrame, combo: str) -> np.ndarray:
 def _probe_pipeline() -> Pipeline:
     """The locked probe: ``StandardScaler → L2 LogisticRegression``.
 
-    ``l1_ratio=0.0`` is the sklearn 1.8 idiom for a pure-L2 penalty (the bare
-    ``penalty='l2'`` argument is deprecated there). ``C`` is set per grid point by
-    the caller's ``GridSearchCV``.
+    sklearn 1.8 defaults ``LogisticRegression`` to L2 (the ``penalty`` arg is
+    mid-deprecation — passing ``penalty='l2'`` warns). ``l1_ratio`` only takes effect
+    under elasticnet, so ``l1_ratio=0.0`` is a no-op here; it's passed to pin the
+    intent to pure-L2 (and to guard against a future default drifting toward
+    elasticnet). ``C`` is set per grid point by the caller's ``GridSearchCV``.
     """
     return Pipeline(
         [
             ("scaler", StandardScaler()),
             ("clf", LogisticRegression(l1_ratio=0.0, max_iter=_MAX_ITER)),
         ]
+    )
+
+
+def _inner_c_search(c_grid: np.ndarray, k: int, n_jobs: int) -> GridSearchCV:
+    """The inner C-tuning search shared by the OOF folds and the all-data fit.
+
+    Kept in one place so the leak-free OOF folds (``traitgym_nested_oof``) and the
+    reusable all-data classifier (``fit_full_classifier``) tune ``C`` *identically* —
+    same pipeline, same ``GroupKFold`` AUPRC inner CV. Diverging the two would break
+    the leakage-equivalence the protocol relies on.
+    """
+    return GridSearchCV(
+        _probe_pipeline(),
+        {"clf__C": c_grid},
+        cv=GroupKFold(n_splits=k),
+        scoring="average_precision",
+        n_jobs=n_jobs,
     )
 
 
@@ -170,13 +192,7 @@ def traitgym_nested_oof(
     selected: list[float] = []
     for tr, te in LeaveOneGroupOut().split(X, y, g):
         k = min(inner_splits, len(np.unique(g[tr])))
-        gs = GridSearchCV(
-            _probe_pipeline(),
-            {"clf__C": c_grid},
-            cv=GroupKFold(n_splits=k),
-            scoring="average_precision",
-            n_jobs=n_jobs,
-        )
+        gs = _inner_c_search(c_grid, k, n_jobs)
         gs.fit(X[tr], y[tr], groups=g[tr])
         oof[te] = gs.predict_proba(X[te])[:, 1]
         selected.append(float(gs.best_params_["clf__C"]))
@@ -212,13 +228,7 @@ def fit_full_classifier(
     assert X.ndim == 2 and X.shape[0] == n == len(g), (X.shape, n, len(g))
     k = min(inner_splits, len(np.unique(g)))
     assert k >= 2, f"need >=2 groups for inner C-search, got {len(np.unique(g))}"
-    gs = GridSearchCV(
-        _probe_pipeline(),
-        {"clf__C": c_grid},
-        cv=GroupKFold(n_splits=k),
-        scoring="average_precision",
-        n_jobs=n_jobs,
-    )
+    gs = _inner_c_search(c_grid, k, n_jobs)
     gs.fit(X, y, groups=g)
     # Inner-CV mean AUPRC per grid C, ordered ascending in C so c_scores[0] is the
     # heavy-reg floor and c_scores[-1] the weak-reg cap (the edge-saturation check).
@@ -258,6 +268,7 @@ def summarize_selected_c(
     sel = np.asarray(selected_cs, dtype=float)
     grid = np.sort(np.asarray(c_grid, dtype=float))
     assert sel.ndim == 1 and sel.size >= 1, sel.shape
+    assert grid.size >= 2, f"c_grid needs >=2 points for edge logic, got {grid.size}"
     lo, hi = float(grid[0]), float(grid[-1])
     n_low = int(np.sum(sel == lo))
     n_high = int(np.sum(sel == hi))
@@ -284,9 +295,13 @@ def summarize_selected_c(
         low_pinned = n_low > 0 or full_c == lo
         out["high_edge_gain"] = high_gain
         out["low_edge_gain"] = low_gain
-        out["truncation_risk"] = bool(
-            (high_pinned and high_gain > tol) or (low_pinned and low_gain > tol)
-        )
+        # A pinned edge is risky if it's still improving past tol — OR if its gain is
+        # NaN (a failed/single-class inner-CV fold left mean_test_score NaN): we then
+        # could NOT verify saturation, so we must not silently report "benign"
+        # (`nan > tol` is False, which would). Flag it instead.
+        high_risky = high_pinned and (np.isnan(high_gain) or high_gain > tol)
+        low_risky = low_pinned and (np.isnan(low_gain) or low_gain > tol)
+        out["truncation_risk"] = bool(high_risky or low_risky)
     return out
 
 

--- a/src/marin_dna/pipelines/evals/variant_probe.py
+++ b/src/marin_dna/pipelines/evals/variant_probe.py
@@ -1,0 +1,414 @@
+"""Frozen-embedding linear probe for variant effect prediction (issues #314/#320).
+
+Trains a leak-proof linear probe on the **in-bundle pooled embeddings** (the
+``emb_ref``/``emb_alt`` columns the #318 score bundle writes per variant) and
+emits, per consequence ``subset``:
+
+- the **leave-one-chromosome-out (LOOC) predictions** for every variant
+  (``run_subset_probes`` → ``probe_score``), consumed by the downstream metrics
+  step; and
+- the **fitted classifier** (all-data fit), serialized so it can be reused on
+  other datasets.
+
+This is the productionized form of #314's settled protocol — **one** approach,
+no sweeps:
+
+- **Feature.** ``pair_feature_from_bundle`` upcasts the f16 allele means to
+  float32 (a cancellation guard, see #318) and combines them: ``concat_ref_delta
+  = [ref, alt−ref]`` for directional datasets (mendelian, sge) or ``sum_absdiff =
+  [ref+alt, |alt−ref|]`` for swap-invariant ones (complex, caqtl, dsqtl).
+- **Probe.** A fixed ``StandardScaler → LogisticRegression(L2)`` pipeline; the
+  only tuned knob is the L2 strength ``C``.
+- **CV.** ``traitgym_nested_oof`` — outer leave-one-chromosome-out, inner
+  ``GroupKFold`` ``GridSearchCV`` re-tuning ``C`` per fold (leakage-free, the
+  TraitGym protocol). ``fit_full_classifier`` fits the reusable all-data probe
+  with the same inner C-search.
+- **C-edge diagnostic (verified).** ``summarize_selected_c`` records when the chosen
+  ``C`` lands on a grid boundary and, given the all-data inner-CV curve, *verifies*
+  the pin is saturated/flat (the interior neighbor gives the same AUPRC) rather than
+  a truncation. High edge ⟹ the unregularized limit (the fit saturates; ``1e4`` ≈
+  ``C→∞`` in ranking); low edge ⟹ the maximally-shrunk mean-difference direction (a
+  *flat* region, not a constant predictor — AUPRC is rank-based, so even ‖w‖→0 keeps
+  a ranking). ``truncation_risk`` fires only if a pinned edge is still improving,
+  which the anchored grid avoids.
+
+``ref``/``alt`` always denote the reference- and alternate-allele embeddings.
+``concat_ref_delta``/``sum_absdiff`` are the production combos; ``delta``/
+``abs_delta`` are the documented bare-effect fallbacks.
+"""
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import GridSearchCV, GroupKFold, LeaveOneGroupOut
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+# ref↔alt combinations of the pooled allele embeddings. The symmetric ones are
+# invariant under swapping which allele is "ref" — the only valid features for
+# datasets with no biological ref/alt direction (complex_traits, caqtl, dsqtl).
+PAIR_COMBOS: tuple[str, ...] = (
+    "delta",
+    "concat",
+    "concat_ref_delta",
+    "abs_delta",
+    "prod",
+    "sum_absdiff",
+)
+SYMMETRIC_COMBOS: frozenset[str] = frozenset({"abs_delta", "prod", "sum_absdiff"})
+
+# The fixed L2-strength grid, anchored at both regularization regimes so it can't
+# truncate the optimum (no widening, no np.inf):
+#   low  1e-12 — a practical heavy-reg floor. As C→0 the L2 fit shrinks to the
+#                scale-free mean-difference direction (NOT a constant predictor —
+#                AUPRC is rank-based, so the ranking persists), and the AUPRC-vs-C
+#                curve goes flat well above 1e-12 for any realistic model; a low-edge
+#                pin = the flat maximally-regularized solution (verified, not assumed).
+#   high 1e4   — a saturation cap. Past ~1e2 the logistic fit stops changing, and
+#                1e4 reproduces the unregularized (C→∞) *ranking* exactly (all AUPRC
+#                sees) for separable and non-separable cells alike — so no np.inf is
+#                needed; a high-edge pin means "wants minimal reg (saturated)".
+# Both edge-pins are recorded per subset by ``summarize_selected_c`` as diagnostics.
+DEFAULT_C_GRID: np.ndarray = np.logspace(-12, 4, 17)
+_MAX_ITER: int = 2000
+
+
+def pair_feature(ref: np.ndarray, alt: np.ndarray, combo: str) -> np.ndarray:
+    """Combine pooled ref/alt embeddings ``[N, D]`` into a per-variant feature.
+
+    ``delta``/``concat``/``concat_ref_delta`` are signed (ref↔alt direction
+    matters); ``abs_delta``/``prod``/``sum_absdiff`` are invariant under a ref↔alt
+    swap (see ``SYMMETRIC_COMBOS``). Returns ``[N, D]`` for
+    ``delta``/``abs_delta``/``prod`` and ``[N, 2D]`` for
+    ``concat``/``sum_absdiff``/``concat_ref_delta``.
+    """
+    assert ref.shape == alt.shape and ref.ndim == 2, (ref.shape, alt.shape)
+    if combo == "delta":
+        return alt - ref
+    if combo == "concat":
+        return np.concatenate([ref, alt], axis=1)
+    if combo == "concat_ref_delta":
+        # signed effect (alt−ref) + local context (ref). Spans the same space as
+        # `concat` but differs under L2 — the directional analog of `sum_absdiff`.
+        return np.concatenate([ref, alt - ref], axis=1)
+    if combo == "abs_delta":
+        return np.abs(alt - ref)
+    if combo == "prod":
+        return ref * alt
+    if combo == "sum_absdiff":
+        return np.concatenate([ref + alt, np.abs(alt - ref)], axis=1)
+    raise ValueError(f"unknown combo {combo!r}; expected one of {PAIR_COMBOS}")
+
+
+def pair_feature_from_bundle(df: pd.DataFrame, combo: str) -> np.ndarray:
+    """Build the per-variant pair-feature from the in-bundle pooled embeddings.
+
+    Reads the ``emb_ref``/``emb_alt`` list-columns (length-``D`` float16 vectors
+    written by the #318 score bundle) and **upcasts to float32 before
+    combining**: the ``delta``/``abs_delta`` subtraction of two near-equal allele
+    means is a catastrophic-cancellation risk in f16 (see #318), so the upcast
+    must precede ``pair_feature``, not follow it. Returns ``[N, D]`` or ``[N, 2D]``
+    per ``combo``.
+    """
+    assert "emb_ref" in df.columns and "emb_alt" in df.columns, (
+        "scores parquet lacks emb_ref/emb_alt columns — re-score with "
+        "inference.return_embeddings=true (the #318 overlay)"
+    )
+    # f16 store -> f32 BEFORE the difference (cancellation guard).
+    ref = np.stack(df["emb_ref"].to_numpy()).astype(np.float32)
+    alt = np.stack(df["emb_alt"].to_numpy()).astype(np.float32)
+    assert ref.shape == alt.shape and ref.ndim == 2, (ref.shape, alt.shape)
+    assert np.isfinite(ref).all() and np.isfinite(alt).all(), "non-finite embeddings"
+    return pair_feature(ref, alt, combo)
+
+
+def _probe_pipeline() -> Pipeline:
+    """The locked probe: ``StandardScaler → L2 LogisticRegression``.
+
+    ``l1_ratio=0.0`` is the sklearn 1.8 idiom for a pure-L2 penalty (the bare
+    ``penalty='l2'`` argument is deprecated there). ``C`` is set per grid point by
+    the caller's ``GridSearchCV``.
+    """
+    return Pipeline(
+        [
+            ("scaler", StandardScaler()),
+            ("clf", LogisticRegression(l1_ratio=0.0, max_iter=_MAX_ITER)),
+        ]
+    )
+
+
+def traitgym_nested_oof(
+    features: np.ndarray,
+    label: np.ndarray,
+    groups: np.ndarray,
+    *,
+    c_grid: np.ndarray | None = None,
+    inner_splits: int = 5,
+    n_jobs: int = -1,
+) -> tuple[np.ndarray, list[float]]:
+    """Nested leave-one-group-out OOF — the TraitGym linear-probing protocol.
+
+    **Outer:** leave-one-group-out over ``groups`` (a whole chromosome held out
+    each fold). **Inner:** within each outer fold's training groups, ``GridSearchCV``
+    over a ``GroupKFold`` of those groups tunes ``C`` by AUPRC — so ``C`` is re-tuned
+    per fold (hence per model and adaptively to its feature dimensionality), with no
+    leakage. Fixed pipeline ``StandardScaler → LogisticRegression`` (L2, no PCA).
+
+    Returns ``(oof_scores, selected_Cs)`` — OOF ``predict_proba[:, 1]`` aligned to
+    ``features`` rows, and the ``C`` chosen on each outer fold (feed to
+    ``summarize_selected_c`` to confirm the grid isn't truncating the optimum).
+    """
+    if c_grid is None:
+        c_grid = DEFAULT_C_GRID
+    X = np.asarray(features, dtype=np.float32)
+    y = np.asarray(label).astype(int)
+    g = np.asarray(groups)
+    n = len(y)
+    assert X.ndim == 2 and X.shape[0] == n == len(g), (X.shape, n, len(g))
+    assert len(np.unique(g)) >= 3, "need >=3 groups for nested LOGO"
+    oof = np.full(n, np.nan, dtype=float)
+    selected: list[float] = []
+    for tr, te in LeaveOneGroupOut().split(X, y, g):
+        k = min(inner_splits, len(np.unique(g[tr])))
+        gs = GridSearchCV(
+            _probe_pipeline(),
+            {"clf__C": c_grid},
+            cv=GroupKFold(n_splits=k),
+            scoring="average_precision",
+            n_jobs=n_jobs,
+        )
+        gs.fit(X[tr], y[tr], groups=g[tr])
+        oof[te] = gs.predict_proba(X[te])[:, 1]
+        selected.append(float(gs.best_params_["clf__C"]))
+    assert not np.isnan(oof).any(), "some rows were never held out — check groups"
+    return oof, selected
+
+
+def fit_full_classifier(
+    features: np.ndarray,
+    label: np.ndarray,
+    groups: np.ndarray,
+    *,
+    c_grid: np.ndarray | None = None,
+    inner_splits: int = 5,
+    n_jobs: int = -1,
+) -> tuple[Pipeline, float, np.ndarray]:
+    """Fit the reusable all-data probe, ``C`` chosen by one inner C-search.
+
+    The same pipeline and inner ``GroupKFold`` ``GridSearchCV`` as the OOF folds,
+    but fit on **all** the variants (no held-out chromosome) — this is the
+    classifier serialized for cross-dataset reuse. Returns ``(fitted_pipeline,
+    selected_C, c_scores)`` (``GridSearchCV`` refits ``best_estimator_`` on the full
+    data). ``c_scores`` is the inner-CV mean AUPRC per grid ``C``, **ascending in
+    C**, used by ``summarize_selected_c`` to verify a pinned edge is saturated (the
+    interior neighbor gives the same result), not a truncation.
+    """
+    if c_grid is None:
+        c_grid = DEFAULT_C_GRID
+    X = np.asarray(features, dtype=np.float32)
+    y = np.asarray(label).astype(int)
+    g = np.asarray(groups)
+    n = len(y)
+    assert X.ndim == 2 and X.shape[0] == n == len(g), (X.shape, n, len(g))
+    k = min(inner_splits, len(np.unique(g)))
+    assert k >= 2, f"need >=2 groups for inner C-search, got {len(np.unique(g))}"
+    gs = GridSearchCV(
+        _probe_pipeline(),
+        {"clf__C": c_grid},
+        cv=GroupKFold(n_splits=k),
+        scoring="average_precision",
+        n_jobs=n_jobs,
+    )
+    gs.fit(X, y, groups=g)
+    # Inner-CV mean AUPRC per grid C, ordered ascending in C so c_scores[0] is the
+    # heavy-reg floor and c_scores[-1] the weak-reg cap (the edge-saturation check).
+    grid_c = np.asarray(gs.cv_results_["param_clf__C"], dtype=float)
+    c_scores = np.asarray(gs.cv_results_["mean_test_score"], dtype=float)[
+        np.argsort(grid_c)
+    ]
+    return gs.best_estimator_, float(gs.best_params_["clf__C"]), c_scores
+
+
+def summarize_selected_c(
+    selected_cs: list[float] | np.ndarray,
+    full_c: float,
+    c_grid: np.ndarray,
+    *,
+    full_c_scores: np.ndarray | None = None,
+    tol: float = 0.01,
+) -> dict[str, float | int | bool | None]:
+    """Summarize the chosen ``C``s, flag grid-edge pinning, and verify saturation.
+
+    ``GridSearchCV.best_params_`` returns an exact grid value, so edge detection is
+    exact equality with the grid's min/max. ``at_edge`` is true when any outer fold
+    *or* the shipped ``full_c`` lands on a boundary.
+
+    A pin is benign as long as the edge is **saturated/flat** — i.e. the interior
+    neighbor gives the same result, so there is nothing beyond the grid to miss
+    (high edge ⟹ the unregularized limit; low edge ⟹ the maximally-shrunk
+    mean-difference direction). When ``full_c_scores`` (the all-data inner-CV mean
+    AUPRC per grid ``C``, **ascending in C**) is given, this is *verified* rather
+    than assumed: ``high_edge_gain = c_scores[-1] − c_scores[-2]`` and
+    ``low_edge_gain = c_scores[0] − c_scores[1]`` measure how much better each edge
+    is than its interior neighbor, and ``truncation_risk`` is set only when a
+    *pinned* edge is still improving by more than ``tol`` AUPRC (the optimum may lie
+    outside the grid → widen). With the grid anchored at both regularization limits
+    this should not fire; the check makes that auditable per cell.
+    """
+    sel = np.asarray(selected_cs, dtype=float)
+    grid = np.sort(np.asarray(c_grid, dtype=float))
+    assert sel.ndim == 1 and sel.size >= 1, sel.shape
+    lo, hi = float(grid[0]), float(grid[-1])
+    n_low = int(np.sum(sel == lo))
+    n_high = int(np.sum(sel == hi))
+    full_at_edge = bool(full_c == lo or full_c == hi)
+    out: dict[str, float | int | bool | None] = {
+        "c_min": float(sel.min()),
+        "c_med": float(np.median(sel)),
+        "c_max": float(sel.max()),
+        "full_c": float(full_c),
+        "n_at_low_edge": n_low,
+        "n_at_high_edge": n_high,
+        "full_at_edge": full_at_edge,
+        "at_edge": bool(n_low > 0 or n_high > 0 or full_at_edge),
+        "high_edge_gain": None,
+        "low_edge_gain": None,
+        "truncation_risk": None,
+    }
+    if full_c_scores is not None:
+        s = np.asarray(full_c_scores, dtype=float)
+        assert s.shape == grid.shape, (s.shape, grid.shape)
+        high_gain = float(s[-1] - s[-2])  # >tol ⟹ still rising at the weak-reg cap
+        low_gain = float(s[0] - s[1])  # >tol ⟹ wants heavier reg than the floor
+        high_pinned = n_high > 0 or full_c == hi
+        low_pinned = n_low > 0 or full_c == lo
+        out["high_edge_gain"] = high_gain
+        out["low_edge_gain"] = low_gain
+        out["truncation_risk"] = bool(
+            (high_pinned and high_gain > tol) or (low_pinned and low_gain > tol)
+        )
+    return out
+
+
+def run_subset_probes(
+    df: pd.DataFrame,
+    *,
+    feature_combo: str,
+    c_grid: np.ndarray | None = None,
+    min_variants: int = 300,
+    min_chroms: int = 3,
+    inner_splits: int = 5,
+    n_jobs: int = -1,
+) -> tuple[pd.DataFrame, dict]:
+    """Train a per-subset nested-LOOC probe over an in-bundle scores frame.
+
+    For each consequence ``subset`` (or a single synthetic ``"all"`` group when the
+    frame has no ``subset`` column, e.g. caqtl/dsqtl) that clears ``min_variants``
+    *and* ``min_chroms``: run ``traitgym_nested_oof`` for the LOOC ``probe_score``
+    and ``fit_full_classifier`` for the reusable classifier. Subsets below the
+    threshold (or that error / are single-class) are skipped — their rows keep a
+    ``NaN`` ``probe_score`` and get no classifier.
+
+    Returns ``(predictions, classifiers)``:
+
+    - ``predictions`` — ``df`` minus the bulky ``emb_ref``/``emb_alt`` columns, plus
+      a ``probe_score`` column (the LOOC OOF prediction; ``NaN`` for skipped rows).
+    - ``classifiers`` — ``{subset: {"pipeline", "C", "feature", "n", "n_pos",
+      "c_summary"}}`` (``c_summary`` is ``summarize_selected_c``).
+    """
+    if c_grid is None:
+        c_grid = DEFAULT_C_GRID
+    c_grid = np.asarray(c_grid, dtype=float)
+    assert "chrom" in df.columns and "label" in df.columns, (
+        "frame needs `chrom` and `label` columns"
+    )
+    feat = pair_feature_from_bundle(df, feature_combo)  # [N, F] float32
+    n_rows = len(df)
+    assert feat.shape[0] == n_rows, (feat.shape, n_rows)
+    chrom = df["chrom"].astype(str).to_numpy()
+    label = df["label"].to_numpy().astype(int)
+    # No biological consequence subsets on the QTL datasets -> one "all" group.
+    subset = (
+        df["subset"].astype(str).to_numpy()
+        if "subset" in df.columns
+        else np.full(n_rows, "all")
+    )
+
+    oof = np.full(n_rows, np.nan, dtype=float)
+    classifiers: dict = {}
+    for s in sorted(set(subset)):
+        mask = subset == s
+        n = int(mask.sum())
+        n_chrom = len(set(chrom[mask]))
+        n_pos = int(label[mask].sum())
+        if n < min_variants or n_chrom < min_chroms:
+            print(
+                f"[probe] skip {s!r}: n={n} (min {min_variants}), "
+                f"n_chrom={n_chrom} (min {min_chroms})"
+            )
+            continue
+        if not 0 < n_pos < n:
+            print(f"[probe] skip {s!r}: single-class (n_pos={n_pos}/{n})")
+            continue
+        try:
+            oof_s, selected = traitgym_nested_oof(
+                feat[mask],
+                label[mask],
+                chrom[mask],
+                c_grid=c_grid,
+                inner_splits=inner_splits,
+                n_jobs=n_jobs,
+            )
+            clf, full_c, c_scores = fit_full_classifier(
+                feat[mask],
+                label[mask],
+                chrom[mask],
+                c_grid=c_grid,
+                inner_splits=inner_splits,
+                n_jobs=n_jobs,
+            )
+        except Exception as e:  # keep an unattended multi-subset run alive
+            print(f"[probe] SKIP {s!r}: {type(e).__name__}: {e}")
+            continue
+        oof[mask] = oof_s
+        c_summary = summarize_selected_c(
+            selected, full_c, c_grid, full_c_scores=c_scores
+        )
+        classifiers[s] = {
+            "pipeline": clf,
+            "C": full_c,
+            "feature": feature_combo,
+            "n": n,
+            "n_pos": n_pos,
+            "c_summary": c_summary,
+        }
+        print(
+            f"[probe] {s}: n={n} n_pos={n_pos} C med={c_summary['c_med']:.1e} "
+            f"[{c_summary['c_min']:.0e},{c_summary['c_max']:.0e}] full={full_c:.1e}"
+        )
+        if c_summary["at_edge"]:
+            # A pinned edge is benign when it's saturated/flat (the interior neighbor
+            # gives the same result — verified via the inner-CV gains). truncation_risk
+            # fires only if a pinned edge is still improving > tol (optimum may be
+            # outside the grid). With both ends at the reg limits it should not fire.
+            verdict = (
+                "TRUNCATION RISK — edge still improving, widen c_grid"
+                if c_summary["truncation_risk"]
+                else "saturated/flat (benign)"
+            )
+            print(
+                f"[probe] note {s!r}: C pinned grid edge "
+                f"(n_low={c_summary['n_at_low_edge']}, "
+                f"n_high={c_summary['n_at_high_edge']}, full_c={c_summary['full_c']:.0e}; "
+                f"gain low={c_summary['low_edge_gain']:+.3f} "
+                f"high={c_summary['high_edge_gain']:+.3f}) — {verdict}"
+            )
+
+    assert classifiers, (
+        f"no subset met the threshold (min_variants={min_variants}, "
+        f"min_chroms={min_chroms}) — check the dataset / lower the threshold"
+    )
+    keep = [c for c in df.columns if c not in ("emb_ref", "emb_alt")]
+    predictions = df[keep].copy()
+    predictions["probe_score"] = oof
+    return predictions, classifiers

--- a/tests/pipelines/evals/test_variant_probe.py
+++ b/tests/pipelines/evals/test_variant_probe.py
@@ -1,0 +1,362 @@
+"""Tests for the frozen-embedding variant probe (issues #314/#320).
+
+Covers the correctness guarantees the production rule relies on: ref↔alt symmetry
+of the swap-invariant features, the f16→f32 upcast that guards the delta against
+cancellation, leak-proof nested chromosome-grouped OOF, the C-edge guard, and the
+per-subset orchestration (coverage, threshold skipping, no-subset path, reusable
+classifier).
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.metrics import average_precision_score
+
+from marin_dna.pipelines.evals.variant_probe import (
+    SYMMETRIC_COMBOS,
+    fit_full_classifier,
+    pair_feature,
+    pair_feature_from_bundle,
+    run_subset_probes,
+    summarize_selected_c,
+    traitgym_nested_oof,
+)
+
+# Small grid / fold count keep the nested-CV tests fast.
+C_GRID_TEST = np.logspace(-2, 2, 5)  # [0.01, 0.1, 1, 10, 100]
+
+
+def _rng(seed: int = 0) -> np.random.Generator:
+    return np.random.default_rng(seed)
+
+
+# --------------------------------------------------------------------------
+# Feature construction + symmetry
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("combo", ["abs_delta", "prod", "sum_absdiff"])
+def test_symmetric_combos_invariant_under_swap(combo: str) -> None:
+    rng = _rng()
+    ref, alt = rng.standard_normal((20, 8)), rng.standard_normal((20, 8))
+    assert combo in SYMMETRIC_COMBOS
+    np.testing.assert_allclose(
+        pair_feature(ref, alt, combo), pair_feature(alt, ref, combo)
+    )
+
+
+def test_signed_combos_change_under_swap() -> None:
+    rng = _rng()
+    ref, alt = rng.standard_normal((20, 8)), rng.standard_normal((20, 8))
+    # delta negates; concat swaps its two halves.
+    np.testing.assert_allclose(
+        pair_feature(ref, alt, "delta"), -pair_feature(alt, ref, "delta")
+    )
+    swapped = pair_feature(alt, ref, "concat")
+    np.testing.assert_allclose(pair_feature(ref, alt, "concat")[:, :8], swapped[:, 8:])
+    # concat_ref_delta = [ref, alt-ref]: the delta half negates under swap (signed).
+    crd = pair_feature(ref, alt, "concat_ref_delta")
+    crd_s = pair_feature(alt, ref, "concat_ref_delta")
+    np.testing.assert_allclose(crd[:, 8:], -crd_s[:, 8:])
+    assert "concat_ref_delta" not in SYMMETRIC_COMBOS
+
+
+def test_pair_feature_shapes() -> None:
+    ref, alt = np.zeros((5, 8)), np.ones((5, 8))
+    assert pair_feature(ref, alt, "delta").shape == (5, 8)
+    assert pair_feature(ref, alt, "abs_delta").shape == (5, 8)
+    assert pair_feature(ref, alt, "prod").shape == (5, 8)
+    assert pair_feature(ref, alt, "concat").shape == (5, 16)
+    assert pair_feature(ref, alt, "sum_absdiff").shape == (5, 16)
+    assert pair_feature(ref, alt, "concat_ref_delta").shape == (5, 16)
+
+
+def test_pair_feature_rejects_unknown() -> None:
+    with pytest.raises(ValueError):
+        pair_feature(np.zeros((2, 3)), np.zeros((2, 3)), "nope")
+
+
+# --------------------------------------------------------------------------
+# pair_feature_from_bundle — the in-bundle f16 path
+# --------------------------------------------------------------------------
+
+
+def _emb_frame(ref: np.ndarray, alt: np.ndarray, **cols) -> pd.DataFrame:
+    """Frame with emb_ref/emb_alt stored as the #318 list[f16] columns."""
+    data = {
+        "emb_ref": list(ref.astype(np.float16)),
+        "emb_alt": list(alt.astype(np.float16)),
+    }
+    data.update(cols)
+    return pd.DataFrame(data)
+
+
+def test_pair_feature_from_bundle_upcasts_f16_before_combining() -> None:
+    # values exact in f16 so the only thing under test is the upcast + combine.
+    ref = np.array([[1.0, 2.0], [0.5, 4.0]], dtype=np.float32)
+    alt = np.array([[1.5, 2.5], [0.25, 4.5]], dtype=np.float32)
+    feat = pair_feature_from_bundle(_emb_frame(ref, alt), "delta")
+    assert feat.dtype == np.float32
+    np.testing.assert_allclose(feat, alt - ref)
+
+
+def test_pair_feature_from_bundle_matches_manual_stack() -> None:
+    rng = _rng(3)
+    ref, alt = rng.standard_normal((6, 5)), rng.standard_normal((6, 5))
+    df = _emb_frame(ref, alt)
+    expected = pair_feature(
+        np.stack(df["emb_ref"]).astype(np.float32),
+        np.stack(df["emb_alt"]).astype(np.float32),
+        "concat_ref_delta",
+    )
+    np.testing.assert_allclose(
+        pair_feature_from_bundle(df, "concat_ref_delta"), expected
+    )
+
+
+def test_pair_feature_from_bundle_requires_emb_columns() -> None:
+    with pytest.raises(AssertionError):
+        pair_feature_from_bundle(pd.DataFrame({"chrom": ["1"], "label": [1]}), "delta")
+
+
+# --------------------------------------------------------------------------
+# Nested chromosome-grouped OOF
+# --------------------------------------------------------------------------
+
+
+def _toy_dataset(n_groups: int = 6, per_group: int = 60, signal: float = 3.0):
+    rng = _rng(7)
+    groups = np.repeat(np.arange(n_groups), per_group)
+    label = rng.integers(0, 2, size=n_groups * per_group)
+    feats = rng.standard_normal((n_groups * per_group, 6))
+    feats[:, 0] += signal * label  # one informative dimension
+    return feats, label, groups
+
+
+def test_nested_oof_covers_rows_tunes_C_and_recovers_signal() -> None:
+    feats, label, groups = _toy_dataset(signal=3.0)
+    oof, selected = traitgym_nested_oof(
+        feats, label, groups, c_grid=C_GRID_TEST, inner_splits=3, n_jobs=1
+    )
+    # every row held out exactly once; one selected C per outer (LOGO) fold
+    assert oof.shape == label.shape and not np.isnan(oof).any()
+    assert len(selected) == len(np.unique(groups))
+    # tuned C is always drawn from the supplied grid
+    assert all(any(np.isclose(c, g) for g in C_GRID_TEST) for c in selected)
+    # nested CV still recovers the planted signal
+    assert average_precision_score(label, oof) > 0.75
+
+
+def test_nested_oof_no_group_leakage() -> None:
+    # Features carry information ONLY via group identity (one-hot of group), labels
+    # i.i.d. per group — a model that memorizes group->label in-fold cannot predict
+    # a held-out (unseen) group: OOF AUPRC ~ prevalence.
+    rng = _rng(11)
+    n_groups, per_group = 8, 40
+    groups = np.repeat(np.arange(n_groups), per_group)
+    label = rng.integers(0, 2, size=n_groups * per_group)
+    onehot = np.eye(n_groups)[groups]
+    oof, _ = traitgym_nested_oof(
+        onehot, label, groups, c_grid=C_GRID_TEST, inner_splits=3, n_jobs=1
+    )
+    ap = average_precision_score(label, oof)
+    assert abs(ap - label.mean()) < 0.12, f"group identity leaked: AP={ap:.3f}"
+
+
+def test_nested_oof_requires_three_groups() -> None:
+    feats, label, _ = _toy_dataset()
+    with pytest.raises(AssertionError):
+        traitgym_nested_oof(feats, label, np.zeros(len(label)), n_jobs=1)
+
+
+# --------------------------------------------------------------------------
+# Full (reusable) classifier
+# --------------------------------------------------------------------------
+
+
+def test_fit_full_classifier_predicts_and_returns_grid_C_and_scores() -> None:
+    feats, label, groups = _toy_dataset(signal=3.0)
+    clf, c, c_scores = fit_full_classifier(
+        feats, label, groups, c_grid=C_GRID_TEST, inner_splits=3, n_jobs=1
+    )
+    assert any(np.isclose(c, g) for g in C_GRID_TEST)
+    proba = clf.predict_proba(feats[:5])
+    assert proba.shape == (5, 2) and np.all((proba >= 0) & (proba <= 1))
+    # one inner-CV AUPRC per grid C, ascending in C, finite
+    assert c_scores.shape == C_GRID_TEST.shape and np.isfinite(c_scores).all()
+
+
+# --------------------------------------------------------------------------
+# C-edge guard
+# --------------------------------------------------------------------------
+
+
+def test_summarize_selected_c_interior_not_flagged() -> None:
+    out = summarize_selected_c([1.0, 10.0, 1.0], full_c=10.0, c_grid=C_GRID_TEST)
+    assert out["at_edge"] is False
+    assert out["n_at_low_edge"] == 0 and out["n_at_high_edge"] == 0
+    assert out["c_min"] == 1.0 and out["c_max"] == 10.0
+
+
+def test_summarize_selected_c_low_edge_flagged() -> None:
+    # two folds pin the 0.01 floor; the shipped full_c also pins it.
+    out = summarize_selected_c([0.01, 0.01, 1.0], full_c=0.01, c_grid=C_GRID_TEST)
+    assert out["at_edge"] is True
+    assert out["n_at_low_edge"] == 2 and out["n_at_high_edge"] == 0
+    assert out["full_at_edge"] is True
+
+
+def test_summarize_selected_c_high_edge_via_full_c() -> None:
+    # interior folds, but the all-data fit lands on the 100 ceiling.
+    out = summarize_selected_c([1.0, 10.0], full_c=100.0, c_grid=C_GRID_TEST)
+    assert out["at_edge"] is True and out["full_at_edge"] is True
+    assert out["n_at_low_edge"] == 0 and out["n_at_high_edge"] == 0
+
+
+def test_summarize_selected_c_high_edge_saturated_is_benign() -> None:
+    # full_c pins the 100 cap, but the inner-CV curve is flat at the top (interior
+    # neighbor gives the same AUPRC) → saturated, not a truncation.
+    scores = np.array([0.30, 0.40, 0.50, 0.55, 0.55])  # ascending in C_GRID_TEST
+    out = summarize_selected_c(
+        [1.0, 100.0], full_c=100.0, c_grid=C_GRID_TEST, full_c_scores=scores
+    )
+    assert out["at_edge"] is True
+    assert out["high_edge_gain"] == pytest.approx(0.0)
+    assert out["truncation_risk"] is False
+
+
+def test_summarize_selected_c_high_edge_truncation_flagged() -> None:
+    # full_c pins the cap and the curve is STILL rising there → optimum may be beyond.
+    scores = np.array([0.30, 0.40, 0.50, 0.55, 0.70])
+    out = summarize_selected_c(
+        [100.0], full_c=100.0, c_grid=C_GRID_TEST, full_c_scores=scores
+    )
+    assert out["high_edge_gain"] == pytest.approx(0.15)
+    assert out["truncation_risk"] is True
+
+
+def test_summarize_selected_c_low_edge_flat_is_benign() -> None:
+    # folds pin the floor but the curve is flat there (the ncRNA case) → benign.
+    scores = np.array([0.36, 0.37, 0.40, 0.30, 0.20])  # flat-then-peak-then-drop
+    out = summarize_selected_c(
+        [0.01, 0.01, 0.1], full_c=0.01, c_grid=C_GRID_TEST, full_c_scores=scores
+    )
+    assert out["n_at_low_edge"] == 2
+    assert out["low_edge_gain"] == pytest.approx(0.36 - 0.37)  # <0 → not improving
+    assert out["truncation_risk"] is False
+
+
+# --------------------------------------------------------------------------
+# run_subset_probes — per-subset orchestration
+# --------------------------------------------------------------------------
+
+
+def _toy_bundle(
+    subsets: dict[str, int],
+    *,
+    n_chrom: int = 4,
+    d: int = 8,
+    signal: float = 3.0,
+    seed: int = 0,
+) -> pd.DataFrame:
+    """Per-subset bundle frame; signal lives in the alt−ref delta (dim 0)."""
+    rng = _rng(seed)
+    frames = []
+    for name, n in subsets.items():
+        chrom = np.array([f"chr{i % n_chrom + 1}" for i in range(n)])
+        label = rng.integers(0, 2, size=n)
+        ref = rng.standard_normal((n, d)).astype(np.float32)
+        delta = (rng.standard_normal((n, d)) * 0.1).astype(np.float32)
+        delta[:, 0] += signal * label
+        frames.append(
+            _emb_frame(ref, ref + delta, chrom=chrom, label=label, subset=name)
+        )
+    return pd.concat(frames, ignore_index=True)
+
+
+def test_run_subset_probes_covers_trained_subsets_and_drops_emb() -> None:
+    df = _toy_bundle({"a": 80, "b": 80})
+    preds, clfs = run_subset_probes(
+        df,
+        feature_combo="concat_ref_delta",
+        c_grid=C_GRID_TEST,
+        min_variants=40,
+        min_chroms=3,
+        inner_splits=3,
+        n_jobs=1,
+    )
+    assert set(clfs) == {"a", "b"}
+    # predictions carry one row per variant, probe_score everywhere, no emb cols.
+    assert len(preds) == len(df)
+    assert "probe_score" in preds.columns
+    assert "emb_ref" not in preds.columns and "emb_alt" not in preds.columns
+    assert not preds["probe_score"].isna().any()
+    # the planted signal is recovered out-of-fold.
+    assert average_precision_score(preds["label"], preds["probe_score"]) > 0.75
+    # each classifier records provenance + is reusable.
+    for entry in clfs.values():
+        assert entry["feature"] == "concat_ref_delta"
+        assert any(np.isclose(entry["C"], g) for g in C_GRID_TEST)
+        assert "c_summary" in entry
+
+
+def test_run_subset_probes_skips_below_threshold_subset() -> None:
+    df = _toy_bundle({"big": 80, "small": 20})
+    preds, clfs = run_subset_probes(
+        df,
+        feature_combo="concat_ref_delta",
+        c_grid=C_GRID_TEST,
+        min_variants=40,
+        min_chroms=3,
+        inner_splits=3,
+        n_jobs=1,
+    )
+    assert set(clfs) == {"big"}  # small (n=20 < 40) dropped
+    small = preds["subset"] == "small"
+    assert preds.loc[small, "probe_score"].isna().all()
+    assert not preds.loc[~small, "probe_score"].isna().any()
+
+
+def test_run_subset_probes_no_subset_column_uses_all_group() -> None:
+    df = _toy_bundle({"only": 80}).drop(columns="subset")
+    preds, clfs = run_subset_probes(
+        df,
+        feature_combo="concat_ref_delta",
+        c_grid=C_GRID_TEST,
+        min_variants=40,
+        min_chroms=3,
+        inner_splits=3,
+        n_jobs=1,
+    )
+    assert set(clfs) == {"all"}
+    assert not preds["probe_score"].isna().any()
+
+
+def test_run_subset_probes_reusable_classifier_predicts_other_data() -> None:
+    train = _toy_bundle({"a": 80}, seed=0)
+    preds, clfs = run_subset_probes(
+        train,
+        feature_combo="concat_ref_delta",
+        c_grid=C_GRID_TEST,
+        min_variants=40,
+        min_chroms=3,
+        inner_splits=3,
+        n_jobs=1,
+    )
+    # apply the saved classifier to a fresh bundle (cross-dataset reuse).
+    fresh = _toy_bundle({"a": 30}, seed=99)
+    feat_fresh = pair_feature_from_bundle(fresh, "concat_ref_delta")
+    proba = clfs["a"]["pipeline"].predict_proba(feat_fresh)
+    assert proba.shape == (30, 2) and np.all((proba >= 0) & (proba <= 1))
+
+
+def test_run_subset_probes_all_below_threshold_raises() -> None:
+    df = _toy_bundle({"a": 20})
+    with pytest.raises(AssertionError):
+        run_subset_probes(
+            df,
+            feature_combo="concat_ref_delta",
+            c_grid=C_GRID_TEST,
+            min_variants=1000,
+            n_jobs=1,
+        )

--- a/tests/pipelines/evals/test_variant_probe.py
+++ b/tests/pipelines/evals/test_variant_probe.py
@@ -92,12 +92,16 @@ def _emb_frame(ref: np.ndarray, alt: np.ndarray, **cols) -> pd.DataFrame:
 
 
 def test_pair_feature_from_bundle_upcasts_f16_before_combining() -> None:
-    # values exact in f16 so the only thing under test is the upcast + combine.
-    ref = np.array([[1.0, 2.0], [0.5, 4.0]], dtype=np.float32)
-    alt = np.array([[1.5, 2.5], [0.25, 4.5]], dtype=np.float32)
-    feat = pair_feature_from_bundle(_emb_frame(ref, alt), "delta")
+    # 1500/1501 are exact in f16, but their sum 3001 is NOT (f16 spacing is 2 above
+    # 2048), so `ref+alt` computed in f16 rounds to 3000 while f32 keeps 3001. Using
+    # `sum_absdiff` (which adds) makes the upcast observable — `delta` alone can't,
+    # since f16 subtraction of near-equal values is exact (Sterbenz). A missing
+    # pre-combine upcast would return f16 [[3000, 1]] and fail both asserts.
+    ref = np.array([[1500.0]], dtype=np.float32)
+    alt = np.array([[1501.0]], dtype=np.float32)
+    feat = pair_feature_from_bundle(_emb_frame(ref, alt), "sum_absdiff")
     assert feat.dtype == np.float32
-    np.testing.assert_allclose(feat, alt - ref)
+    np.testing.assert_array_equal(feat, [[3001.0, 1.0]])
 
 
 def test_pair_feature_from_bundle_matches_manual_stack() -> None:
@@ -246,6 +250,28 @@ def test_summarize_selected_c_low_edge_flat_is_benign() -> None:
     assert out["truncation_risk"] is False
 
 
+def test_summarize_selected_c_low_edge_truncation_flagged() -> None:
+    # full_c pins the floor and the curve is STILL higher there than its interior
+    # neighbor (descending) → wants heavier reg than the grid allows → flagged.
+    scores = np.array([0.60, 0.40, 0.30, 0.20, 0.10])  # best at the heavy-reg floor
+    out = summarize_selected_c(
+        [0.01], full_c=0.01, c_grid=C_GRID_TEST, full_c_scores=scores
+    )
+    assert out["low_edge_gain"] == pytest.approx(0.20)  # 0.60 - 0.40
+    assert out["truncation_risk"] is True
+
+
+def test_summarize_selected_c_nan_edge_gain_flags_risk() -> None:
+    # A failed/single-class inner-CV fold leaves mean_test_score NaN at the pinned
+    # edge; saturation can't be verified, so it must NOT be reported benign.
+    scores = np.array([0.30, 0.40, 0.50, 0.55, np.nan])  # NaN at the pinned high edge
+    out = summarize_selected_c(
+        [100.0], full_c=100.0, c_grid=C_GRID_TEST, full_c_scores=scores
+    )
+    assert np.isnan(out["high_edge_gain"])
+    assert out["truncation_risk"] is True  # not silently False via `nan > tol`
+
+
 # --------------------------------------------------------------------------
 # run_subset_probes — per-subset orchestration
 # --------------------------------------------------------------------------
@@ -360,3 +386,70 @@ def test_run_subset_probes_all_below_threshold_raises() -> None:
             min_variants=1000,
             n_jobs=1,
         )
+
+
+def test_run_subset_probes_skips_single_class_subset() -> None:
+    # a subset that clears the size/chrom gates but is all-one-class must be skipped
+    # (LogisticRegression needs both classes), not crash the run.
+    df = _toy_bundle({"normal": 80, "allneg": 80})
+    df.loc[df["subset"] == "allneg", "label"] = 0  # force single-class
+    preds, clfs = run_subset_probes(
+        df,
+        feature_combo="concat_ref_delta",
+        c_grid=C_GRID_TEST,
+        min_variants=40,
+        min_chroms=3,
+        inner_splits=3,
+        n_jobs=1,
+    )
+    assert set(clfs) == {"normal"}
+    assert preds.loc[preds["subset"] == "allneg", "probe_score"].isna().all()
+
+
+def test_run_subset_probes_skips_below_min_chroms() -> None:
+    # plenty of variants but only 2 chromosomes (< min_chroms) → skipped, not fed to
+    # LeaveOneGroupOut (which needs >=3 groups).
+    wide = _toy_bundle({"wide": 80}, n_chrom=4)
+    narrow = _toy_bundle({"narrow": 80}, n_chrom=2, seed=1)
+    df = pd.concat([wide, narrow], ignore_index=True)
+    preds, clfs = run_subset_probes(
+        df,
+        feature_combo="concat_ref_delta",
+        c_grid=C_GRID_TEST,
+        min_variants=40,
+        min_chroms=3,
+        inner_splits=3,
+        n_jobs=1,
+    )
+    assert set(clfs) == {"wide"}
+    assert preds.loc[preds["subset"] == "narrow", "probe_score"].isna().all()
+
+
+def test_run_subset_probes_keeps_going_when_one_subset_errors(monkeypatch) -> None:
+    # the per-subset try/except must keep an unattended multi-subset run alive: one
+    # erroring subset is skipped (NaN), siblings still train.
+    from marin_dna.pipelines.evals import variant_probe as vp
+
+    df = _toy_bundle({"aaa_bad": 80, "zzz_good": 80})  # sorted() → aaa_bad first
+    real = vp.traitgym_nested_oof
+    calls = {"n": 0}
+
+    def flaky(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:  # only the first subset errors
+            raise RuntimeError("boom")
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(vp, "traitgym_nested_oof", flaky)
+    preds, clfs = vp.run_subset_probes(
+        df,
+        feature_combo="concat_ref_delta",
+        c_grid=C_GRID_TEST,
+        min_variants=40,
+        min_chroms=3,
+        inner_splits=3,
+        n_jobs=1,
+    )
+    assert set(clfs) == {"zzz_good"}
+    assert preds.loc[preds["subset"] == "aaa_bad", "probe_score"].isna().all()
+    assert not preds.loc[preds["subset"] == "zzz_good", "probe_score"].isna().any()


### PR DESCRIPTION
🤖 Productionizes #314's settled frozen-embedding linear-probe VEP protocol — the **probe-training** component (follows #318 inference; precedes the downstream metrics step).

Closes #320.

## What this adds

One **CPU rule** ([`compute_probe`](https://github.com/Open-Athena/marin-dna/blob/ddff494c80fac8c49f725d64450e0a7cf16f8d94/snakemake/analysis/evals_v2/workflow/rules/probe.smk#L22-L69), off `rule all`) that takes the in-bundle pooled embeddings (`emb_ref`/`emb_alt`, #318), trains a per-consequence-subset linear probe, and emits two artifacts per `(model, dataset)`:

- `results/probe/{model}/{dataset}.parquet` — the **leave-one-chromosome-out (LOOC) prediction** for every variant (`probe_score`; `NaN` for skipped subsets), consumed by the downstream metrics issue.
- `results/probe/{model}/{dataset}.joblib` — the **fitted per-subset classifiers** (`{subset: {pipeline, C, feature, n, n_pos, c_summary}}`), serialized for reuse on other datasets.

## The one LOOC protocol (no variants)

- **Feature** ([`pair_feature_from_bundle`](https://github.com/Open-Athena/marin-dna/blob/ddff494c80fac8c49f725d64450e0a7cf16f8d94/src/marin_dna/pipelines/evals/variant_probe.py#L103-L117)) — upcast `emb_ref`/`emb_alt` f16→**f32** before combining (cancellation guard, #318), then `concat_ref_delta` (directional: mendelian/sge) or `sum_absdiff` (swap-invariant: complex/caqtl/dsqtl).
- **Per consequence `subset`**, trained only if `n≥300` **and** `n_chrom≥3`; QTL datasets (no `subset`) collapse to one `all` group; smaller subsets get `NaN` `probe_score` and no classifier.
- **Probe** — fixed `StandardScaler → LogisticRegression(L2)`; the only tuned knob is `C`.
- **CV** ([`traitgym_nested_oof`](https://github.com/Open-Athena/marin-dna/blob/ddff494c80fac8c49f725d64450e0a7cf16f8d94/src/marin_dna/pipelines/evals/variant_probe.py#L140-L185)) — outer leave-one-chromosome-out, inner `GroupKFold` `GridSearchCV` re-tuning `C` per fold; the reusable classifier ([`fit_full_classifier`](https://github.com/Open-Athena/marin-dna/blob/ddff494c80fac8c49f725d64450e0a7cf16f8d94/src/marin_dna/pipelines/evals/variant_probe.py#L187-L230)) is the same pipeline fit on all data. Orchestrated by [`run_subset_probes`](https://github.com/Open-Athena/marin-dna/blob/ddff494c80fac8c49f725d64450e0a7cf16f8d94/src/marin_dna/pipelines/evals/variant_probe.py#L293-L376).

## C grid + verified edge diagnostic

`c_grid = logspace(-12, 4, 17)`, **anchored at both regularization limits** so it can't truncate the optimum — no `inf`, no adaptive widening:
- high `1e4` = a saturation cap (reproduces the unregularized `C→∞` *ranking* bit-for-bit, so `inf` is unnecessary);
- low `1e-12` = a heavy-reg floor (as `C→0` the L2 fit shrinks to the scale-free **mean-difference direction** — *not* a constant predictor, since AUPRC is rank-based).

[`summarize_selected_c`](https://github.com/Open-Athena/marin-dna/blob/ddff494c80fac8c49f725d64450e0a7cf16f8d94/src/marin_dna/pipelines/evals/variant_probe.py#L232-L291) **verifies** every edge pin from the all-data inner-CV curve: `high_edge_gain`/`low_edge_gain` measure whether a pinned edge is still improving vs its interior neighbor, and `truncation_risk` fires only if it is (which the anchored grid avoids). So an edge pin is confirmed *saturated/flat* rather than assumed.

## Verification

24 unit tests; ruff clean; DAG dry-runs to only `compute_probe`. Ran end-to-end on `mix-v0.9-p1B-i24-exp135-m5.1/mendelian_traits` (the one cell already carrying embeddings) on a CPU SkyPilot node:

<details><summary>8-subset parity + edge verification (no truncation anywhere)</summary>

| subset | OOF AUPRC | full_C | edges | low_gain | high_gain | truncation_risk |
|---|---|---|---|---|---|---|
| missense | 0.525 | 1e-3 | clean | −0.0000 | −0.0042 | False |
| splicing | 0.535 | 1e-2 | clean | −0.0000 | −0.0009 | False |
| 3′UTR | 0.499 | 1e-3 | clean | −0.0000 | −0.0029 | False |
| synonymous | 0.498 | **1e4** | 2 high | +0.0000 | +0.0017 | False |
| 5′UTR | 0.483 | 1e-3 | clean | −0.0000 | +0.0005 | False |
| distal | 0.418 | 1e3 | 1 high | −0.0010 | −0.0006 | False |
| ncRNA_exon | 0.319 | 1e-7 | 6 low | +0.0000 | +0.0001 | False |
| tss_proximal | 0.294 | 1e-4 | clean | −0.0000 | −0.0070 | False |
| mature_miRNA | — | _skipped (n=40 < 300)_ | | | | |

All edge gains ≤ 0.007 AUPRC ⟹ the three edge-pinning subsets (synonymous/distal high, ncRNA low) are verified saturated/flat, so `truncation_risk=False` everywhere. OOF AUPRCs track #314 (strong on missense/splicing, weak on ncRNA/tss).
</details>

## Out of scope (handoffs)

- **No metrics** — per-chrom AUPRC (#319), global AUPRC, paired probe-vs-LLR delta. The downstream metrics issue consumes the `probe_score` parquet.
- **No `transfer_oof`** — cross-dataset reuse is via the serialized classifiers, not an explicit transfer loop.
- **Prerequisite:** probing a cell requires its scores parquet to have been produced with `inference.return_embeddings: true`; the rule fails fast otherwise. Only `exp135-m5.1/mendelian` qualifies today — others need a GPU re-score via the #318 overlay first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
