### PR TITLE
metrics: library-home per-chromosome-weighted AUPRC (the TraitGym metric)

### DIFF
--- a/scripts/issue319_verify_against_314.py
+++ b/scripts/issue319_verify_against_314.py
@@ -1,39 +1,43 @@
-"""issue #319 — verify the library ``per_chrom_weighted_ap`` reproduces #314.
+"""issue #319 — verify the metric AND the parent #320 probe reproduce #314.
 
-Two checks, both on the #314 headline generalist exp135-1B-m5.1 (productionized name
-``mix-v0.9-p1B-i24-exp135-m5.1-step-59158``) on ``mendelian_traits``:
+All on the #314 headline generalist exp135-1B-m5.1 (productionized name
+``mix-v0.9-p1B-i24-exp135-m5.1-step-59158``) on ``mendelian_traits``; every subset's
+row count matches #314 exactly, so it's the same variant set.
 
-1. **Bit-for-bit metric anchor (the real test).** #314's iter1 OOF parquets carry
-   #314's own ``llr_fwd``/``llr_rc``. Computing ``per_chrom_weighted_ap`` on
-   ``minus_llr_avg = -(llr_fwd + llr_rc) / 2`` from those scores must reproduce #314's
-   saved iter2 ``llr_perchrom`` *exactly* — same scores + same metric definition. (The
-   ``llr_perchrom`` baseline is computed once per subset in iter2, identical across its
-   reps.) This isolates the metric from any scoring difference: Δ == 0 ⇒ the library
-   function is the #314 helper. It passes for all 8 subsets at Δ = 0.
+[1] **Metric, bit-for-bit (validates #319).** #314's iter1 OOF parquets carry #314's
+    own ``llr_fwd``/``llr_rc``. ``per_chrom_weighted_ap`` on ``minus_llr_avg`` from
+    those scores reproduces #314's saved iter2 ``llr_perchrom`` *exactly* (Δ = 0, all 8
+    subsets) — same scores + same metric ⇒ the library function is the #314 helper.
 
-2. **End-to-end sanity (productionized pipeline + library metric).** Apply the same
-   metric to the *productionized* ``compute_probe`` predictions (#320/#330 evals_v2
-   rule, on S3) — both the LOOC ``probe_score`` and ``minus_llr_avg`` — and put them
-   beside #314's iter2 numbers. The productionized LLR is a different scoring code path
-   from #314's embedding cache (corr ≈ 0.999, mean |Δllr| ≈ 0.07–0.10), so per-chrom
-   lands within ~0.001 of #314 on 7/8 subsets; ``synonymous_variant`` (smallest, n=460)
-   is most sensitive to that per-variant drift and differs ~0.025. The probe is a
-   different protocol from iter2's nested rep sweep (LOOC, min_variants 300 vs 100,
-   single directional feature), so its ``probe_perchrom`` is close-but-not-identical to
-   iter2's ``delta`` rep — what we confirm is that the productionized pipeline + library
-   metric reproduce the #314 finding that per-chrom AUPRC > the global pooled AUPRC.
+[2] **Productionized probe vs #314's *matching* arm (validates the parent end-to-end).**
+    The mendelian probe feature is ``concat_ref_delta`` (the ``minus_llr`` protocol →
+    ``PROBE_FEATURE_BY_PROTOCOL``), i.e. #314's ref-context ablation arm — so the right
+    reference is ``iter2_nested_refdelta``'s ``concat_ref_delta`` rep, NOT the plain
+    ``delta`` rep (plain ``delta`` is ~0.1 lower; ref-context is the whole point of that
+    #314 ablation). Per-chrom AUPRC from the productionized predictions lands within
+    ~0.01 of that arm (mean), the residual being a different scoring/pooling code path
+    (evals_v2 #318 vs #314's cache; LLR corr ≈ 0.999, mean |Δllr| ≈ 0.1). ``probe`` >
+    its global pooled AUPRC on every subset — the calibration artifact #314 found.
 
-Run (needs S3 + the library on this branch):
+[3] **Parent #320 reproducibility (validates the training rule).** Re-run #320's own
+    ``run_subset_probes`` on the pipeline's input embeddings (``results/scores/...``,
+    the 125 MB emb-bearing parquet) for the two smallest probed subsets; the saved
+    ``probe_score`` reproduces to fp/threading tolerance (synonymous ~2e-10, distal
+    ~3e-3 — parallel-``GridSearchCV`` nondeterminism), per-chrom AUPRC within ~1e-3.
+
+Run (needs S3 + the library on this branch; [3] downloads the 125 MB scores parquet):
   uv run --group genome-s3 python scripts/issue319_verify_against_314.py
 """
 
 import numpy as np
+import pandas as pd
 import polars as pl
 
 from marin_dna.pipelines.evals.metrics import (
     auprc_with_bootstrap_se,
     per_chrom_weighted_ap,
 )
+from marin_dna.pipelines.evals.variant_probe import run_subset_probes
 
 MODEL_314 = "exp135-1B-m5.1"
 MODEL_PROD = "mix-v0.9-p1B-i24-exp135-m5.1-step-59158"
@@ -42,78 +46,118 @@ ITER1_OOF = (
     f"s3://oa-bolinas/analysis/issue314/iter1_search/{MODEL_314}/oof_{{}}.parquet"
 )
 ITER2 = f"s3://oa-bolinas/analysis/issue314/iter2_nested/nested_{MODEL_314}.parquet"
-PROD = (
-    "s3://oa-bolinas/snakemake/analysis/evals_v2/results/probe/"
-    f"{MODEL_PROD}/mendelian_traits.parquet"
-)
+ITER2_REFDELTA = f"s3://oa-bolinas/analysis/issue314/iter2_nested_refdelta/nested_{MODEL_314}.parquet"
+_PROD = "s3://oa-bolinas/snakemake/analysis/evals_v2/results"
+PRED = f"{_PROD}/probe/{MODEL_PROD}/mendelian_traits.parquet"
+SCORES = f"{_PROD}/scores/{MODEL_PROD}/mendelian_traits.parquet"  # emb-bearing input
+
+# The productionized mendelian probe feature (config: score_protocol minus_llr →
+# PROBE_FEATURE_BY_PROTOCOL). Pinned here so [2]/[3] reference the right #314 arm.
+PROBE_FEATURE = "concat_ref_delta"
+PROBE_C_GRID = np.logspace(-12, 4, 17)  # config probe.c_grid
+KEY = ["chrom", "pos", "ref", "alt"]
 
 
-def _minus_llr_avg(df) -> np.ndarray:
+def _minus_llr_avg(df: pd.DataFrame) -> np.ndarray:
     """Directional mendelian baseline (iter2's non-``--abs_llr`` path)."""
     return (-(df["llr_fwd"] + df["llr_rc"]) / 2.0).to_numpy()
 
 
-def main() -> None:
-    ref = pl.read_parquet(ITER2).to_pandas()
-    # llr_perchrom is computed once per subset in iter2 (same across reps); the
-    # `delta` rep is the directional analog of the productionized minus_llr feature.
-    ref_llr = ref.groupby("subset")["llr_perchrom"].first()
-    ref_probe_delta = ref[ref["rep"] == "entire_window/delta"].set_index("subset")[
-        "probe_perchrom"
-    ]
-    subsets = sorted(ref_llr.index)
-
-    # --- Check 1: bit-for-bit on #314's own scores ------------------------------
-    print("[1] library metric on #314's own iter1-OOF llr  vs  #314 saved llr_perchrom")
+def check1_metric_anchor(ref_llr: pd.Series, subsets: list[str]) -> None:
+    print("[1] metric on #314's own iter1-OOF llr  vs  #314 saved llr_perchrom")
     print(f"    {'subset':36s} {'n':>5s} {'mine':>10s} {'#314':>10s} {'Δ':>11s}")
-    max_anchor = 0.0
+    worst = 0.0
     for s in subsets:
         d = pl.read_parquet(ITER1_OOF.format(s)).to_pandas()
         d["chrom"] = d["chrom"].astype(str)
         y = d["label"].to_numpy().astype(int)
         mine = per_chrom_weighted_ap(y, _minus_llr_avg(d), d["chrom"].to_numpy())
         r = float(ref_llr[s])
-        max_anchor = max(max_anchor, abs(mine - r))
+        worst = max(worst, abs(mine - r))
         print(f"    {s:36s} {len(d):5d} {mine:10.6f} {r:10.6f} {mine - r:+11.2e}")
-    print(f"    max |Δ| anchor = {max_anchor:.3e}")
-    assert max_anchor < 1e-9, (
-        f"library per_chrom_weighted_ap does NOT reproduce #314 llr_perchrom on #314's "
-        f"own scores (max |Δ| = {max_anchor:.3e}); the metric and the helper must match"
+    print(f"    max |Δ| = {worst:.3e}")
+    assert worst < 1e-9, (
+        f"metric does NOT reproduce #314 llr_perchrom (max|Δ|={worst:.2e})"
     )
     print("    PASS — library metric == #314 helper, bit-for-bit.\n")
 
-    # --- Check 2: end-to-end on the productionized predictions -------------------
-    pred = pl.read_parquet(PROD).to_pandas()
+
+def check2_probe_vs_matching_arm(ref_concat: pd.Series, subsets: list[str]) -> None:
+    pred = pl.read_parquet(PRED).to_pandas()
     pred["chrom"] = pred["chrom"].astype(str)
-    print("[2] productionized predictions (#320/#330) + library metric  vs  #314 iter2")
     print(
-        f"    {'subset':36s} {'n':>5s} | {'llr_pc':>8s} {'#314':>8s} {'Δ':>8s} | "
-        f"{'probe_pc':>8s} {'probe_g':>8s} {'#314 Δrep':>9s}"
+        f"[2] productionized probe ({PROBE_FEATURE}) per-chrom  vs  #314 concat_ref_delta arm"
     )
+    print(
+        f"    {'subset':36s} {'n':>5s} {'probe_pc':>9s} {'probe_g':>8s} "
+        f"{'#314':>8s} {'Δ':>8s}"
+    )
+    deltas = []
     for s in subsets:
-        d = pred[pred["subset"] == s]
-        y = d["label"].to_numpy().astype(int)
-        ch = d["chrom"].to_numpy()
-        llr_pc = per_chrom_weighted_ap(y, _minus_llr_avg(d), ch)
-        r = float(ref_llr[s])
-        dp = d[d["probe_score"].notna()]
-        if len(dp):
-            yp = dp["label"].to_numpy().astype(int)
-            sp = dp["probe_score"].to_numpy()
-            probe_pc = per_chrom_weighted_ap(yp, sp, dp["chrom"].to_numpy())
-            probe_g = auprc_with_bootstrap_se(
-                yp, sp, dp["match_group"].to_numpy(), n_bootstrap=0
-            )["value"]
-        else:
-            probe_pc = probe_g = float("nan")
-        print(
-            f"    {s:36s} {len(d):5d} | {llr_pc:8.4f} {r:8.4f} {llr_pc - r:+8.4f} | "
-            f"{probe_pc:8.4f} {probe_g:8.4f} {float(ref_probe_delta.get(s, np.nan)):9.4f}"
-        )
+        dp = pred[(pred["subset"] == s) & pred["probe_score"].notna()]
+        y = dp["label"].to_numpy().astype(int)
+        sp = dp["probe_score"].to_numpy()
+        pc = per_chrom_weighted_ap(y, sp, dp["chrom"].to_numpy())
+        g = auprc_with_bootstrap_se(y, sp, dp["match_group"].to_numpy(), n_bootstrap=0)[
+            "value"
+        ]
+        r = float(ref_concat[s])
+        deltas.append(abs(pc - r))
+        assert pc > g, f"{s}: per-chrom {pc:.3f} !> global {g:.3f} (the #314 finding)"
+        print(f"    {s:36s} {len(dp):5d} {pc:9.4f} {g:8.4f} {r:8.4f} {pc - r:+8.4f}")
+    print(f"    mean |Δ| = {np.mean(deltas):.4f}, max |Δ| = {np.max(deltas):.4f}")
     print(
-        "\n    (probe_pc > probe_g on every subset — the per-chrom>global finding #314 "
-        "productionizes.)"
+        "    (probe per-chrom > global on every subset; ~0.01 from #314's matching arm.)\n"
     )
+
+
+def check3_parent_reproducibility(ref_concat: pd.Series) -> None:
+    print(
+        "[3] re-run #320 run_subset_probes on its input embeddings  vs  saved probe_score"
+    )
+    saved = pd.read_parquet(PRED, columns=KEY + ["subset", "label", "probe_score"])
+    print(
+        f"    {'subset':22s} {'n':>5s} {'max|Δscore|':>12s} {'pc(rerun)':>10s} {'pc(saved)':>10s}"
+    )
+    for s in ("synonymous_variant", "distal"):  # two smallest probed subsets (fast)
+        inp = pd.read_parquet(SCORES, filters=[("subset", "==", s)])
+        preds, _ = run_subset_probes(
+            inp,
+            feature_combo=PROBE_FEATURE,
+            c_grid=PROBE_C_GRID,
+            min_variants=300,
+            min_chroms=3,
+            inner_splits=5,
+            n_jobs=4,
+        )
+        rerun = preds[KEY + ["probe_score"]].rename(columns={"probe_score": "rerun"})
+        sv = saved[saved["subset"] == s].reset_index(drop=True).merge(rerun, on=KEY)
+        sv = sv[sv["probe_score"].notna() & sv["rerun"].notna()]
+        mad = float((sv["probe_score"] - sv["rerun"]).abs().max())
+        y = sv["label"].to_numpy().astype(int)
+        ch = sv["chrom"].astype(str).to_numpy()
+        pc_re = per_chrom_weighted_ap(y, sv["rerun"].to_numpy(), ch)
+        pc_sv = per_chrom_weighted_ap(y, sv["probe_score"].to_numpy(), ch)
+        assert mad < 0.05 and abs(pc_re - pc_sv) < 0.02, (
+            f"{s}: re-run diverges from saved (max|Δscore|={mad:.2e}, "
+            f"Δpc={pc_re - pc_sv:+.2e}) beyond fp/threading tolerance"
+        )
+        print(f"    {s:22s} {len(sv):5d} {mad:12.2e} {pc_re:10.4f} {pc_sv:10.4f}")
+    print("    PASS — saved S3 probe predictions reproduce #320's run_subset_probes.\n")
+
+
+def main() -> None:
+    ref = pl.read_parquet(ITER2).to_pandas()
+    ref_llr = ref.groupby("subset")["llr_perchrom"].first()
+    rd = pl.read_parquet(ITER2_REFDELTA).to_pandas()
+    ref_concat = rd[rd["rep"] == "entire_window/concat_ref_delta"].set_index("subset")[
+        "probe_perchrom"
+    ]
+    subsets = sorted(ref_llr.index)
+
+    check1_metric_anchor(ref_llr, subsets)
+    check2_probe_vs_matching_arm(ref_concat, subsets)
+    check3_parent_reproducibility(ref_concat)
 
 
 if __name__ == "__main__":

--- a/scripts/issue319_verify_against_314.py
+++ b/scripts/issue319_verify_against_314.py
@@ -1,0 +1,120 @@
+"""issue #319 — verify the library ``per_chrom_weighted_ap`` reproduces #314.
+
+Two checks, both on the #314 headline generalist exp135-1B-m5.1 (productionized name
+``mix-v0.9-p1B-i24-exp135-m5.1-step-59158``) on ``mendelian_traits``:
+
+1. **Bit-for-bit metric anchor (the real test).** #314's iter1 OOF parquets carry
+   #314's own ``llr_fwd``/``llr_rc``. Computing ``per_chrom_weighted_ap`` on
+   ``minus_llr_avg = -(llr_fwd + llr_rc) / 2`` from those scores must reproduce #314's
+   saved iter2 ``llr_perchrom`` *exactly* — same scores + same metric definition. (The
+   ``llr_perchrom`` baseline is computed once per subset in iter2, identical across its
+   reps.) This isolates the metric from any scoring difference: Δ == 0 ⇒ the library
+   function is the #314 helper. It passes for all 8 subsets at Δ = 0.
+
+2. **End-to-end sanity (productionized pipeline + library metric).** Apply the same
+   metric to the *productionized* ``compute_probe`` predictions (#320/#330 evals_v2
+   rule, on S3) — both the LOOC ``probe_score`` and ``minus_llr_avg`` — and put them
+   beside #314's iter2 numbers. The productionized LLR is a different scoring code path
+   from #314's embedding cache (corr ≈ 0.999, mean |Δllr| ≈ 0.07–0.10), so per-chrom
+   lands within ~0.001 of #314 on 7/8 subsets; ``synonymous_variant`` (smallest, n=460)
+   is most sensitive to that per-variant drift and differs ~0.025. The probe is a
+   different protocol from iter2's nested rep sweep (LOOC, min_variants 300 vs 100,
+   single directional feature), so its ``probe_perchrom`` is close-but-not-identical to
+   iter2's ``delta`` rep — what we confirm is that the productionized pipeline + library
+   metric reproduce the #314 finding that per-chrom AUPRC > the global pooled AUPRC.
+
+Run (needs S3 + the library on this branch):
+  uv run --group genome-s3 python scripts/issue319_verify_against_314.py
+"""
+
+import numpy as np
+import polars as pl
+
+from marin_dna.pipelines.evals.metrics import (
+    auprc_with_bootstrap_se,
+    per_chrom_weighted_ap,
+)
+
+MODEL_314 = "exp135-1B-m5.1"
+MODEL_PROD = "mix-v0.9-p1B-i24-exp135-m5.1-step-59158"
+
+ITER1_OOF = (
+    f"s3://oa-bolinas/analysis/issue314/iter1_search/{MODEL_314}/oof_{{}}.parquet"
+)
+ITER2 = f"s3://oa-bolinas/analysis/issue314/iter2_nested/nested_{MODEL_314}.parquet"
+PROD = (
+    "s3://oa-bolinas/snakemake/analysis/evals_v2/results/probe/"
+    f"{MODEL_PROD}/mendelian_traits.parquet"
+)
+
+
+def _minus_llr_avg(df) -> np.ndarray:
+    """Directional mendelian baseline (iter2's non-``--abs_llr`` path)."""
+    return (-(df["llr_fwd"] + df["llr_rc"]) / 2.0).to_numpy()
+
+
+def main() -> None:
+    ref = pl.read_parquet(ITER2).to_pandas()
+    # llr_perchrom is computed once per subset in iter2 (same across reps); the
+    # `delta` rep is the directional analog of the productionized minus_llr feature.
+    ref_llr = ref.groupby("subset")["llr_perchrom"].first()
+    ref_probe_delta = ref[ref["rep"] == "entire_window/delta"].set_index("subset")[
+        "probe_perchrom"
+    ]
+    subsets = sorted(ref_llr.index)
+
+    # --- Check 1: bit-for-bit on #314's own scores ------------------------------
+    print("[1] library metric on #314's own iter1-OOF llr  vs  #314 saved llr_perchrom")
+    print(f"    {'subset':36s} {'n':>5s} {'mine':>10s} {'#314':>10s} {'Δ':>11s}")
+    max_anchor = 0.0
+    for s in subsets:
+        d = pl.read_parquet(ITER1_OOF.format(s)).to_pandas()
+        d["chrom"] = d["chrom"].astype(str)
+        y = d["label"].to_numpy().astype(int)
+        mine = per_chrom_weighted_ap(y, _minus_llr_avg(d), d["chrom"].to_numpy())
+        r = float(ref_llr[s])
+        max_anchor = max(max_anchor, abs(mine - r))
+        print(f"    {s:36s} {len(d):5d} {mine:10.6f} {r:10.6f} {mine - r:+11.2e}")
+    print(f"    max |Δ| anchor = {max_anchor:.3e}")
+    assert max_anchor < 1e-9, (
+        f"library per_chrom_weighted_ap does NOT reproduce #314 llr_perchrom on #314's "
+        f"own scores (max |Δ| = {max_anchor:.3e}); the metric and the helper must match"
+    )
+    print("    PASS — library metric == #314 helper, bit-for-bit.\n")
+
+    # --- Check 2: end-to-end on the productionized predictions -------------------
+    pred = pl.read_parquet(PROD).to_pandas()
+    pred["chrom"] = pred["chrom"].astype(str)
+    print("[2] productionized predictions (#320/#330) + library metric  vs  #314 iter2")
+    print(
+        f"    {'subset':36s} {'n':>5s} | {'llr_pc':>8s} {'#314':>8s} {'Δ':>8s} | "
+        f"{'probe_pc':>8s} {'probe_g':>8s} {'#314 Δrep':>9s}"
+    )
+    for s in subsets:
+        d = pred[pred["subset"] == s]
+        y = d["label"].to_numpy().astype(int)
+        ch = d["chrom"].to_numpy()
+        llr_pc = per_chrom_weighted_ap(y, _minus_llr_avg(d), ch)
+        r = float(ref_llr[s])
+        dp = d[d["probe_score"].notna()]
+        if len(dp):
+            yp = dp["label"].to_numpy().astype(int)
+            sp = dp["probe_score"].to_numpy()
+            probe_pc = per_chrom_weighted_ap(yp, sp, dp["chrom"].to_numpy())
+            probe_g = auprc_with_bootstrap_se(
+                yp, sp, dp["match_group"].to_numpy(), n_bootstrap=0
+            )["value"]
+        else:
+            probe_pc = probe_g = float("nan")
+        print(
+            f"    {s:36s} {len(d):5d} | {llr_pc:8.4f} {r:8.4f} {llr_pc - r:+8.4f} | "
+            f"{probe_pc:8.4f} {probe_g:8.4f} {float(ref_probe_delta.get(s, np.nan)):9.4f}"
+        )
+    print(
+        "\n    (probe_pc > probe_g on every subset — the per-chrom>global finding #314 "
+        "productionizes.)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue319_verify_against_314.py
+++ b/scripts/issue319_verify_against_314.py
@@ -71,7 +71,16 @@ def check1_metric_anchor(ref_llr: pd.Series, subsets: list[str]) -> None:
         d = pl.read_parquet(ITER1_OOF.format(s)).to_pandas()
         d["chrom"] = d["chrom"].astype(str)
         y = d["label"].to_numpy().astype(int)
-        mine = per_chrom_weighted_ap(y, _minus_llr_avg(d), d["chrom"].to_numpy())
+        minus_llr = _minus_llr_avg(d)
+        # iter2 computed the saved llr_perchrom with NO finite mask (m = chrom==c);
+        # the library uses the iter3 finite-MASKED variant. They agree bit-for-bit
+        # only where the llr is all-finite (the mask is then a no-op). Assert that
+        # precondition so a non-finite #314 llr surfaces here, not as a phantom
+        # "metric mismatch" below.
+        assert np.isfinite(minus_llr).all(), (
+            f"{s}: non-finite #314 llr breaks the anchor"
+        )
+        mine = per_chrom_weighted_ap(y, minus_llr, d["chrom"].to_numpy())
         r = float(ref_llr[s])
         worst = max(worst, abs(mine - r))
         print(f"    {s:36s} {len(d):5d} {mine:10.6f} {r:10.6f} {mine - r:+11.2e}")
@@ -82,9 +91,9 @@ def check1_metric_anchor(ref_llr: pd.Series, subsets: list[str]) -> None:
     print("    PASS — library metric == #314 helper, bit-for-bit.\n")
 
 
-def check2_probe_vs_matching_arm(ref_concat: pd.Series, subsets: list[str]) -> None:
-    pred = pl.read_parquet(PRED).to_pandas()
-    pred["chrom"] = pred["chrom"].astype(str)
+def check2_probe_vs_matching_arm(
+    pred: pd.DataFrame, ref_concat: pd.Series, subsets: list[str]
+) -> None:
     print(
         f"[2] productionized probe ({PROBE_FEATURE}) per-chrom  vs  #314 concat_ref_delta arm"
     )
@@ -92,9 +101,16 @@ def check2_probe_vs_matching_arm(ref_concat: pd.Series, subsets: list[str]) -> N
         f"    {'subset':36s} {'n':>5s} {'probe_pc':>9s} {'probe_g':>8s} "
         f"{'#314':>8s} {'Δ':>8s}"
     )
-    deltas = []
+    deltas, n_gt = [], 0
     for s in subsets:
         dp = pred[(pred["subset"] == s) & pred["probe_score"].notna()]
+        # The llr-derived `subsets` is ungated; a subset can be below the probe's
+        # min_variants (all-NaN probe_score → empty `dp`) or absent from the
+        # refdelta arm. Skip rather than KeyError / hit auprc's both-classes assert
+        # on an empty frame — per-chrom is probe-gated, the llr anchor isn't.
+        if dp.empty or s not in ref_concat.index:
+            print(f"    {s:36s} {len(dp):5d}  (unprobed / no refdelta ref — skipped)")
+            continue
         y = dp["label"].to_numpy().astype(int)
         sp = dp["probe_score"].to_numpy()
         pc = per_chrom_weighted_ap(y, sp, dp["chrom"].to_numpy())
@@ -103,19 +119,21 @@ def check2_probe_vs_matching_arm(ref_concat: pd.Series, subsets: list[str]) -> N
         ]
         r = float(ref_concat[s])
         deltas.append(abs(pc - r))
-        assert pc > g, f"{s}: per-chrom {pc:.3f} !> global {g:.3f} (the #314 finding)"
+        n_gt += int(pc > g)
         print(f"    {s:36s} {len(dp):5d} {pc:9.4f} {g:8.4f} {r:8.4f} {pc - r:+8.4f}")
     print(f"    mean |Δ| = {np.mean(deltas):.4f}, max |Δ| = {np.max(deltas):.4f}")
+    # per-chrom > global is the #314 calibration *tendency* (and pc drops
+    # single-class chroms that g keeps), not a hard invariant — report the count.
     print(
-        "    (probe per-chrom > global on every subset; ~0.01 from #314's matching arm.)\n"
+        f"    (per-chrom > global on {n_gt}/{len(deltas)} subsets; "
+        "~0.01 from #314's matching arm.)\n"
     )
 
 
-def check3_parent_reproducibility(ref_concat: pd.Series) -> None:
+def check3_parent_reproducibility(saved: pd.DataFrame) -> None:
     print(
         "[3] re-run #320 run_subset_probes on its input embeddings  vs  saved probe_score"
     )
-    saved = pd.read_parquet(PRED, columns=KEY + ["subset", "label", "probe_score"])
     print(
         f"    {'subset':22s} {'n':>5s} {'max|Δscore|':>12s} {'pc(rerun)':>10s} {'pc(saved)':>10s}"
     )
@@ -128,10 +146,17 @@ def check3_parent_reproducibility(ref_concat: pd.Series) -> None:
             min_variants=300,
             min_chroms=3,
             inner_splits=5,
-            n_jobs=4,
+            n_jobs=2,  # local-node etiquette: cap at nproc/2 on the shared 4-vCPU box
         )
         rerun = preds[KEY + ["probe_score"]].rename(columns={"probe_score": "rerun"})
-        sv = saved[saved["subset"] == s].reset_index(drop=True).merge(rerun, on=KEY)
+        # (chrom,pos,ref,alt) is unique within a subset → validate one-to-one so a
+        # duplicate key fails loud instead of silently cartesian-inflating (and
+        # re-weighting) the per-chrom comparison.
+        sv = (
+            saved[saved["subset"] == s]
+            .reset_index(drop=True)
+            .merge(rerun, on=KEY, validate="one_to_one")
+        )
         sv = sv[sv["probe_score"].notna() & sv["rerun"].notna()]
         mad = float((sv["probe_score"] - sv["rerun"]).abs().max())
         y = sv["label"].to_numpy().astype(int)
@@ -153,11 +178,22 @@ def main() -> None:
     ref_concat = rd[rd["rep"] == "entire_window/concat_ref_delta"].set_index("subset")[
         "probe_perchrom"
     ]
+    assert not ref_concat.empty, (
+        "no 'entire_window/concat_ref_delta' rows in the refdelta parquet — the rep "
+        "label or schema changed; check [2] would otherwise KeyError on every subset"
+    )
     subsets = sorted(ref_llr.index)
 
+    # Read the productionized predictions once (column subset) and share across
+    # checks [2] and [3] rather than re-reading the S3 object twice.
+    pred = pd.read_parquet(
+        PRED, columns=KEY + ["subset", "label", "match_group", "probe_score"]
+    )
+    pred["chrom"] = pred["chrom"].astype(str)
+
     check1_metric_anchor(ref_llr, subsets)
-    check2_probe_vs_matching_arm(ref_concat, subsets)
-    check3_parent_reproducibility(ref_concat)
+    check2_probe_vs_matching_arm(pred, ref_concat, subsets)
+    check3_parent_reproducibility(pred)
 
 
 if __name__ == "__main__":

--- a/src/marin_dna/pipelines/evals/metrics.py
+++ b/src/marin_dna/pipelines/evals/metrics.py
@@ -7,7 +7,11 @@ Four metric families live here:
   matched-pair clustering). Used by the ``evals_v2``, ``conservation_eval``,
   and ``alphagenome_eval`` pipelines on the matched-pair datasets
   (``mendelian_traits`` / ``complex_traits``), whose 1:k structure (PR #194)
-  the Wald-binomial pairwise metric can't represent.
+  the Wald-binomial pairwise metric can't represent. ``per_chrom_weighted_ap``
+  is the within-chromosome, sample-size-weighted AUPRC — the headline metric of
+  the #314/#319 frozen-embedding linear-probe protocol; scoring within each
+  chromosome sidesteps the cross-chromosome score-calibration artifact that
+  biases the global pooled AUPRC.
 - ``compute_qtl_metrics``: global AUPRC (plain row bootstrap) plus Pearson /
   Spearman of the model score vs ``effect_size`` over the positive variants
   only. For the unmatched DART-Eval QTL datasets (``caqtl`` / ``dsqtl``,
@@ -221,6 +225,60 @@ def auprc_with_bootstrap_se(
         "n_groups": int(n_groups),
         "n_rows": int(len(label_arr)),
     }
+
+
+def per_chrom_weighted_ap(
+    y: np.ndarray,
+    score: np.ndarray,
+    chrom: np.ndarray,
+) -> float:
+    """Per-chromosome-weighted AUPRC — the #314/#319 linear-probe headline metric.
+
+    For each unique chromosome, computes ``average_precision_score`` over that
+    chromosome's finite-score variants, then returns the mean of those
+    per-chromosome AUPRCs weighted by each chromosome's (finite-score) variant
+    count.
+
+    Why per-chromosome rather than a single global pooled AUPRC: pooling
+    variants across chromosomes lets a cross-fold score-calibration offset
+    masquerade as discrimination, systematically *understating* a probe that is
+    well-calibrated *within* each chromosome (#314 saw e.g. exp166-4B 5'UTR
+    global 0.134 vs per-chrom 0.322). Scoring within each chromosome and then
+    size-weighting removes that artifact. This is TraitGym's metric and the
+    single headline number for the protocol.
+
+    Chromosomes lacking both classes among their finite-score variants are
+    skipped (AUPRC is undefined on a single class). Non-finite scores (NaN /
+    ±inf) are dropped per chromosome — the ``iter3`` finite-score guard — so an
+    unaligned or uncomputable locus neither counts as a class member nor enters
+    the size weight.
+
+    Args:
+        y: 0/1 (or bool) label per variant.
+        score: numeric score per variant; non-finite entries are dropped.
+        chrom: chromosome id per variant (any comparable dtype — string names
+            like ``"chr1"`` or ints).
+
+    Returns:
+        Sample-size-weighted mean of the per-chromosome AUPRCs, or ``nan`` when
+        no chromosome has both classes among its finite-score variants.
+    """
+    y = np.asarray(y)
+    score = np.asarray(score, dtype=float)
+    chrom = np.asarray(chrom)
+    assert len(y) == len(score) == len(chrom), (
+        f"length mismatch: y={len(y)} score={len(score)} chrom={len(chrom)}"
+    )
+    total, weight = 0.0, 0
+    for c in np.unique(chrom):
+        keep = (chrom == c) & np.isfinite(score)
+        n = int(keep.sum())
+        # Skip a chromosome unless it carries at least one of each class among
+        # its finite-score variants — AUPRC is undefined on a single class.
+        if 0 < int(y[keep].sum()) < n:
+            total += float(average_precision_score(y[keep], score[keep])) * n
+            weight += n
+    return total / weight if weight else float("nan")
 
 
 def paired_metric_delta_bootstrap(

--- a/src/marin_dna/pipelines/evals/metrics.py
+++ b/src/marin_dna/pipelines/evals/metrics.py
@@ -263,11 +263,19 @@ def per_chrom_weighted_ap(
         Sample-size-weighted mean of the per-chromosome AUPRCs, or ``nan`` when
         no chromosome has both classes among its finite-score variants.
     """
-    y = np.asarray(y)
+    # Labels must be 0/1 (or bool). Cast like the module's other metrics
+    # (``auprc_with_bootstrap_se``) so a 0/1-valued object/float column still
+    # works, then fail loud on a non-binary encoding: an un-cast object/str label
+    # would make ``y[keep].sum()`` string-concatenate and silently skip every
+    # chromosome (a wrong ``nan``) instead of raising.
+    y = np.asarray(y).astype(int)
     score = np.asarray(score, dtype=float)
     chrom = np.asarray(chrom)
     assert len(y) == len(score) == len(chrom), (
         f"length mismatch: y={len(y)} score={len(score)} chrom={len(chrom)}"
+    )
+    assert np.isin(y, (0, 1)).all(), (
+        f"labels must be 0/1 (or bool), got values={np.unique(y)[:5]}"
     )
     total, weight = 0.0, 0
     for c in np.unique(chrom):

--- a/tests/pipelines/evals/test_metrics.py
+++ b/tests/pipelines/evals/test_metrics.py
@@ -24,6 +24,7 @@ from marin_dna.pipelines.evals.metrics import (
     compute_qtl_metrics,
     compute_sge_metrics,
     paired_metric_delta_bootstrap,
+    per_chrom_weighted_ap,
 )
 
 
@@ -886,3 +887,127 @@ def test_sge_seed_reproducibility():
     a = compute_sge_metrics(dataset, scores, n_bootstrap=50, rng=0)
     b = compute_sge_metrics(dataset, scores, n_bootstrap=50, rng=0)
     pd.testing.assert_frame_equal(a, b)
+
+
+# ---------------------------------------------------------------------------
+# per_chrom_weighted_ap (TraitGym / #314 linear-probe headline metric)
+# ---------------------------------------------------------------------------
+
+
+def _ref_per_chrom_weighted_ap(
+    y: np.ndarray, score: np.ndarray, chrom: np.ndarray
+) -> float:
+    """Verbatim copy of the iter3 inlined helper (the finite-score-guard variant
+    from ``scripts/issue314/iter3_transfer.py``) — the bit-for-bit reference the
+    library function must reproduce."""
+    tot, w = 0.0, 0
+    for c in np.unique(chrom):
+        m = (chrom == c) & np.isfinite(score)
+        if 0 < int(y[m].sum()) < int(m.sum()):
+            tot += average_precision_score(y[m], score[m]) * int(m.sum())
+            w += int(m.sum())
+    return tot / w if w else float("nan")
+
+
+def test_per_chrom_weighted_ap_perfect_separation():
+    """Within every chromosome positives outscore negatives → each chrom AUPRC=1
+    → weighted mean 1.0, regardless of the (unequal) chromosome sizes."""
+    y = np.array([1, 1, 0, 0, 0, 1, 0, 0])
+    score = np.array([0.9, 0.8, 0.2, 0.1, 0.3, 0.95, 0.05, 0.15])
+    chrom = np.array(["chr1", "chr1", "chr1", "chr1", "chr1", "chr2", "chr2", "chr2"])
+    assert per_chrom_weighted_ap(y, score, chrom) == pytest.approx(1.0)
+
+
+def test_per_chrom_weighted_ap_single_class_chrom_skipped():
+    """A chromosome with only one class is dropped: the result is exactly the
+    AUPRC of the lone both-class chromosome (the skipped one adds no weight)."""
+    y = np.array([1, 1, 0, 0, 1, 1, 1, 1])
+    score = np.array([0.9, 0.3, 0.6, 0.2, 0.7, 0.5, 0.4, 0.8])
+    chrom = np.array(["chr1"] * 5 + ["chr2"] * 3)  # chr2 is all-positive → skipped
+    m1 = chrom == "chr1"
+    expected = average_precision_score(y[m1], score[m1])
+    assert per_chrom_weighted_ap(y, score, chrom) == pytest.approx(expected)
+
+
+def test_per_chrom_weighted_ap_size_weighted_not_equal_weighted():
+    """The mean is weighted by chromosome size: two both-class chromosomes of
+    different sizes and different AUPRCs → the result is the size-weighted mean
+    and differs from the plain (equal-weight) mean."""
+    # chr1: 10 variants, imperfect ranking. chr2: 4 variants, perfect ranking.
+    y1 = np.array([1, 0, 1, 0, 0, 1, 0, 0, 0, 0])
+    s1 = np.array([0.5, 0.9, 0.4, 0.3, 0.2, 0.8, 0.1, 0.05, 0.6, 0.7])
+    y2 = np.array([1, 0, 1, 0])
+    s2 = np.array([0.9, 0.1, 0.8, 0.2])
+    y = np.concatenate([y1, y2])
+    score = np.concatenate([s1, s2])
+    chrom = np.array(["chr1"] * len(y1) + ["chr2"] * len(y2))
+    ap1 = average_precision_score(y1, s1)
+    ap2 = average_precision_score(y2, s2)
+    n1, n2 = len(y1), len(y2)
+    expected = (ap1 * n1 + ap2 * n2) / (n1 + n2)
+    got = per_chrom_weighted_ap(y, score, chrom)
+    assert got == pytest.approx(expected)
+    # Guard the fixture: the chroms must actually differ in AUPRC and size, so
+    # the test genuinely separates size-weighting from equal-weighting.
+    assert ap1 != pytest.approx(ap2) and n1 != n2
+    assert got != pytest.approx((ap1 + ap2) / 2)
+
+
+def test_per_chrom_weighted_ap_nonfinite_scores_dropped():
+    """Non-finite scores (NaN, ±inf) are excluded per chromosome — they neither
+    count toward a class nor toward the size weight; a chromosome left
+    single-class after the drop is skipped."""
+    # chr1: a NaN and a +inf dropped → finite rows [0.9 (pos), 0.2 (neg)] → AP=1, n=2.
+    y1 = np.array([1, 1, 0, 0])
+    s1 = np.array([0.9, np.nan, 0.2, np.inf])
+    # chr2: a -inf dropped → finite labels [1, 0, 0], scores [0.5, 0.6, 0.4].
+    y2 = np.array([1, 0, 1, 0])
+    s2 = np.array([0.5, 0.6, -np.inf, 0.4])
+    # chr3: its only finite-score row is a positive → single class → skipped.
+    y3 = np.array([1, 1])
+    s3 = np.array([np.nan, 0.5])
+    y = np.concatenate([y1, y2, y3])
+    score = np.concatenate([s1, s2, s3])
+    chrom = np.array(["chr1"] * 4 + ["chr2"] * 4 + ["chr3"] * 2)
+
+    f1, f2 = np.isfinite(s1), np.isfinite(s2)
+    ap1, n1 = average_precision_score(y1[f1], s1[f1]), int(f1.sum())
+    ap2, n2 = average_precision_score(y2[f2], s2[f2]), int(f2.sum())
+    expected = (ap1 * n1 + ap2 * n2) / (n1 + n2)  # chr3 contributes nothing
+    assert per_chrom_weighted_ap(y, score, chrom) == pytest.approx(expected)
+
+
+def test_per_chrom_weighted_ap_all_single_class_returns_nan():
+    """No chromosome has both classes → undefined → nan (not 0, not a crash)."""
+    y = np.array([1, 1, 0, 0])
+    score = np.array([0.9, 0.8, 0.2, 0.1])
+    chrom = np.array(["chr1", "chr1", "chr2", "chr2"])  # chr1 all-pos, chr2 all-neg
+    assert math.isnan(per_chrom_weighted_ap(y, score, chrom))
+
+
+def test_per_chrom_weighted_ap_length_mismatch_raises():
+    with pytest.raises(AssertionError, match="length mismatch"):
+        per_chrom_weighted_ap(
+            np.array([1, 0, 1]),
+            np.array([0.5, 0.5]),
+            np.array(["chr1", "chr1", "chr2"]),
+        )
+
+
+@pytest.mark.parametrize("seed", [0, 1, 7])
+def test_per_chrom_weighted_ap_matches_inlined_reference(seed: int):
+    """Bit-for-bit agreement with the verbatim iter3 helper on a randomized
+    fixture spanning non-finite scores and a forced single-class chromosome
+    (the issue's stated verification)."""
+    rng = np.random.default_rng(seed)
+    n = 200
+    y = (rng.random(n) < 0.3).astype(int)
+    score = rng.normal(size=n)
+    score[rng.choice(n, size=15, replace=False)] = np.nan
+    score[rng.choice(n, size=5, replace=False)] = np.inf
+    chrom = rng.choice(["chr1", "chr2", "chr3", "chr4"], size=n)
+    chrom[:6] = "chrX"  # force a single-class chromosome into the mix
+    y[:6] = 1
+    got = per_chrom_weighted_ap(y, score, chrom)
+    expected = _ref_per_chrom_weighted_ap(y, score, chrom)
+    assert got == pytest.approx(expected, nan_ok=True)

--- a/tests/pipelines/evals/test_metrics.py
+++ b/tests/pipelines/evals/test_metrics.py
@@ -897,9 +897,10 @@ def test_sge_seed_reproducibility():
 def _ref_per_chrom_weighted_ap(
     y: np.ndarray, score: np.ndarray, chrom: np.ndarray
 ) -> float:
-    """Verbatim copy of the iter3 inlined helper (the finite-score-guard variant
-    from ``scripts/issue314/iter3_transfer.py``) — the bit-for-bit reference the
-    library function must reproduce."""
+    """Verbatim copy of the iter3 inlined helper (the finite-score-guard variant) —
+    the bit-for-bit reference the library function must reproduce. The source lives
+    on the #314 branch, not ``main``: ``scripts/issue314/iter3_transfer.py`` at commit
+    e963ebd (.../blob/e963ebd/scripts/issue314/iter3_transfer.py#L35-L42)."""
     tot, w = 0.0, 0
     for c in np.unique(chrom):
         m = (chrom == c) & np.isfinite(score)
@@ -1011,3 +1012,15 @@ def test_per_chrom_weighted_ap_matches_inlined_reference(seed: int):
     got = per_chrom_weighted_ap(y, score, chrom)
     expected = _ref_per_chrom_weighted_ap(y, score, chrom)
     assert got == pytest.approx(expected, nan_ok=True)
+
+
+def test_per_chrom_weighted_ap_non_binary_labels_raise():
+    """Labels outside {0, 1} fail loud rather than silently mis-skipping a
+    chromosome — an un-cast object/str column or a {0, 2} encoding would otherwise
+    corrupt the size-weighted mean (silently, via a string-concatenated sum)."""
+    with pytest.raises(AssertionError, match="labels must be 0/1"):
+        per_chrom_weighted_ap(
+            np.array([2, 0, 2, 0]),
+            np.array([0.9, 0.2, 0.8, 0.1]),
+            np.array(["chr1", "chr1", "chr1", "chr1"]),
+        )


### PR DESCRIPTION
🤖 Productionizes the per-chromosome-weighted AUPRC — the single headline metric of the #314 frozen-embedding linear-probe VEP protocol — into the tested library.

## What

- `per_chrom_weighted_ap(y, score, chrom) -> float` added to `src/marin_dna/pipelines/evals/metrics.py`: AUPRC computed *within* each chromosome over its finite-score variants, then a **sample-size-weighted** mean across chromosomes. Chromosomes lacking both classes (after dropping non-finite scores) are skipped; returns `nan` if none qualify. This is the **iter3** variant — it carries the finite-score guard (`& np.isfinite(score)`), so NaN/±inf scores neither count toward a class nor enter the size weight.
- Until now this lived only as a duplicated, untested inlined helper in two `scripts/issue314/*` files (off `main`).

## Why per-chromosome

#314 found a single global pooled AUPRC systematically **understates** the probe — a cross-fold score-calibration offset masquerades as lost discrimination. Scoring within each chromosome then size-weighting removes that artifact (e.g. exp166-4B 5′UTR: global 0.134 → per-chrom 0.322). Per #319 this is **the** metric for the protocol; the general-purpose `auprc_with_bootstrap_se` stays in the library for the matched-pair pipelines but is not part of this protocol's reporting.

## Tests (`test_metrics.py`)

Perfect separation → 1.0; single-class chromosome skipped; size-weighting ≠ equal-weighting; non-finite (NaN/±inf) scores dropped per chromosome (single-class-after-drop skipped); all-single-class → `nan`; length-mismatch assert; and **bit-for-bit** agreement with a verbatim copy of the inlined iter3 helper across seeds.

`uv run pytest tests/pipelines/evals/test_metrics.py` → 54 passed.

## Follow-up (not in this PR)

Scope item 3 — swapping the two `scripts/issue314/{iter2_nested,iter3_transfer}.py` inlined helpers to import this function — lands on the `claude/issue-314-linear-probe-vep` branch once this is on `main` (the only branch those scripts exist on).

Closes #319.
