### PR TITLE
evals_v2: per-subset per-chrom-weighted AUPRC metrics rule for the frozen-embedding probe

### DIFF
--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -273,7 +273,7 @@ results/probe/{model}/{dataset}.joblib    # {subset: {pipeline, C, feature, n, n
 ```
 
 The predictions parquet (the LOOC `probe_score` per variant) is consumed by the
-**downstream metrics step** (a separate issue); the joblib classifiers are
+**`compute_probe_metrics`** rule below; the joblib classifiers are
 serialized for **reuse on other datasets**. Configured under `probe:` in
 `config.yaml` (`min_variants`, `min_chroms`, `c_grid` = `logspace(lo, hi, num)`,
 `inner_splits`, `n_jobs`, and `models: [{name, datasets}]` — datasets listed
@@ -290,6 +290,31 @@ snakemake results/probe/<model>/<dataset>.parquet --rerun-triggers mtime   # one
 # A cell whose scores parquet predates the embeddings must be re-scored first:
 snakemake --configfile ../../../scripts/issue318_embed_overlay.yaml --forcerun \
   compute_scores -- results/scores/<model>/<dataset>.parquet
+```
+
+### Linear-probe metrics (per-subset per-chrom AUPRC, #331/#341)
+
+`snakemake probe_metrics` scores the probe against its matched zero-shot LLR
+baseline, per `(model, dataset)`, also **off `rule all`**. The `compute_probe_metrics`
+rule reads a `results/probe/{model}/{dataset}.parquet` — which carries **both**
+`probe_score` **and** the raw `llr_fwd`/`llr_rc` atoms (only `emb_ref`/`emb_alt` are
+dropped) — so the probe and its baseline are scored on **identical rows** under one
+metric. It emits, per consequence `subset`, the **per-chromosome-weighted AUPRC** (the
+TraitGym / #314 headline; `marin_dna.pipelines.evals.metrics.per_chrom_ap_table` →
+`per_chrom_weighted_ap`) for two score types: `probe_score` and the dataset's
+zero-shot baseline (its `score_protocol` applied to the FWD/RC-averaged LLR, e.g.
+`minus_llr_avg` for mendelian). `matched_pair` datasets only (needs `subset` + `chrom`;
+`qtl_global`/`sge` are rejected).
+
+```
+results/probe_metrics/{model}/{dataset}.parquet   # [score_type, subset, value, n, n_pos, n_chrom, model, dataset, split]
+```
+
+```bash
+# Same `--rerun-triggers mtime` note as `probe` (its upstream scores parquet was
+# built with the embedding overlay, differing from the committed default).
+snakemake probe_metrics --rerun-triggers mtime                                    # all configured probe cells
+snakemake results/probe_metrics/<model>/<dataset>.parquet --rerun-triggers mtime  # one cell
 ```
 
 ### Parallel sky-cluster sweep (one cluster per target)

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -18,6 +18,7 @@ from marin_dna.pipelines.evals.metrics import (
     compute_auprc_metrics,
     compute_qtl_metrics,
     compute_sge_metrics,
+    per_chrom_ap_table,
 )
 from marin_dna.pipelines.evals.variant_probe import PAIR_COMBOS, run_subset_probes
 

--- a/snakemake/analysis/evals_v2/workflow/rules/probe.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/probe.smk
@@ -82,3 +82,71 @@ rule probe:
             for pm in PROBE_MODELS
             for dataset in pm["datasets"]
         ],
+
+
+rule compute_probe_metrics:
+    """Per-subset per-chromosome-weighted AUPRC (#331 / TraitGym) for the probe vs its
+    matched zero-shot LLR baseline — the metrics step of the #320/#331 protocol (wires
+    #319; #341).
+
+    The probe predictions parquet carries BOTH `probe_score` AND the raw `llr_fwd`/
+    `llr_rc` atoms (`compute_probe` drops only `emb_ref`/`emb_alt`), so the probe and
+    its zero-shot baseline are scored on IDENTICAL rows under the identical metric — a
+    paired probe-vs-LLR comparison in one parquet. The baseline is the dataset's own
+    `score_protocol` applied to the FWD/RC-averaged LLR (`minus_llr_avg` for mendelian),
+    matching `compute_metrics`'s `_avg` semantics. The per-subset per-chrom-weighted
+    metric is the matched_pair (subset + chrom) path, so qtl_global/sge are rejected.
+
+    Thin glue over `marin_dna.pipelines.evals.metrics.per_chrom_ap_table`. CPU-only; off
+    `rule all`. Reads a probe parquet, so the same `--rerun-triggers mtime` note as
+    `compute_probe` applies (its upstream scores parquet was built with the #318
+    overlay)."""
+    input:
+        "results/probe/{model}/{dataset}.parquet",
+    output:
+        "results/probe_metrics/{model}/{dataset}.parquet",
+    wildcard_constraints:
+        model="|".join(MODELS),
+        dataset="|".join(DATASETS),
+    params:
+        score_protocol=lambda wc: get_dataset_config(wc.dataset)["score_protocol"],
+    run:
+        eval_protocol = get_dataset_protocol(wildcards.dataset)
+        assert eval_protocol == "matched_pair", (
+            f"compute_probe_metrics is the per-subset per-chrom-weighted AUPRC "
+            f"(matched_pair / TraitGym) path — needs subset + chrom; dataset "
+            f"{wildcards.dataset!r} is eval_protocol {eval_protocol!r}"
+        )
+        transform = SCORE_PROTOCOLS[params.score_protocol]
+        df = pd.read_parquet(input[0])
+        for col in ("probe_score", "label", "subset", "chrom", "llr_fwd", "llr_rc"):
+            assert col in df.columns, (
+                f"{input[0]} missing column {col!r} — expected a compute_probe "
+                f"predictions parquet"
+            )
+        # Zero-shot baseline on the identical rows: the dataset's score protocol applied
+        # to the FWD/RC-averaged raw LLR (== compute_metrics `_avg`).
+        baseline_col = f"{params.score_protocol}_avg"
+        df[baseline_col] = transform((df["llr_fwd"] + df["llr_rc"]) / 2)
+
+        metrics = per_chrom_ap_table(df, ["probe_score", baseline_col])
+        metrics["model"] = wildcards.model
+        metrics["dataset"] = wildcards.dataset
+        metrics["split"] = config["split"]
+        metrics.to_parquet(output[0], index=False)
+        print(
+            f"[evals_v2] probe_metrics {wildcards.model} {wildcards.dataset}: "
+            f"{metrics['subset'].nunique()} subsets × 2 score types "
+            f"(probe_score, {baseline_col})"
+        )
+
+
+rule probe_metrics:
+    """Aggregate convenience target: probe_metrics for every configured probe cell.
+    Not part of `rule all`."""
+    input:
+        [
+            f"results/probe_metrics/{pm['name']}/{dataset}.parquet"
+            for pm in PROBE_MODELS
+            for dataset in pm["datasets"]
+        ],

--- a/src/marin_dna/pipelines/evals/metrics.py
+++ b/src/marin_dna/pipelines/evals/metrics.py
@@ -328,6 +328,15 @@ def per_chrom_ap_table(
         assert col in df.columns, f"df missing required column {col!r}"
     missing = [c for c in score_columns if c not in df.columns]
     assert not missing, f"df missing score columns {missing}"
+    # Fail loud on nulls in the grouping / weighting keys: a null ``subset`` would be
+    # silently dropped by ``groupby`` (pandas ``dropna=True`` default) and a null
+    # ``chrom``/``label`` would mis-weight or mis-count the per-chromosome AUPRC — a
+    # silent-corruption risk (mirrors ``compute_sge_metrics``'s ``subset`` notna guard).
+    for col in (subset_col, chrom_col, label_col):
+        assert df[col].notna().all(), (
+            f"{col!r} contains nulls; per_chrom_ap_table would silently drop / "
+            f"mis-weight those rows — fail loud instead"
+        )
 
     rows: list[dict] = []
     for subset_name, sub in df.groupby(subset_col, sort=False):

--- a/src/marin_dna/pipelines/evals/metrics.py
+++ b/src/marin_dna/pipelines/evals/metrics.py
@@ -289,6 +289,72 @@ def per_chrom_weighted_ap(
     return total / weight if weight else float("nan")
 
 
+def per_chrom_ap_table(
+    df: pd.DataFrame,
+    score_columns: list[str],
+    *,
+    label_col: str = "label",
+    subset_col: str = "subset",
+    chrom_col: str = "chrom",
+) -> pd.DataFrame:
+    """Per-subset per-chromosome-weighted AUPRC for one or more score columns.
+
+    For each ``(subset, score_col)`` this computes ``per_chrom_weighted_ap`` over
+    that subset's rows — the tidy paired-comparison table behind the #341
+    linear-probe scaling-ladder analysis. Pass the ``compute_probe`` predictions
+    frame with ``score_columns=["probe_score", "minus_llr_avg"]`` to get the probe
+    and its matched zero-shot LLR baseline scored on **identical rows** under the
+    identical per-chromosome metric.
+
+    ``n`` / ``n_pos`` / ``n_chrom`` are subset-level counts (independent of the
+    score column) for context; ``value`` is per (subset, score_col) and is
+    ``NaN`` when no chromosome carries both classes among that score's finite
+    values — e.g. a subset whose probe was skipped (all-``NaN`` ``probe_score``),
+    which surfaces as a ``NaN`` probe row beside a finite baseline row.
+
+    Args:
+        df: variant frame with ``label`` / ``subset`` / ``chrom`` columns plus
+            every name in ``score_columns`` (row-aligned).
+        score_columns: score column names to score (e.g. ``probe_score``).
+        label_col: 0/1 label column name.
+        subset_col: consequence-subset column name (the grouping key).
+        chrom_col: chromosome column name (the per-chrom weighting key).
+
+    Returns:
+        DataFrame ``[score_type, subset, value, n, n_pos, n_chrom]``, one row per
+        ``(subset, score_col)`` in first-appearance subset order.
+    """
+    for col in (label_col, subset_col, chrom_col):
+        assert col in df.columns, f"df missing required column {col!r}"
+    missing = [c for c in score_columns if c not in df.columns]
+    assert not missing, f"df missing score columns {missing}"
+
+    rows: list[dict] = []
+    for subset_name, sub in df.groupby(subset_col, sort=False):
+        n = int(len(sub))
+        n_pos = int(np.asarray(sub[label_col]).astype(int).sum())
+        n_chrom = int(pd.unique(sub[chrom_col]).size)
+        for score_col in score_columns:
+            value = per_chrom_weighted_ap(
+                sub[label_col].to_numpy(),
+                sub[score_col].to_numpy(),
+                sub[chrom_col].to_numpy(),
+            )
+            rows.append(
+                {
+                    "score_type": score_col,
+                    "subset": str(subset_name),
+                    "value": value,
+                    "n": n,
+                    "n_pos": n_pos,
+                    "n_chrom": n_chrom,
+                }
+            )
+    return pd.DataFrame(
+        rows, columns=["score_type", "subset", "value", "n", "n_pos", "n_chrom"]
+    )
+
+
 def paired_metric_delta_bootstrap(
     label: pd.Series,
     score_a: pd.Series,

--- a/tests/pipelines/evals/test_metrics.py
+++ b/tests/pipelines/evals/test_metrics.py
@@ -24,6 +24,7 @@ from marin_dna.pipelines.evals.metrics import (
     compute_qtl_metrics,
     compute_sge_metrics,
     paired_metric_delta_bootstrap,
+    per_chrom_ap_table,
     per_chrom_weighted_ap,
 )
 
@@ -1024,3 +1025,99 @@ def test_per_chrom_weighted_ap_non_binary_labels_raise():
             np.array([0.9, 0.2, 0.8, 0.1]),
             np.array(["chr1", "chr1", "chr1", "chr1"]),
         )
+
+
+# ---------------------------------------------------------------------------
+# per_chrom_ap_table (per-subset per-chrom-weighted AUPRC table, #341)
+# ---------------------------------------------------------------------------
+
+
+def _probe_like_frame() -> pd.DataFrame:
+    """Two subsets × two score columns, each subset spanning two chromosomes so the
+    per-chrom weighting is exercised — mirrors the ``compute_probe`` predictions frame
+    (``label`` / ``subset`` / ``chrom`` + score columns)."""
+    return pd.DataFrame(
+        {
+            "label": [1, 1, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0],
+            "subset": ["missense"] * 6 + ["synonymous"] * 6,
+            "chrom": (
+                ["chr1", "chr1", "chr1", "chr2", "chr2", "chr2"]
+                + ["chr1", "chr1", "chr1", "chr3", "chr3", "chr3"]
+            ),
+            "probe_score": [0.9, 0.7, 0.2, 0.3, 0.8, 0.6, 0.4, 0.9, 0.1, 0.7, 0.2, 0.5],
+            "minus_llr_avg": [
+                0.2,
+                0.4,
+                0.8,
+                0.7,
+                0.1,
+                0.3,
+                0.6,
+                0.2,
+                0.9,
+                0.4,
+                0.8,
+                0.5,
+            ],
+        }
+    )
+
+
+def test_per_chrom_ap_table_shape_and_matches_direct():
+    """One row per (subset, score_col); each ``value`` reproduces
+    ``per_chrom_weighted_ap`` called directly on that subset's rows."""
+    df = _probe_like_frame()
+    out = per_chrom_ap_table(df, ["probe_score", "minus_llr_avg"])
+    assert list(out.columns) == [
+        "score_type",
+        "subset",
+        "value",
+        "n",
+        "n_pos",
+        "n_chrom",
+    ]
+    assert len(out) == 4  # 2 subsets × 2 score columns
+    assert set(out["subset"]) == {"missense", "synonymous"}
+    assert set(out["score_type"]) == {"probe_score", "minus_llr_avg"}
+    for (subset, score_type), row in out.set_index(["subset", "score_type"]).iterrows():
+        sub = df[df["subset"] == subset]
+        expected = per_chrom_weighted_ap(
+            sub["label"].to_numpy(),
+            sub[score_type].to_numpy(),
+            sub["chrom"].to_numpy(),
+        )
+        assert row["value"] == pytest.approx(expected)
+    missense = out[out["subset"] == "missense"].iloc[0]
+    assert missense["n"] == 6 and missense["n_pos"] == 3 and missense["n_chrom"] == 2
+
+
+def test_per_chrom_ap_table_all_nan_score_is_nan_row():
+    """A score column that is all-NaN within a subset (a skipped probe) yields a NaN
+    value for that (subset, score) while the baseline stays finite; the subset-level
+    counts are score-independent."""
+    df = _probe_like_frame()
+    df.loc[df["subset"] == "missense", "probe_score"] = np.nan
+    out = per_chrom_ap_table(df, ["probe_score", "minus_llr_avg"])
+    probe_row = out[
+        (out["subset"] == "missense") & (out["score_type"] == "probe_score")
+    ].iloc[0]
+    base_row = out[
+        (out["subset"] == "missense") & (out["score_type"] == "minus_llr_avg")
+    ].iloc[0]
+    assert math.isnan(probe_row["value"])
+    assert np.isfinite(base_row["value"])
+    assert probe_row["n"] == 6 and probe_row["n_pos"] == 3 and probe_row["n_chrom"] == 2
+
+
+def test_per_chrom_ap_table_preserves_subset_order():
+    """Subsets appear in first-appearance order (``groupby(sort=False)``)."""
+    out = per_chrom_ap_table(_probe_like_frame(), ["probe_score"])
+    assert list(out["subset"]) == ["missense", "synonymous"]
+
+
+def test_per_chrom_ap_table_missing_column_raises():
+    """A missing key column or a missing score column fails loud."""
+    with pytest.raises(AssertionError, match="missing required column"):
+        per_chrom_ap_table(_probe_like_frame().drop(columns=["chrom"]), ["probe_score"])
+    with pytest.raises(AssertionError, match="missing score columns"):
+        per_chrom_ap_table(_probe_like_frame(), ["nonexistent"])

--- a/tests/pipelines/evals/test_metrics.py
+++ b/tests/pipelines/evals/test_metrics.py
@@ -1121,3 +1121,13 @@ def test_per_chrom_ap_table_missing_column_raises():
         per_chrom_ap_table(_probe_like_frame().drop(columns=["chrom"]), ["probe_score"])
     with pytest.raises(AssertionError, match="missing score columns"):
         per_chrom_ap_table(_probe_like_frame(), ["nonexistent"])
+
+
+def test_per_chrom_ap_table_null_key_raises():
+    """A null subset / chrom / label fails loud rather than being silently dropped by
+    groupby(dropna) or mis-weighting the per-chrom AUPRC."""
+    for key in ("subset", "chrom", "label"):
+        df = _probe_like_frame()
+        df.loc[0, key] = None
+        with pytest.raises(AssertionError, match="contains nulls"):
+            per_chrom_ap_table(df, ["probe_score"])


### PR DESCRIPTION
## What

Wires the frozen-embedding linear-probe **metrics step** into `evals_v2`: a `compute_probe_metrics` rule + `probe_metrics` target that emit **per-subset per-chromosome-weighted AUPRC** (#331 / TraitGym) for the probe (`probe_score`) vs its matched zero-shot LLR baseline, from one `compute_probe` predictions parquet.

## Why

#321 productionized the probe protocol as inference (#318) → probe training (#320) → metrics (#319/#331). #331 library-homed `per_chrom_weighted_ap`, but nothing yet consumed `probe_score` into an AUPRC parquet — `compute_metrics` only reads `results/scores/` (the zero-shot leaderboard path). This closes that gap so the probe has a first-class, tested metrics output.

## Contents (core only — no analysis config / plots / overlays)

- **`per_chrom_ap_table`** (`src/marin_dna/pipelines/evals/metrics.py`) — a thin loop over consequence `subset`s calling the existing `per_chrom_weighted_ap` per `(subset, score_col)`, returning a tidy `[score_type, subset, value, n, n_pos, n_chrom]` frame. +4 unit tests (matches-direct, all-NaN→NaN row, order, missing-column).
- **`compute_probe_metrics` rule + `probe_metrics` target** (`snakemake/analysis/evals_v2/workflow/rules/probe.smk`) — reads `results/probe/{model}/{dataset}.parquet` (which carries **both** `probe_score` **and** the raw `llr_*` atoms — `compute_probe` drops only `emb_ref`/`emb_alt`), derives the dataset's zero-shot baseline (`score_protocol` on the FWD/RC-avg LLR, e.g. `minus_llr_avg`), and scores both on **identical rows** under the identical per-chrom metric. `matched_pair` datasets only (needs `subset` + `chrom`); off `rule all`. README documents it.

## Validation

Exercised end-to-end across the 8-rung scaling ladder in #341 (reproduced the #302 readout-localized missense degradation through this rule). `uv run pytest tests/pipelines/evals/test_metrics.py` → 59 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
