### PR TITLE
evals_v2: chromosome-cluster bootstrap SE + macro-avg row for the frozen-embedding probe metric

### DIFF
--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -1208,6 +1208,14 @@ probe:
                           # Edge-pinned C is recorded per subset as a diagnostic (low
                           # = ~no signal, high = minimal reg), not a truncation.
   inner_splits: 5         # inner GroupKFold splits for the per-fold C GridSearchCV.
+  # --- compute_probe_metrics knobs (chrom-cluster bootstrap SE + macro-avg row, #347) ---
+  n_bootstrap: 1000       # chromosome-cluster bootstrap iterations for the per-subset AND
+                          # joint macro-avg AUPRC SE. Output-affecting → a `params` rerun
+                          # trigger; the rng seed is pinned to 0 in-rule for bit-stable
+                          # re-runs.
+  n_min: 30               # min positives for a subset to enter the macro average
+                          # (project-wide leaderboard convention; 300-variant 1:9 ⇒ ~30,
+                          # matching the min_variants probe-training gate above).
   n_jobs: 4               # GridSearchCV parallelism. Execution-only (not output-
                           # affecting) → read via the rule's `threads`, so tuning it
                           # never forces a re-run. The shared dev box is 4-vCPU; bump

--- a/snakemake/analysis/evals_v2/workflow/rules/probe.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/probe.smk
@@ -85,8 +85,9 @@ rule probe:
 
 
 rule compute_probe_metrics:
-    """Per-subset per-chromosome-weighted AUPRC (#331 / TraitGym) for the probe vs its
-    matched zero-shot LLR baseline — the metrics step of the #320/#331 protocol (wires
+    """Per-subset per-chromosome-weighted AUPRC + chromosome-cluster bootstrap SE and a
+    `_macro_avg_` aggregate row (#331 / TraitGym; SE + macro per #347) for the probe vs
+    its matched zero-shot LLR baseline — the metrics step of the #320/#331 protocol (wires
     #319; #341).
 
     The probe predictions parquet carries BOTH `probe_score` AND the raw `llr_fwd`/
@@ -110,6 +111,8 @@ rule compute_probe_metrics:
         dataset="|".join(DATASETS),
     params:
         score_protocol=lambda wc: get_dataset_config(wc.dataset)["score_protocol"],
+        n_bootstrap=config["probe"]["n_bootstrap"],
+        n_min=config["probe"]["n_min"],
     run:
         eval_protocol = get_dataset_protocol(wildcards.dataset)
         assert eval_protocol == "matched_pair", (
@@ -129,15 +132,22 @@ rule compute_probe_metrics:
         baseline_col = f"{params.score_protocol}_avg"
         df[baseline_col] = transform((df["llr_fwd"] + df["llr_rc"]) / 2)
 
-        metrics = per_chrom_ap_table(df, ["probe_score", baseline_col])
+        metrics = per_chrom_ap_table(
+            df,
+            ["probe_score", baseline_col],
+            n_bootstrap=params.n_bootstrap,
+            rng=0,
+            n_min=params.n_min,
+        )
         metrics["model"] = wildcards.model
         metrics["dataset"] = wildcards.dataset
         metrics["split"] = config["split"]
         metrics.to_parquet(output[0], index=False)
         print(
             f"[evals_v2] probe_metrics {wildcards.model} {wildcards.dataset}: "
-            f"{metrics['subset'].nunique()} subsets × 2 score types "
-            f"(probe_score, {baseline_col})"
+            f"{len(metrics)} rows (per-subset + macro_avg × 2 score types: "
+            f"probe_score, {baseline_col}); SE from {params.n_bootstrap} "
+            f"chromosome-cluster bootstraps"
         )
 
 

--- a/src/marin_dna/pipelines/evals/metrics.py
+++ b/src/marin_dna/pipelines/evals/metrics.py
@@ -339,7 +339,7 @@ def _per_chrom_cluster_bootstrap_se(
     ap: np.ndarray,
     weight: np.ndarray,
     n_bootstrap: int,
-    gen: np.random.Generator,
+    rng: np.random.Generator | int | None,
 ) -> float:
     """Chromosome-cluster bootstrap SE of a subset's per-chromosome-weighted AUPRC.
 
@@ -348,10 +348,18 @@ def _per_chrom_cluster_bootstrap_se(
     returns the ``ddof=1`` std of the resampled weighted means. ``nan`` when
     ``n_bootstrap <= 0`` or fewer than two chromosomes contribute — a cluster-bootstrap
     SE needs at least two clusters.
+
+    A fresh ``default_rng(rng)`` is constructed here rather than threaded in from the
+    caller, so this cell's SE is a pure function of its own data + seed — independent of
+    how many other cells were bootstrapped before it (mirrors ``auprc_with_bootstrap_se``,
+    which ``compute_auprc_metrics`` calls once per cell). With an ``int`` seed the shared
+    value only correlates the per-iteration noise across cells; it doesn't couple their
+    data or make one cell's SE depend on the ``score_columns`` order.
     """
     m = len(ap)
     if n_bootstrap <= 0 or m < 2:
         return float("nan")
+    gen = np.random.default_rng(rng)
     boot = np.empty(n_bootstrap, dtype=float)
     for b in range(n_bootstrap):
         idx = gen.integers(0, m, size=m)
@@ -362,7 +370,7 @@ def _per_chrom_cluster_bootstrap_se(
 def _macro_joint_chrom_bootstrap_se(
     components: list[tuple[np.ndarray, np.ndarray, np.ndarray]],
     n_bootstrap: int,
-    gen: np.random.Generator,
+    rng: np.random.Generator | int | None,
 ) -> float:
     """Joint chromosome-cluster bootstrap SE of the macro-average AUPRC.
 
@@ -375,8 +383,17 @@ def _macro_joint_chrom_bootstrap_se(
     together, and the SE reflects that coupling. ``nan`` when ``n_bootstrap <= 0`` or the
     union has fewer than two chromosomes.
 
+    Every retained iteration averages over ALL K subsets (like the point macro), so the
+    bootstrap stays centered on the point estimate. A draw that assigns multiplicity 0 to
+    every chromosome some subset owns leaves that subset undefined; that whole draw is
+    dropped (``nan``) rather than averaging the survivors — averaging survivors would bias
+    the center toward a smaller-K macro and let subset-dropout masquerade as sampling
+    noise. Under the heavy chromosome overlap of genome-wide consequence subsets this is
+    vanishingly rare (only near-disjoint chromosome sets trigger it).
+
     ``components`` is the list of ``(chroms, ap, weight)`` from ``_per_chrom_components``
-    for the qualifying subsets (those entering the macro average).
+    for the qualifying subsets. A fresh ``default_rng(rng)`` is constructed here so the
+    macro SE is order-independent (see ``_per_chrom_cluster_bootstrap_se``).
     """
     if n_bootstrap <= 0:
         return float("nan")
@@ -396,13 +413,16 @@ def _macro_joint_chrom_bootstrap_se(
             ap_u[pos[c]] = a
             w_u[pos[c]] = wi
         aligned.append((ap_u, w_u))
+    gen = np.random.default_rng(rng)
     boot = np.empty(n_bootstrap, dtype=float)
     for b in range(n_bootstrap):
         mult = np.bincount(
             gen.integers(0, n_union, size=n_union), minlength=n_union
         ).astype(float)
         vals = np.array([_weighted_ap(ap_u, w_u, mult) for ap_u, w_u in aligned])
-        boot[b] = float(np.nanmean(vals)) if np.isfinite(vals).any() else np.nan
+        # Keep the draw only if every subset is defined under it, so each retained macro is
+        # a fixed-K mean centered on the point estimate; a dropped-out subset voids the draw.
+        boot[b] = float(np.mean(vals)) if np.isfinite(vals).all() else np.nan
     return float(np.nanstd(boot, ddof=1))
 
 
@@ -431,11 +451,15 @@ def per_chrom_ap_table(
     disjoint-cluster SE-of-mean formula (``compute_auprc_metrics``) would misstate it.
     **No ``_global_`` row** — probe scores come from a separate per-subset classifier, so a
     pooled global ranking is undefined (unlike the matched-pair leaderboard). The macro row
-    keeps honest ``n`` / ``n_pos`` sums (the dashboard read layer overloads the displayed
-    ``n`` to K, as it already does for the matched-pair macro).
+    keeps honest ``n`` / ``n_pos`` sums and an all-chromosomes ``n_chrom`` (the #348 dashboard
+    read layer will overload the displayed ``n`` to K, as ``fetch_method_metrics`` already
+    does for the matched-pair macro).
 
     ``n`` / ``n_pos`` / ``n_chrom`` are subset-level counts (independent of the score
-    column); ``value`` / ``se`` are per ``(subset, score_col)`` and ``NaN`` when no
+    column); on the ``_macro_avg_`` row ``n`` / ``n_pos`` are sums over the qualifying
+    subsets and ``n_chrom`` is the count of distinct chromosomes across them (same
+    all-chromosomes sense as the per-subset ``n_chrom``, deduped). ``value`` / ``se`` are
+    per ``(subset, score_col)`` and ``NaN`` when no
     chromosome carries both classes among that score's finite values (e.g. a skipped
     probe's all-``NaN`` ``probe_score`` beside a finite baseline row). ``se`` is also
     ``NaN`` when ``n_bootstrap <= 0`` or fewer than two chromosomes contribute.
@@ -449,9 +473,11 @@ def per_chrom_ap_table(
         chrom_col: chromosome column name (per-chrom weighting + bootstrap-cluster key).
         n_bootstrap: chromosome-cluster bootstrap iterations; ``<= 0`` skips the resample
             (``se = NaN``, point estimates only) — the macro row is still emitted.
-        rng: ``numpy.random.Generator``, seed int, or ``None``. ``0`` (default) →
-            reproducible across re-runs (bit-stable pipeline output); ``None`` → fresh
-            randomness.
+        rng: seed int (recommended), ``numpy.random.Generator``, or ``None``. Each SE
+            builds its own ``default_rng(rng)``, so with an ``int`` seed (``0`` default →
+            bit-stable pipeline output) every cell's SE is reproducible AND independent of
+            the ``score_columns`` order; ``None`` → fresh randomness. Passing a live
+            ``Generator`` re-couples cells to draw order (as in ``auprc_with_bootstrap_se``).
         n_min: minimum ``n_pos`` for a subset to enter the macro average. Default 30
             (project-wide leaderboard convention; a 300-variant 1:9-matched subset ⇒ ~30
             positives, matching the probe's ``min_variants`` gate).
@@ -475,18 +501,20 @@ def per_chrom_ap_table(
             f"mis-weight those rows — fail loud instead"
         )
 
-    gen = np.random.default_rng(rng)
     rows: list[dict] = []
     # Per score column, gather the qualifying subsets' components (for the joint macro
-    # bootstrap), point values (for the macro mean), and counts — in first-appearance
-    # order so the macro is deterministic.
+    # bootstrap), point values (for the macro mean), counts, and the union of their (all)
+    # chromosomes (for the macro's n_chrom) — in first-appearance order so the macro is
+    # deterministic.
     qual_components: dict[str, list[tuple]] = {sc: [] for sc in score_columns}
     qual_values: dict[str, list[float]] = {sc: [] for sc in score_columns}
     qual_counts: dict[str, list[tuple[int, int]]] = {sc: [] for sc in score_columns}
+    qual_chroms: dict[str, set] = {sc: set() for sc in score_columns}
     for subset_name, sub in df.groupby(subset_col, sort=False):
         n = int(len(sub))
         n_pos = int(np.asarray(sub[label_col]).astype(int).sum())
-        n_chrom = int(pd.unique(sub[chrom_col]).size)
+        sub_chroms = pd.unique(sub[chrom_col])
+        n_chrom = int(sub_chroms.size)
         for score_col in score_columns:
             chroms, ap, weight = _per_chrom_components(
                 sub[label_col].to_numpy(),
@@ -494,7 +522,9 @@ def per_chrom_ap_table(
                 sub[chrom_col].to_numpy(),
             )
             value = _weighted_ap(ap, weight)
-            se = _per_chrom_cluster_bootstrap_se(ap, weight, n_bootstrap, gen)
+            # A fresh default_rng(rng) is built inside the helper per call, so this cell's
+            # SE doesn't depend on the score_columns order (see _per_chrom_cluster_bootstrap_se).
+            se = _per_chrom_cluster_bootstrap_se(ap, weight, n_bootstrap, rng)
             rows.append(
                 {
                     "score_type": score_col,
@@ -510,19 +540,22 @@ def per_chrom_ap_table(
                 qual_components[score_col].append((chroms, ap, weight))
                 qual_values[score_col].append(value)
                 qual_counts[score_col].append((n, n_pos))
+                qual_chroms[score_col].update(sub_chroms.tolist())
 
     for score_col in score_columns:
         comps = qual_components[score_col]
         if comps:
-            union_chroms = {c for chroms, _, _ in comps for c in chroms.tolist()}
             macro = {
                 "score_type": score_col,
                 "subset": MACRO_AVG_SUBSET,
                 "value": float(np.mean(qual_values[score_col])),
-                "se": _macro_joint_chrom_bootstrap_se(comps, n_bootstrap, gen),
+                "se": _macro_joint_chrom_bootstrap_se(comps, n_bootstrap, rng),
                 "n": sum(n for n, _ in qual_counts[score_col]),
                 "n_pos": sum(n_pos for _, n_pos in qual_counts[score_col]),
-                "n_chrom": len(union_chroms),
+                # All distinct chromosomes across the qualifying subsets (deduped) — same
+                # all-chromosomes sense as the per-subset n_chrom, not the contributing-only
+                # union the joint bootstrap uses internally.
+                "n_chrom": len(qual_chroms[score_col]),
             }
         else:
             # No subset cleared n_min with a finite value — still emit the macro row (NaN)

--- a/src/marin_dna/pipelines/evals/metrics.py
+++ b/src/marin_dna/pipelines/evals/metrics.py
@@ -227,6 +227,74 @@ def auprc_with_bootstrap_se(
     }
 
 
+def _per_chrom_components(
+    y: np.ndarray,
+    score: np.ndarray,
+    chrom: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Per-chromosome AUPRC and finite-score weight for the *contributing* chromosomes.
+
+    The shared primitive behind ``per_chrom_weighted_ap`` (whose value is the
+    weight-average of ``ap``) and ``per_chrom_ap_table``'s chromosome-cluster bootstrap
+    SE. Returns ``(chroms, ap, weight)`` over only the chromosomes that carry both
+    classes among their finite-score variants (``0 < positives < n``); single-class or
+    all-non-finite chromosomes are dropped (AUPRC is undefined there). ``ap[i]`` is
+    chromosome ``chroms[i]``'s AUPRC and ``weight[i]`` its finite-score variant count.
+
+    Because ``average_precision_score`` is invariant to exact row duplication, a
+    chromosome-cluster bootstrap can resample these ``(ap, weight)`` pairs with
+    replacement rather than re-scoring: a chromosome's ``ap`` is fixed, only its weight
+    scales with the resample multiplicity.
+
+    Non-finite scores (NaN / ±inf) are dropped per chromosome — the ``iter3``
+    finite-score guard — so an unaligned or uncomputable locus neither counts as a class
+    member nor enters the size weight.
+    """
+    # Labels must be 0/1 (or bool). Cast like the module's other metrics
+    # (``auprc_with_bootstrap_se``) so a 0/1-valued object/float column still
+    # works, then fail loud on a non-binary encoding: an un-cast object/str label
+    # would make ``y[keep].sum()`` string-concatenate and silently skip every
+    # chromosome (a wrong ``nan``) instead of raising.
+    y = np.asarray(y).astype(int)
+    score = np.asarray(score, dtype=float)
+    chrom = np.asarray(chrom)
+    assert len(y) == len(score) == len(chrom), (
+        f"length mismatch: y={len(y)} score={len(score)} chrom={len(chrom)}"
+    )
+    assert np.isin(y, (0, 1)).all(), (
+        f"labels must be 0/1 (or bool), got values={np.unique(y)[:5]}"
+    )
+    chroms: list = []
+    aps: list[float] = []
+    weights: list[float] = []
+    for c in np.unique(chrom):
+        keep = (chrom == c) & np.isfinite(score)
+        n = int(keep.sum())
+        # Keep a chromosome only if it carries at least one of each class among its
+        # finite-score variants — AUPRC is undefined on a single class.
+        if 0 < int(y[keep].sum()) < n:
+            chroms.append(c)
+            aps.append(float(average_precision_score(y[keep], score[keep])))
+            weights.append(float(n))
+    return (
+        np.asarray(chroms),
+        np.asarray(aps, dtype=float),
+        np.asarray(weights, dtype=float),
+    )
+
+
+def _weighted_ap(
+    ap: np.ndarray, weight: np.ndarray, mult: np.ndarray | None = None
+) -> float:
+    """Size-weighted mean of per-chromosome AUPRCs, optionally re-weighted by a
+    bootstrap multiplicity ``mult`` (per-chromosome resample counts). ``nan`` when the
+    total weight is zero — no contributing chromosome, or a resample that drew none of a
+    subset's chromosomes."""
+    w = weight if mult is None else weight * mult
+    total = float(w.sum())
+    return float((ap * w).sum() / total) if total > 0 else float("nan")
+
+
 def per_chrom_weighted_ap(
     y: np.ndarray,
     score: np.ndarray,
@@ -263,30 +331,79 @@ def per_chrom_weighted_ap(
         Sample-size-weighted mean of the per-chromosome AUPRCs, or ``nan`` when
         no chromosome has both classes among its finite-score variants.
     """
-    # Labels must be 0/1 (or bool). Cast like the module's other metrics
-    # (``auprc_with_bootstrap_se``) so a 0/1-valued object/float column still
-    # works, then fail loud on a non-binary encoding: an un-cast object/str label
-    # would make ``y[keep].sum()`` string-concatenate and silently skip every
-    # chromosome (a wrong ``nan``) instead of raising.
-    y = np.asarray(y).astype(int)
-    score = np.asarray(score, dtype=float)
-    chrom = np.asarray(chrom)
-    assert len(y) == len(score) == len(chrom), (
-        f"length mismatch: y={len(y)} score={len(score)} chrom={len(chrom)}"
-    )
-    assert np.isin(y, (0, 1)).all(), (
-        f"labels must be 0/1 (or bool), got values={np.unique(y)[:5]}"
-    )
-    total, weight = 0.0, 0
-    for c in np.unique(chrom):
-        keep = (chrom == c) & np.isfinite(score)
-        n = int(keep.sum())
-        # Skip a chromosome unless it carries at least one of each class among
-        # its finite-score variants — AUPRC is undefined on a single class.
-        if 0 < int(y[keep].sum()) < n:
-            total += float(average_precision_score(y[keep], score[keep])) * n
-            weight += n
-    return total / weight if weight else float("nan")
+    _, ap, weight = _per_chrom_components(y, score, chrom)
+    return _weighted_ap(ap, weight)
+
+
+def _per_chrom_cluster_bootstrap_se(
+    ap: np.ndarray,
+    weight: np.ndarray,
+    n_bootstrap: int,
+    gen: np.random.Generator,
+) -> float:
+    """Chromosome-cluster bootstrap SE of a subset's per-chromosome-weighted AUPRC.
+
+    Resamples the contributing chromosomes with replacement (``average_precision_score``
+    is duplication-invariant, so a repeated chromosome just re-weights that cluster) and
+    returns the ``ddof=1`` std of the resampled weighted means. ``nan`` when
+    ``n_bootstrap <= 0`` or fewer than two chromosomes contribute — a cluster-bootstrap
+    SE needs at least two clusters.
+    """
+    m = len(ap)
+    if n_bootstrap <= 0 or m < 2:
+        return float("nan")
+    boot = np.empty(n_bootstrap, dtype=float)
+    for b in range(n_bootstrap):
+        idx = gen.integers(0, m, size=m)
+        boot[b] = _weighted_ap(ap[idx], weight[idx])
+    return float(np.nanstd(boot, ddof=1))
+
+
+def _macro_joint_chrom_bootstrap_se(
+    components: list[tuple[np.ndarray, np.ndarray, np.ndarray]],
+    n_bootstrap: int,
+    gen: np.random.Generator,
+) -> float:
+    """Joint chromosome-cluster bootstrap SE of the macro-average AUPRC.
+
+    Chromosomes are *shared* across consequence subsets, so the macro-average's SE can't
+    use the disjoint-cluster ``sqrt(sum(se**2)) / K`` formula (that's the matched-pair
+    ``compute_auprc_metrics``, whose subsets partition their ``match_group``s). Instead
+    resample the UNION of contributing chromosomes ONCE per iteration and recompute every
+    subset's per-chromosome-weighted AUPRC under that single shared resample, then average
+    across subsets — a chromosome that is 'lucky' across several subsets moves them
+    together, and the SE reflects that coupling. ``nan`` when ``n_bootstrap <= 0`` or the
+    union has fewer than two chromosomes.
+
+    ``components`` is the list of ``(chroms, ap, weight)`` from ``_per_chrom_components``
+    for the qualifying subsets (those entering the macro average).
+    """
+    if n_bootstrap <= 0:
+        return float("nan")
+    union = sorted({c for chroms, _, _ in components for c in chroms.tolist()})
+    n_union = len(union)
+    if n_union < 2:
+        return float("nan")
+    pos = {c: i for i, c in enumerate(union)}
+    # Align each subset's (ap, weight) onto the shared union index; a chromosome a subset
+    # lacks gets weight 0, so it drops out of that subset's weighted mean under any
+    # resample multiplicity.
+    aligned: list[tuple[np.ndarray, np.ndarray]] = []
+    for chroms, ap, weight in components:
+        ap_u = np.zeros(n_union, dtype=float)
+        w_u = np.zeros(n_union, dtype=float)
+        for c, a, wi in zip(chroms.tolist(), ap, weight):
+            ap_u[pos[c]] = a
+            w_u[pos[c]] = wi
+        aligned.append((ap_u, w_u))
+    boot = np.empty(n_bootstrap, dtype=float)
+    for b in range(n_bootstrap):
+        mult = np.bincount(
+            gen.integers(0, n_union, size=n_union), minlength=n_union
+        ).astype(float)
+        vals = np.array([_weighted_ap(ap_u, w_u, mult) for ap_u, w_u in aligned])
+        boot[b] = float(np.nanmean(vals)) if np.isfinite(vals).any() else np.nan
+    return float(np.nanstd(boot, ddof=1))
 
 
 def per_chrom_ap_table(
@@ -296,33 +413,53 @@ def per_chrom_ap_table(
     label_col: str = "label",
     subset_col: str = "subset",
     chrom_col: str = "chrom",
+    n_bootstrap: int = 1000,
+    rng: np.random.Generator | int | None = 0,
+    n_min: int = 30,
 ) -> pd.DataFrame:
-    """Per-subset per-chromosome-weighted AUPRC for one or more score columns.
+    """Per-subset per-chromosome-weighted AUPRC + chromosome-cluster bootstrap SE, with a
+    ``_macro_avg_`` aggregate row per score column (#341 scaling ladder; SE + macro #347).
 
-    For each ``(subset, score_col)`` this computes ``per_chrom_weighted_ap`` over
-    that subset's rows — the tidy paired-comparison table behind the #341
-    linear-probe scaling-ladder analysis. Pass the ``compute_probe`` predictions
-    frame with ``score_columns=["probe_score", "minus_llr_avg"]`` to get the probe
-    and its matched zero-shot LLR baseline scored on **identical rows** under the
-    identical per-chromosome metric.
+    For each ``(subset, score_col)`` computes ``per_chrom_weighted_ap`` and its
+    chromosome-cluster bootstrap SE. Pass the ``compute_probe`` predictions frame with
+    ``score_columns=["probe_score", "minus_llr_avg"]`` to score the probe and its matched
+    zero-shot LLR baseline on **identical rows** under the identical metric.
 
-    ``n`` / ``n_pos`` / ``n_chrom`` are subset-level counts (independent of the
-    score column) for context; ``value`` is per (subset, score_col) and is
-    ``NaN`` when no chromosome carries both classes among that score's finite
-    values — e.g. a subset whose probe was skipped (all-``NaN`` ``probe_score``),
-    which surfaces as a ``NaN`` probe row beside a finite baseline row.
+    Aggregate: one ``_macro_avg_`` row per score column — the unweighted mean over subsets
+    with ``n_pos >= n_min`` and a finite value. Its SE is a JOINT chromosome bootstrap
+    (``_macro_joint_chrom_bootstrap_se``): chromosomes are shared across subsets, so the
+    disjoint-cluster SE-of-mean formula (``compute_auprc_metrics``) would misstate it.
+    **No ``_global_`` row** — probe scores come from a separate per-subset classifier, so a
+    pooled global ranking is undefined (unlike the matched-pair leaderboard). The macro row
+    keeps honest ``n`` / ``n_pos`` sums (the dashboard read layer overloads the displayed
+    ``n`` to K, as it already does for the matched-pair macro).
+
+    ``n`` / ``n_pos`` / ``n_chrom`` are subset-level counts (independent of the score
+    column); ``value`` / ``se`` are per ``(subset, score_col)`` and ``NaN`` when no
+    chromosome carries both classes among that score's finite values (e.g. a skipped
+    probe's all-``NaN`` ``probe_score`` beside a finite baseline row). ``se`` is also
+    ``NaN`` when ``n_bootstrap <= 0`` or fewer than two chromosomes contribute.
 
     Args:
-        df: variant frame with ``label`` / ``subset`` / ``chrom`` columns plus
-            every name in ``score_columns`` (row-aligned).
+        df: variant frame with ``label`` / ``subset`` / ``chrom`` columns plus every name
+            in ``score_columns`` (row-aligned).
         score_columns: score column names to score (e.g. ``probe_score``).
         label_col: 0/1 label column name.
         subset_col: consequence-subset column name (the grouping key).
-        chrom_col: chromosome column name (the per-chrom weighting key).
+        chrom_col: chromosome column name (per-chrom weighting + bootstrap-cluster key).
+        n_bootstrap: chromosome-cluster bootstrap iterations; ``<= 0`` skips the resample
+            (``se = NaN``, point estimates only) — the macro row is still emitted.
+        rng: ``numpy.random.Generator``, seed int, or ``None``. ``0`` (default) →
+            reproducible across re-runs (bit-stable pipeline output); ``None`` → fresh
+            randomness.
+        n_min: minimum ``n_pos`` for a subset to enter the macro average. Default 30
+            (project-wide leaderboard convention; a 300-variant 1:9-matched subset ⇒ ~30
+            positives, matching the probe's ``min_variants`` gate).
 
     Returns:
-        DataFrame ``[score_type, subset, value, n, n_pos, n_chrom]``, one row per
-        ``(subset, score_col)`` in first-appearance subset order.
+        DataFrame ``[score_type, subset, value, se, n, n_pos, n_chrom]`` — one row per
+        ``(subset, score_col)`` in first-appearance subset order, then one ``_macro_avg_``
+        row per score column.
     """
     for col in (label_col, subset_col, chrom_col):
         assert col in df.columns, f"df missing required column {col!r}"
@@ -338,29 +475,72 @@ def per_chrom_ap_table(
             f"mis-weight those rows — fail loud instead"
         )
 
+    gen = np.random.default_rng(rng)
     rows: list[dict] = []
+    # Per score column, gather the qualifying subsets' components (for the joint macro
+    # bootstrap), point values (for the macro mean), and counts — in first-appearance
+    # order so the macro is deterministic.
+    qual_components: dict[str, list[tuple]] = {sc: [] for sc in score_columns}
+    qual_values: dict[str, list[float]] = {sc: [] for sc in score_columns}
+    qual_counts: dict[str, list[tuple[int, int]]] = {sc: [] for sc in score_columns}
     for subset_name, sub in df.groupby(subset_col, sort=False):
         n = int(len(sub))
         n_pos = int(np.asarray(sub[label_col]).astype(int).sum())
         n_chrom = int(pd.unique(sub[chrom_col]).size)
         for score_col in score_columns:
-            value = per_chrom_weighted_ap(
+            chroms, ap, weight = _per_chrom_components(
                 sub[label_col].to_numpy(),
                 sub[score_col].to_numpy(),
                 sub[chrom_col].to_numpy(),
             )
+            value = _weighted_ap(ap, weight)
+            se = _per_chrom_cluster_bootstrap_se(ap, weight, n_bootstrap, gen)
             rows.append(
                 {
                     "score_type": score_col,
                     "subset": str(subset_name),
                     "value": value,
+                    "se": se,
                     "n": n,
                     "n_pos": n_pos,
                     "n_chrom": n_chrom,
                 }
             )
+            if n_pos >= n_min and np.isfinite(value):
+                qual_components[score_col].append((chroms, ap, weight))
+                qual_values[score_col].append(value)
+                qual_counts[score_col].append((n, n_pos))
+
+    for score_col in score_columns:
+        comps = qual_components[score_col]
+        if comps:
+            union_chroms = {c for chroms, _, _ in comps for c in chroms.tolist()}
+            macro = {
+                "score_type": score_col,
+                "subset": MACRO_AVG_SUBSET,
+                "value": float(np.mean(qual_values[score_col])),
+                "se": _macro_joint_chrom_bootstrap_se(comps, n_bootstrap, gen),
+                "n": sum(n for n, _ in qual_counts[score_col]),
+                "n_pos": sum(n_pos for _, n_pos in qual_counts[score_col]),
+                "n_chrom": len(union_chroms),
+            }
+        else:
+            # No subset cleared n_min with a finite value — still emit the macro row (NaN)
+            # so the aggregate is always present (the dashboard loader keys on it).
+            macro = {
+                "score_type": score_col,
+                "subset": MACRO_AVG_SUBSET,
+                "value": float("nan"),
+                "se": float("nan"),
+                "n": 0,
+                "n_pos": 0,
+                "n_chrom": 0,
+            }
+        rows.append(macro)
+
     return pd.DataFrame(
-        rows, columns=["score_type", "subset", "value", "n", "n_pos", "n_chrom"]
+        rows,
+        columns=["score_type", "subset", "value", "se", "n", "n_pos", "n_chrom"],
     )
 
 

--- a/tests/pipelines/evals/test_metrics.py
+++ b/tests/pipelines/evals/test_metrics.py
@@ -1064,22 +1064,28 @@ def _probe_like_frame() -> pd.DataFrame:
 
 
 def test_per_chrom_ap_table_shape_and_matches_direct():
-    """One row per (subset, score_col); each ``value`` reproduces
-    ``per_chrom_weighted_ap`` called directly on that subset's rows."""
+    """One row per (subset, score_col) plus a ``_macro_avg_`` row per score column; each
+    per-subset ``value`` reproduces ``per_chrom_weighted_ap`` on that subset's rows.
+    ``n_bootstrap=0`` → point-only (``se`` NaN), so this stays a pure value/shape test."""
     df = _probe_like_frame()
-    out = per_chrom_ap_table(df, ["probe_score", "minus_llr_avg"])
+    out = per_chrom_ap_table(df, ["probe_score", "minus_llr_avg"], n_bootstrap=0)
     assert list(out.columns) == [
         "score_type",
         "subset",
         "value",
+        "se",
         "n",
         "n_pos",
         "n_chrom",
     ]
-    assert len(out) == 4  # 2 subsets × 2 score columns
-    assert set(out["subset"]) == {"missense", "synonymous"}
-    assert set(out["score_type"]) == {"probe_score", "minus_llr_avg"}
-    for (subset, score_type), row in out.set_index(["subset", "score_type"]).iterrows():
+    per_subset = out[out["subset"] != MACRO_AVG_SUBSET]
+    assert len(per_subset) == 4  # 2 subsets × 2 score columns
+    assert (out["subset"] == MACRO_AVG_SUBSET).sum() == 2  # one macro row per score
+    assert set(per_subset["subset"]) == {"missense", "synonymous"}
+    assert set(per_subset["score_type"]) == {"probe_score", "minus_llr_avg"}
+    for (subset, score_type), row in per_subset.set_index(
+        ["subset", "score_type"]
+    ).iterrows():
         sub = df[df["subset"] == subset]
         expected = per_chrom_weighted_ap(
             sub["label"].to_numpy(),
@@ -1087,8 +1093,12 @@ def test_per_chrom_ap_table_shape_and_matches_direct():
             sub["chrom"].to_numpy(),
         )
         assert row["value"] == pytest.approx(expected)
-    missense = out[out["subset"] == "missense"].iloc[0]
+    missense = per_subset[
+        (per_subset["subset"] == "missense")
+        & (per_subset["score_type"] == "probe_score")
+    ].iloc[0]
     assert missense["n"] == 6 and missense["n_pos"] == 3 and missense["n_chrom"] == 2
+    assert out["se"].isna().all()  # n_bootstrap=0 → SE suppressed
 
 
 def test_per_chrom_ap_table_all_nan_score_is_nan_row():
@@ -1097,7 +1107,7 @@ def test_per_chrom_ap_table_all_nan_score_is_nan_row():
     counts are score-independent."""
     df = _probe_like_frame()
     df.loc[df["subset"] == "missense", "probe_score"] = np.nan
-    out = per_chrom_ap_table(df, ["probe_score", "minus_llr_avg"])
+    out = per_chrom_ap_table(df, ["probe_score", "minus_llr_avg"], n_bootstrap=0)
     probe_row = out[
         (out["subset"] == "missense") & (out["score_type"] == "probe_score")
     ].iloc[0]
@@ -1110,9 +1120,12 @@ def test_per_chrom_ap_table_all_nan_score_is_nan_row():
 
 
 def test_per_chrom_ap_table_preserves_subset_order():
-    """Subsets appear in first-appearance order (``groupby(sort=False)``)."""
-    out = per_chrom_ap_table(_probe_like_frame(), ["probe_score"])
-    assert list(out["subset"]) == ["missense", "synonymous"]
+    """Per-subset rows appear in first-appearance order (``groupby(sort=False)``); the
+    ``_macro_avg_`` row is appended last."""
+    out = per_chrom_ap_table(_probe_like_frame(), ["probe_score"], n_bootstrap=0)
+    per_subset = out[out["subset"] != MACRO_AVG_SUBSET]
+    assert list(per_subset["subset"]) == ["missense", "synonymous"]
+    assert out["subset"].iloc[-1] == MACRO_AVG_SUBSET
 
 
 def test_per_chrom_ap_table_missing_column_raises():
@@ -1131,3 +1144,109 @@ def test_per_chrom_ap_table_null_key_raises():
         df.loc[0, key] = None
         with pytest.raises(AssertionError, match="contains nulls"):
             per_chrom_ap_table(df, ["probe_score"])
+
+
+# ---------------------------------------------------------------------------
+# per_chrom_ap_table: chromosome-cluster bootstrap SE + macro-avg row (#347)
+# ---------------------------------------------------------------------------
+
+
+def test_per_chrom_ap_table_emits_macro_never_global():
+    """One ``_macro_avg_`` row per score column and never a ``_global_`` row — probe
+    scores come from a separate per-subset classifier, so a pooled global ranking is
+    undefined."""
+    out = per_chrom_ap_table(
+        _probe_like_frame(), ["probe_score", "minus_llr_avg"], n_bootstrap=0, n_min=1
+    )
+    macro = out[out["subset"] == MACRO_AVG_SUBSET]
+    assert len(macro) == 2
+    assert set(macro["score_type"]) == {"probe_score", "minus_llr_avg"}
+    assert GLOBAL_SUBSET not in set(out["subset"])
+
+
+def test_per_chrom_ap_table_macro_value_is_mean_of_qualifying():
+    """The ``_macro_avg_`` value is the unweighted mean of the qualifying subsets'
+    per-chrom values; ``n`` / ``n_pos`` are honest sums (n_min=1 → both toy subsets
+    qualify)."""
+    df = _probe_like_frame()
+    out = per_chrom_ap_table(df, ["probe_score"], n_bootstrap=0, n_min=1)
+    per_subset = out[
+        (out["subset"] != MACRO_AVG_SUBSET) & (out["score_type"] == "probe_score")
+    ]
+    macro = out[
+        (out["subset"] == MACRO_AVG_SUBSET) & (out["score_type"] == "probe_score")
+    ].iloc[0]
+    assert macro["value"] == pytest.approx(per_subset["value"].mean())
+    assert macro["n"] == int(per_subset["n"].sum())
+    assert macro["n_pos"] == int(per_subset["n_pos"].sum())
+
+
+def test_per_chrom_ap_table_macro_below_n_min_is_nan():
+    """With the default ``n_min=30`` and a tiny fixture (3 positives/subset) no subset
+    qualifies, but the macro row is still emitted — as NaN — so the loader always finds
+    it."""
+    out = per_chrom_ap_table(_probe_like_frame(), ["probe_score"], n_bootstrap=0)
+    macro = out[out["subset"] == MACRO_AVG_SUBSET].iloc[0]
+    assert math.isnan(macro["value"]) and math.isnan(macro["se"])
+    assert macro["n"] == 0 and macro["n_pos"] == 0
+
+
+def test_per_chrom_ap_table_se_present_and_reproducible():
+    """``n_bootstrap > 0`` gives finite, non-negative per-subset and macro SEs, and a
+    pinned ``rng`` seed is bit-stable across calls."""
+    df = _probe_like_frame()
+    a = per_chrom_ap_table(df, ["probe_score"], n_bootstrap=200, rng=0, n_min=1)
+    b = per_chrom_ap_table(df, ["probe_score"], n_bootstrap=200, rng=0, n_min=1)
+    per_subset = a[a["subset"] != MACRO_AVG_SUBSET]
+    assert per_subset["se"].notna().all() and (per_subset["se"] >= 0).all()
+    assert np.isfinite(a[a["subset"] == MACRO_AVG_SUBSET].iloc[0]["se"])
+    pd.testing.assert_frame_equal(a, b)
+
+
+def test_per_chrom_ap_table_se_shrinks_with_more_chromosomes():
+    """The chromosome-cluster bootstrap SE tightens as the number of (equally-weighted,
+    value-varying) chromosomes grows — #347's headline SE property."""
+
+    def frame(reps: int) -> pd.DataFrame:
+        # `reps` copies of a 2-chromosome motif: a "good" chromosome ranks its positive
+        # above its negative (per-chrom AUPRC 1.0), a "bad" one below (0.5). More
+        # chromosomes, same per-chrom value spread → tighter bootstrap SE (~1/sqrt(m)).
+        labels, scores, chroms = [], [], []
+        for r in range(reps):
+            chroms += [f"g{r}", f"g{r}"]
+            labels += [1, 0]
+            scores += [0.9, 0.1]
+            chroms += [f"b{r}", f"b{r}"]
+            labels += [1, 0]
+            scores += [0.1, 0.9]
+        return pd.DataFrame(
+            {
+                "label": labels,
+                "subset": ["s"] * len(labels),
+                "chrom": chroms,
+                "probe_score": scores,
+            }
+        )
+
+    def subset_se(reps: int) -> float:
+        out = per_chrom_ap_table(frame(reps), ["probe_score"], n_bootstrap=400, rng=0)
+        return out[out["subset"] == "s"].iloc[0]["se"]
+
+    assert subset_se(6) < subset_se(1)
+
+
+def test_per_chrom_ap_table_single_class_subset_nan_and_excluded():
+    """A single-class subset yields NaN value + NaN SE and drops out of the macro
+    average, which then reflects only the finite subset."""
+    df = _probe_like_frame()
+    df.loc[df["subset"] == "synonymous", "label"] = 1  # no chromosome has both classes
+    out = per_chrom_ap_table(df, ["probe_score"], n_bootstrap=100, rng=0, n_min=1)
+    syn = out[
+        (out["subset"] == "synonymous") & (out["score_type"] == "probe_score")
+    ].iloc[0]
+    assert math.isnan(syn["value"]) and math.isnan(syn["se"])
+    macro = out[out["subset"] == MACRO_AVG_SUBSET].iloc[0]
+    missense = out[
+        (out["subset"] == "missense") & (out["score_type"] == "probe_score")
+    ].iloc[0]
+    assert macro["value"] == pytest.approx(missense["value"])

--- a/tests/pipelines/evals/test_metrics.py
+++ b/tests/pipelines/evals/test_metrics.py
@@ -1250,3 +1250,50 @@ def test_per_chrom_ap_table_single_class_subset_nan_and_excluded():
         (out["subset"] == "missense") & (out["score_type"] == "probe_score")
     ].iloc[0]
     assert macro["value"] == pytest.approx(missense["value"])
+
+
+def test_per_chrom_ap_table_se_independent_of_score_column_order():
+    """A cell's SE is a pure function of its own data + seed: reordering `score_columns`
+    must not change any (subset, score) SE (the per-cell fresh-`default_rng` fix — a single
+    shared generator threaded through the loop made SEs depend on column order)."""
+    df = _probe_like_frame()
+    fwd = per_chrom_ap_table(
+        df, ["probe_score", "minus_llr_avg"], n_bootstrap=200, rng=0, n_min=1
+    )
+    rev = per_chrom_ap_table(
+        df, ["minus_llr_avg", "probe_score"], n_bootstrap=200, rng=0, n_min=1
+    )
+    key = ["subset", "score_type"]
+    pd.testing.assert_series_equal(
+        fwd.set_index(key)["se"].sort_index(),
+        rev.set_index(key)["se"].sort_index(),
+    )
+
+
+def test_per_chrom_ap_table_macro_se_partial_chrom_overlap():
+    """The joint macro bootstrap tolerates subsets on partially-disjoint chromosome sets:
+    finite macro SE, all-chromosomes `n_chrom` = the deduped union, and no crash when a
+    draw could void a subset (the fixed-K `np.isfinite(vals).all()` guard)."""
+
+    def block(chrom: str, good: bool) -> pd.DataFrame:
+        # One pos + one neg on a chromosome; `good` ranks the pos above (per-chrom AUPRC
+        # 1.0) else below (0.5), so per-chrom values vary and the bootstrap has spread.
+        scores = [0.9, 0.1] if good else [0.1, 0.9]
+        return pd.DataFrame(
+            {"label": [1, 0], "chrom": [chrom, chrom], "probe_score": scores}
+        )
+
+    specs = {
+        "A": ["chr1", "chr2", "chr3", "chr4"],
+        "B": ["chr3", "chr4", "chr5", "chr6"],
+    }
+    frames = []
+    for subset, chroms in specs.items():
+        for i, c in enumerate(chroms):
+            frames.append(block(c, good=(i % 2 == 0)).assign(subset=subset))
+    df = pd.concat(frames, ignore_index=True)
+
+    out = per_chrom_ap_table(df, ["probe_score"], n_bootstrap=300, rng=0, n_min=1)
+    macro = out[out["subset"] == MACRO_AVG_SUBSET].iloc[0]
+    assert np.isfinite(macro["se"]) and macro["se"] >= 0
+    assert macro["n_chrom"] == 6  # union of chr1..chr6 across the two subsets


### PR DESCRIPTION
Closes #347. Foundation for #348 (the dashboard Unsupervised | Supervised toggle reads this SE + macro row and renders the ±1 SE forest plot).

## What

Extends `per_chrom_ap_table` — the TraitGym per-chromosome-weighted AUPRC table that is the frozen-embedding probe's headline metric — to emit, per `(subset, score)`, a **chromosome-cluster bootstrap SE** and a **`_macro_avg_` aggregate row** per score column, and wires it through `compute_probe_metrics`. **No `_global_` row** — probe scores come from a separate per-subset classifier, so a pooled global ranking is undefined (unlike the matched-pair leaderboard).

## Design notes (for review)

- **One source of truth, no fork.** This is core metric code, so rather than add a sibling function I factored the per-chromosome computation into [`_per_chrom_components`](https://github.com/Open-Athena/marin-dna/blob/ca2a6faf911a638c600c56cc1c153270c3a72a30/src/marin_dna/pipelines/evals/metrics.py#L230-L285) + [`_weighted_ap`](https://github.com/Open-Athena/marin-dna/blob/ca2a6faf911a638c600c56cc1c153270c3a72a30/src/marin_dna/pipelines/evals/metrics.py#L286-L296); `per_chrom_weighted_ap` now sits on them (behaviour unchanged, its tests untouched) and [`per_chrom_ap_table`](https://github.com/Open-Athena/marin-dna/blob/ca2a6faf911a638c600c56cc1c153270c3a72a30/src/marin_dna/pipelines/evals/metrics.py#L409-L525) grew the SE + macro in place.
- **Per-subset SE** = chromosome-cluster bootstrap over that subset's contributing chromosomes (the same cluster-bootstrap idea as the matched-pair `auprc_with_bootstrap_se`, with the chromosome as the cluster instead of the match group).
- **Macro SE = a JOINT chromosome bootstrap** ([`_macro_joint_chrom_bootstrap_se`](https://github.com/Open-Athena/marin-dna/blob/ca2a6faf911a638c600c56cc1c153270c3a72a30/src/marin_dna/pipelines/evals/metrics.py#L362-L408)), **not** `sqrt(sum(se²))/K`. Chromosomes are *shared* across consequence subsets, so the disjoint-cluster SE-of-mean formula (valid in `compute_auprc_metrics`, whose subsets partition their `match_group`s) would misstate the macro's uncertainty. Instead we resample the union of contributing chromosomes once per iteration and recompute every subset's AUPRC under that single shared resample, then average — so a chromosome that is "lucky" across several subsets moves them together and the SE reflects that coupling. **This is the main statistical judgment call — flagging for review.**
- `n_bootstrap` (1000) and `n_min` (30) are new `probe:` config knobs; the rng is pinned to 0 in-rule for bit-stable output.

## Verification

- `uv run pytest` → **870 passed, 5 skipped**. New tests cover the SE (finite, reproducible under a fixed seed, shrinks with more chromosomes, `NaN` for <2 contributing chromosomes), the macro (value == mean of qualifying subsets; finite joint-bootstrap SE), single-class subsets → `NaN` and excluded from the macro, and the no-`_global_` invariant.
- Regenerated the `probe_metrics` parquet for the scored checkpoint (`exp135-1B-m5.1` on mendelian) through [`compute_probe_metrics`](https://github.com/Open-Athena/marin-dna/blob/ca2a6faf911a638c600c56cc1c153270c3a72a30/snakemake/analysis/evals_v2/workflow/rules/probe.smk#L87-L148). A dry-run confirmed **only** `compute_probe_metrics` runs (no upstream cascade, per the rule's `--rerun-triggers mtime` guard). Real-data checks passed: schema is `[score_type, subset, value, se, n, n_pos, n_chrom, model, dataset, split]`; the macro value **exactly** equals the mean of the qualifying (`n_pos ≥ 30`, finite) per-subset values; SE is finite on every finite row; and the skipped-probe subset (`mature_miRNA_variant`, n=40 < `min_variants`) is a null probe row beside a finite baseline, correctly excluded from both macros.

<details><summary>probe_metrics — <code>exp135-1B-m5.1</code> × mendelian (regenerated on this branch)</summary>

| subset | probe AUPRC | ±SE | zero-shot LLR | ±SE | n | n_pos |
|---|---|---|---|---|---|---|
| **`_macro_avg_`** | **0.489** | ±0.022 | **0.419** | ±0.030 | 8 subsets | — |
| missense_variant | 0.538 | ±0.019 | 0.453 | ±0.022 | 5800 | 580 |
| splicing | 0.551 | ±0.032 | 0.509 | ±0.044 | 3190 | 319 |
| 5_prime_UTR_variant | 0.503 | ±0.068 | 0.411 | ±0.096 | 2100 | 210 |
| tss_proximal | 0.342 | ±0.089 | 0.309 | ±0.081 | 2050 | 205 |
| non_coding_transcript_exon_variant | 0.408 | ±0.076 | 0.462 | ±0.058 | 1150 | 115 |
| 3_prime_UTR_variant | 0.522 | ±0.068 | 0.455 | ±0.075 | 770 | 77 |
| distal | 0.512 | ±0.077 | 0.365 | ±0.115 | 580 | 58 |
| synonymous_variant | 0.539 | ±0.055 | 0.390 | ±0.065 | 460 | 46 |
| mature_miRNA_variant | *skipped* (n<300) | — | 0.781 | ±0.189 | 40 | 4 |

The macro `n` / `n_pos` here are honest sums over the qualifying subsets; the dashboard read layer (#348) overloads the displayed `n` to K=8, as it already does for the matched-pair macro.

</details>

The probe beats the zero-shot baseline on the macro (0.489 vs 0.419), consistent with #341.
