### PR TITLE
dashboard(mendelian): top-level Unsupervised | Supervised toggle for the linear-probe view

### DIFF
--- a/dashboard/src/components/controls.js
+++ b/dashboard/src/components/controls.js
@@ -16,6 +16,16 @@ export const FAMILY_LABEL = {
   evo2: "Evo 2",
 };
 
+// Top-level supervision mode for the Mendelian leaderboard — the score-world a row was
+// computed in. "Unsupervised" = zero-shot likelihood metrics; "Supervised" = the trained
+// frozen-embedding linear probe (#347/#348). The two use different, non-level-comparable
+// metrics (matched-pair AUPRC vs per-chromosome-weighted AUPRC), so the page renders one at
+// a time — never mixed in a single ranked view. Keys match the parquet `supervision` column.
+export const SUPERVISION_LABEL = {
+  unsupervised: "Unsupervised",
+  supervised: "Supervised",
+};
+
 // Leaderboard-visible protocol options per family. This is the subset of
 // `PROTOCOLS` (in src/marin_dna/pipelines/evals/leaderboard.py) that the
 // leaderboards' `FamilyProtocolToggle` exposes — additional protocols can live in

--- a/dashboard/src/components/heatmap.js
+++ b/dashboard/src/components/heatmap.js
@@ -48,6 +48,9 @@ export function rowsFromLeaderboard(leaderboard) {
     n: Number(r.n),
     n_positives: Number(r.n_positives),
     dataset: String(r.dataset),
+    // "unsupervised" (zero-shot) / "supervised" (linear probe). Drives the Mendelian
+    // page's top-level mode toggle; absent on other pages → "undefined" (harmless).
+    supervision: String(r.supervision),
   }));
 }
 
@@ -137,6 +140,7 @@ export function heatmap({
   onSortChange,
   palette = PALETTE_ABSOLUTE,
   showForest = true,
+  showGlobal = true,
 }) {
   // Group by method_id; collect cells in a Map keyed by subset.
   const byMethod = new Map();
@@ -178,8 +182,11 @@ export function heatmap({
     .filter(([s, n_pos]) => n_pos >= N_POSITIVES_MIN && s in SUBSET_DISPLAY)
     .sort((a, b) => b[1] - a[1])
     .map(([s]) => s);
-  const aggCols =
-    leadingAggregate === MACRO ? [MACRO, GLOBAL] : [GLOBAL, MACRO];
+  // `showGlobal: false` drops the Global column — the supervised probe view has no pooled
+  // global (each subset has its own classifier), so only Macro Avg is meaningful.
+  const aggCols = (
+    leadingAggregate === MACRO ? [MACRO, GLOBAL] : [GLOBAL, MACRO]
+  ).filter((c) => showGlobal || c !== GLOBAL);
   const columns = [...aggCols, ...subsetCols];
 
   // Sample any method that has both aggregate rows to read the per-column

--- a/dashboard/src/components/heatmap.js
+++ b/dashboard/src/components/heatmap.js
@@ -189,12 +189,11 @@ export function heatmap({
   ).filter((c) => showGlobal || c !== GLOBAL);
   const columns = [...aggCols, ...subsetCols];
 
-  // Sample any method that has both aggregate rows to read the per-column
-  // header counts (n for global, K for macro_avg). Aggregates are constant
-  // across methods (same match_groups).
-  const sample = [...byMethod.values()].find(
-    (m) => m.cells.has(GLOBAL) && m.cells.has(MACRO),
-  );
+  // Sample any method with a MACRO row to read the per-column header counts
+  // (K for macro_avg; n for global when present). Aggregates are constant across
+  // methods. Require only MACRO, not GLOBAL — the supervised probe view has no
+  // Global row, and also requiring GLOBAL would leave macroK = 0 ("0 subsets").
+  const sample = [...byMethod.values()].find((m) => m.cells.has(MACRO));
   const globalN = sample?.cells.get(GLOBAL)?.n ?? 0;
   // The macro_avg cell's `n` carries K (qualifying subsets), not variant
   // count — overload set in `leaderboard.fetch_method_metrics`.

--- a/dashboard/src/data/datasets.json.py
+++ b/dashboard/src/data/datasets.json.py
@@ -18,16 +18,16 @@ _METRIC = (
     "AUPRC is 0.10."
 )
 
-# Supervised-mode (linear-probe) metric caption — shown in place of `_METRIC` when the
-# Mendelian page's mode toggle is on Supervised. Same dataset/variants, different scoring.
+# Supervised (linear-probe) metric caption — shown alongside `_METRIC` in the dataset card
+# (both are always listed). Same dataset/variants, different scoring. Plain prose (the card
+# renders the string as text, not markdown), caveats folded in.
 _PROBE_METRIC = (
-    "**Per-chromosome-weighted AUPRC (TraitGym) ± chromosome-cluster bootstrap SE.** For "
-    "each consequence subset, `average_precision_score` is computed *within* each "
-    "chromosome then size-weighted across chromosomes (the TraitGym metric); SE is a "
-    "cluster bootstrap resampling chromosomes (#347). Macro Avg is the unweighted mean over "
-    "subsets — there is **no Global** column, because the probe trains a separate classifier "
-    "per subset, so a pooled global ranking is undefined. 1:9 matching ⇒ the random-baseline "
-    "AUPRC is 0.10."
+    "Per-chromosome-weighted AUPRC (TraitGym) ± chromosome-cluster bootstrap SE (#347) — "
+    "AUPRC is computed within each chromosome then size-weighted, and Macro Avg is the "
+    "unweighted mean over subsets (no Global column: the probe fits a separate classifier "
+    "per subset). MarinDNA only, since probes read our per-allele embeddings; a subset is "
+    "probed only with at least 300 variants and 3 chromosomes. Not level-comparable to the "
+    "Unsupervised metric above — different weighting and matching."
 )
 
 # caQTL/dsQTL moved to the supervised official-metrics Accessibility QTL page (#312),
@@ -63,11 +63,6 @@ DATASETS = {
             "Sorted by Macro Avg by default — the consequence-subset distribution is dominated by missense (a ClinVar annotator-history artifact, not pathogenicity reality), so Global AUPRC over-weights protein-coding-specialist methods. Macro Avg gives equal weight to each subset.",
         ],
         "probe_metric": _PROBE_METRIC,
-        "probe_notes": [
-            "**Supervised:** a frozen-embedding L2-logistic linear probe (nested leave-one-chromosome-out; #314/#320) on **MarinDNA models only** — probes read our per-allele embeddings, so no competitor family appears here.",
-            "A subset is probed only if it has ≥300 variants and ≥3 chromosomes (`min_variants` / `min_chroms`); smaller subsets (e.g. mature-miRNA) get no probe score.",
-            "Not comparable to the Unsupervised metric (matched-pair AUPRC) — different weighting and matching. The toggle switches worlds; the two are never shown together.",
-        ],
     },
     "complex_traits": {
         "name": "Complex Traits",

--- a/dashboard/src/data/datasets.json.py
+++ b/dashboard/src/data/datasets.json.py
@@ -18,6 +18,18 @@ _METRIC = (
     "AUPRC is 0.10."
 )
 
+# Supervised-mode (linear-probe) metric caption — shown in place of `_METRIC` when the
+# Mendelian page's mode toggle is on Supervised. Same dataset/variants, different scoring.
+_PROBE_METRIC = (
+    "**Per-chromosome-weighted AUPRC (TraitGym) ± chromosome-cluster bootstrap SE.** For "
+    "each consequence subset, `average_precision_score` is computed *within* each "
+    "chromosome then size-weighted across chromosomes (the TraitGym metric); SE is a "
+    "cluster bootstrap resampling chromosomes (#347). Macro Avg is the unweighted mean over "
+    "subsets — there is **no Global** column, because the probe trains a separate classifier "
+    "per subset, so a pooled global ranking is undefined. 1:9 matching ⇒ the random-baseline "
+    "AUPRC is 0.10."
+)
+
 # caQTL/dsQTL moved to the supervised official-metrics Accessibility QTL page (#312),
 # which carries its own dataset metadata — so no caqtl/dsqtl entries here anymore.
 
@@ -49,6 +61,12 @@ DATASETS = {
         "notes": [
             "Per-subset columns exclude subsets with fewer than 30 positives (`n < 300` under 1:9 matching).",
             "Sorted by Macro Avg by default — the consequence-subset distribution is dominated by missense (a ClinVar annotator-history artifact, not pathogenicity reality), so Global AUPRC over-weights protein-coding-specialist methods. Macro Avg gives equal weight to each subset.",
+        ],
+        "probe_metric": _PROBE_METRIC,
+        "probe_notes": [
+            "**Supervised:** a frozen-embedding L2-logistic linear probe (nested leave-one-chromosome-out; #314/#320) on **MarinDNA models only** — probes read our per-allele embeddings, so no competitor family appears here.",
+            "A subset is probed only if it has ≥300 variants and ≥3 chromosomes (`min_variants` / `min_chroms`); smaller subsets (e.g. mature-miRNA) get no probe score.",
+            "Not comparable to the Unsupervised metric (matched-pair AUPRC) — different weighting and matching. The toggle switches worlds; the two are never shown together.",
         ],
     },
     "complex_traits": {

--- a/dashboard/src/data/leaderboard.parquet.py
+++ b/dashboard/src/data/leaderboard.parquet.py
@@ -32,23 +32,28 @@ LEADERBOARD_DATASETS: tuple[str, ...] = (
     "complex_traits",
 )
 
+# Datasets that also have frozen-embedding probe metrics on S3 (the Supervised view). Only
+# mendelian today; extend as models are probed on other datasets. Kept explicit so the build
+# doesn't issue a doomed S3 read (one 404 per marin_dna model) for datasets with no probes.
+PROBE_DATASETS: tuple[str, ...] = ("mendelian_traits",)
+
 
 def main() -> None:
-    parts = []
-    for dataset in LEADERBOARD_DATASETS:
-        parts.append(
-            normalized_rows(dataset).with_columns(
-                dataset=pl.lit(dataset), supervision=pl.lit("unsupervised")
-            )
+    parts = [
+        normalized_rows(dataset).with_columns(
+            dataset=pl.lit(dataset), supervision=pl.lit("unsupervised")
         )
-        # Supervised (linear-probe) rows where a marin_dna model has #347-schema probe
-        # metrics on S3 — mendelian only today, empty elsewhere. Appended only when present
-        # so an empty frame never perturbs the concat schema.
-        supervised = probe_normalized_rows(dataset).with_columns(
+        for dataset in LEADERBOARD_DATASETS
+    ]
+    # Supervised (linear-probe) rows, tagged with the same `supervision` column the Mendelian
+    # page's mode toggle filters on. probe_normalized_rows returns an explicitly-typed frame
+    # (empty if a dataset has no probes yet), so it concatenates cleanly.
+    parts += [
+        probe_normalized_rows(dataset).with_columns(
             dataset=pl.lit(dataset), supervision=pl.lit("supervised")
         )
-        if supervised.height:
-            parts.append(supervised)
+        for dataset in PROBE_DATASETS
+    ]
     out = pl.concat(parts, how="vertical_relaxed")
     out.write_parquet(sys.stdout.buffer)
 

--- a/dashboard/src/data/leaderboard.parquet.py
+++ b/dashboard/src/data/leaderboard.parquet.py
@@ -1,12 +1,16 @@
 """Observable Framework data loader: S3 metrics → one tidy parquet.
 
 Pulls per-(method, dataset, subset) metric rows from S3 via
-``marin_dna.pipelines.evals.leaderboard.normalized_rows``, prepends a
-``dataset`` column, concatenates across datasets, and writes the resulting
-DataFrame as a parquet blob on stdout for the dashboard to read via DuckDB.
+``marin_dna.pipelines.evals.leaderboard.normalized_rows`` (zero-shot likelihood metrics)
+and ``probe_normalized_rows`` (the frozen-embedding linear probe, #347/#348), tags each
+with a ``dataset`` and a ``supervision`` column (``unsupervised`` / ``supervised``),
+concatenates, and writes the resulting DataFrame as a parquet blob on stdout for the
+dashboard to read via DuckDB. The Mendelian page's top-level mode toggle filters on
+``supervision`` so the two metric-worlds are never mixed in one ranked view.
 
 Emits one parquet covering the matched-pair leaderboard datasets (mendelian_traits,
-complex_traits). Each page filters by ``dataset``, so they coexist in one file. eQTL
+complex_traits). Each page filters by ``dataset``, so they coexist in one file. Supervised
+rows exist only where a marin_dna model has probe metrics on S3 (mendelian today). eQTL
 was retired in PR #194 (issue #172); the caQTL/dsQTL zero-shot path was retired in #312
 (the supervised official-metrics benchmark now lives on its own Accessibility QTL page,
 fed by ``accessibility_qtl.parquet.py``).
@@ -18,7 +22,10 @@ import sys
 
 import polars as pl
 
-from marin_dna.pipelines.evals.leaderboard import normalized_rows
+from marin_dna.pipelines.evals.leaderboard import (
+    normalized_rows,
+    probe_normalized_rows,
+)
 
 LEADERBOARD_DATASETS: tuple[str, ...] = (
     "mendelian_traits",
@@ -29,8 +36,19 @@ LEADERBOARD_DATASETS: tuple[str, ...] = (
 def main() -> None:
     parts = []
     for dataset in LEADERBOARD_DATASETS:
-        df = normalized_rows(dataset).with_columns(dataset=pl.lit(dataset))
-        parts.append(df)
+        parts.append(
+            normalized_rows(dataset).with_columns(
+                dataset=pl.lit(dataset), supervision=pl.lit("unsupervised")
+            )
+        )
+        # Supervised (linear-probe) rows where a marin_dna model has #347-schema probe
+        # metrics on S3 — mendelian only today, empty elsewhere. Appended only when present
+        # so an empty frame never perturbs the concat schema.
+        supervised = probe_normalized_rows(dataset).with_columns(
+            dataset=pl.lit(dataset), supervision=pl.lit("supervised")
+        )
+        if supervised.height:
+            parts.append(supervised)
     out = pl.concat(parts, how="vertical_relaxed")
     out.write_parquet(sys.stdout.buffer)
 

--- a/dashboard/src/leaderboards/complex.md
+++ b/dashboard/src/leaderboards/complex.md
@@ -22,7 +22,10 @@ import {
 
 ```js
 const allRows = rowsFromLeaderboard(leaderboard);
-const complex = allRows.filter(r => r.dataset === "complex_traits");
+// Zero-shot view only: exclude any `supervision === "supervised"` (linear-probe) rows. None
+// exist for complex_traits today, but this keeps the page correct-by-construction if a
+// complex probe cell is ever added — the two metric-worlds must never mix in one ranking.
+const complex = allRows.filter(r => r.dataset === "complex_traits" && r.supervision !== "supervised");
 const modelById = new Map(methods.map(m => [m.id, m]));
 const meta = datasets.complex_traits;
 ```

--- a/dashboard/src/leaderboards/mendelian.md
+++ b/dashboard/src/leaderboards/mendelian.md
@@ -77,6 +77,18 @@ const mode = view(labeledRow(
 ```
 
 ```js
+// One-way watcher: reset the sort column to the leading aggregate whenever the mode changes.
+// The persisted sort key may name a column the new mode lacks (e.g. Global in Supervised),
+// which would otherwise blank the "Best per family" table + forest plot and drop the row
+// order to alphabetical. Reads `mode` (the trigger) but not sortKeyState, so header-click
+// writes don't re-fire it (no cycle) — same idiom as protocols/marin_dna.md.
+{
+  mode;
+  setSortKey(leadingAggregateSubset(meta));
+}
+```
+
+```js
 // Single source of truth: add/remove a key in `FAMILY_LABEL` (controls.js)
 // to surface a new family pill. Selecting a family reveals its protocol
 // chips inset in the pill (multi-protocol families only).

--- a/dashboard/src/leaderboards/mendelian.md
+++ b/dashboard/src/leaderboards/mendelian.md
@@ -63,6 +63,8 @@ display(html`<div class="card">
 </div>`);
 ```
 
+## Leaderboard
+
 ```js
 // Top-level mode toggle: swaps the whole leaderboard between the two metric-worlds. They
 // are not level-comparable (matched-pair AUPRC vs per-chromosome-weighted AUPRC), so they
@@ -73,8 +75,6 @@ const mode = view(labeledRow(
   "Unsupervised = zero-shot likelihood. Supervised = frozen-embedding linear probe (MarinDNA only). Different metrics — shown one at a time.",
 ));
 ```
-
-## Leaderboard
 
 ```js
 // Single source of truth: add/remove a key in `FAMILY_LABEL` (controls.js)

--- a/dashboard/src/leaderboards/mendelian.md
+++ b/dashboard/src/leaderboards/mendelian.md
@@ -31,18 +31,6 @@ const meta = datasets.mendelian_traits;
 ```
 
 ```js
-// Top-level mode toggle: swaps the whole leaderboard between the two metric-worlds. They
-// are not level-comparable (matched-pair AUPRC vs per-chromosome-weighted AUPRC), so they
-// are never shown together — everything below filters on this. Default = Unsupervised
-// (current behaviour). Supervised = the frozen-embedding linear probe (MarinDNA only).
-const mode = view(labeledRow(
-  "Supervision",
-  PillSelect(Object.keys(SUPERVISION_LABEL), "unsupervised", (m) => SUPERVISION_LABEL[m]),
-  "Unsupervised = zero-shot likelihood. Supervised = frozen-embedding linear probe (MarinDNA only). Different metrics — shown one at a time.",
-));
-```
-
-```js
 // Sort column state — lives outside the heatmap so it survives re-mounts
 // when family / protocol / search filters change. Mutable persists
 // across all later heatmap re-renders.
@@ -66,12 +54,24 @@ display(html`<div class="card">
     <div><b>Positives:</b> ${meta.positives}</div>
     <div><b>Negatives:</b> ${meta.negatives}</div>
     <div><b>Matching:</b> ${meta.matching}</div>
-    <div><b>Metric:</b> ${mode === "supervised" ? meta.probe_metric : meta.metric}</div>
+    <div><b>Metric — Unsupervised:</b> ${meta.metric}</div>
+    <div><b>Metric — Supervised:</b> ${meta.probe_metric}</div>
   </div>
   <div class="dataset-notes">
-    ${(mode === "supervised" ? meta.probe_notes : meta.notes).map((n) => html`<div>${n}</div>`)}
+    ${meta.notes.map((n) => html`<div>${n}</div>`)}
   </div>
 </div>`);
+```
+
+```js
+// Top-level mode toggle: swaps the whole leaderboard between the two metric-worlds. They
+// are not level-comparable (matched-pair AUPRC vs per-chromosome-weighted AUPRC), so they
+// are never shown together — everything below filters on this. Default = Unsupervised.
+const mode = view(labeledRow(
+  "Supervision",
+  PillSelect(Object.keys(SUPERVISION_LABEL), "unsupervised", (m) => SUPERVISION_LABEL[m]),
+  "Unsupervised = zero-shot likelihood. Supervised = frozen-embedding linear probe (MarinDNA only). Different metrics — shown one at a time.",
+));
 ```
 
 ## Leaderboard
@@ -152,6 +152,50 @@ const displayRows = (() => {
 ```
 
 <style>
+/* Top-level supervision toggle — a modern segmented "pill" control (iOS-style:
+   rounded track, white raised active segment). */
+.lb-control-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  margin: 0.25em 0 1.25em;
+  flex-wrap: wrap;
+}
+.lb-control-label { color: #333; font-weight: 600; font-size: 0.9em; }
+.lb-control-hint {
+  color: #9a9a9a;
+  font-size: 0.8em;
+  line-height: 1.35;
+  max-width: 52ch;
+}
+.lb-protocol-segmented {
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+  background: #eef0f3;
+  border-radius: 9999px;
+}
+.lb-protocol-btn {
+  appearance: none;
+  border: none;
+  background: transparent;
+  border-radius: 9999px;
+  padding: 6px 18px;
+  font: inherit;
+  font-size: 0.9em;
+  font-weight: 500;
+  color: #555;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, box-shadow 120ms ease;
+}
+.lb-protocol-btn:hover:not(.active) { color: #111; }
+.lb-protocol-btn.active {
+  background: #fff;
+  color: #111;
+  font-weight: 600;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.14), 0 1px 1px rgba(0, 0, 0, 0.06);
+}
+
 /* Observable Framework's default theme caps prose elements at 640px and
    constrains main to ~1072px even on a wide page. Override both so the
    heatmap and the side-by-side forest plot fit on one row. */

--- a/dashboard/src/leaderboards/mendelian.md
+++ b/dashboard/src/leaderboards/mendelian.md
@@ -13,10 +13,13 @@ const datasets = await FileAttachment("../data/datasets.json").json();
 import {heatmap, colorLegend, leadingAggregateSubset, rowsFromLeaderboard} from "../components/heatmap.js";
 import {
   FAMILY_LABEL,
+  SUPERVISION_LABEL,
   PROTOCOL_OPTIONS,
   PROTOCOL_DEFAULTS,
   FamilyProtocolToggle,
   PillToggle,
+  PillSelect,
+  labeledRow,
 } from "../components/controls.js";
 ```
 
@@ -25,6 +28,18 @@ const allRows = rowsFromLeaderboard(leaderboard);
 const mendelian = allRows.filter(r => r.dataset === "mendelian_traits");
 const modelById = new Map(methods.map(m => [m.id, m]));
 const meta = datasets.mendelian_traits;
+```
+
+```js
+// Top-level mode toggle: swaps the whole leaderboard between the two metric-worlds. They
+// are not level-comparable (matched-pair AUPRC vs per-chromosome-weighted AUPRC), so they
+// are never shown together — everything below filters on this. Default = Unsupervised
+// (current behaviour). Supervised = the frozen-embedding linear probe (MarinDNA only).
+const mode = view(labeledRow(
+  "Supervision",
+  PillSelect(Object.keys(SUPERVISION_LABEL), "unsupervised", (m) => SUPERVISION_LABEL[m]),
+  "Unsupervised = zero-shot likelihood. Supervised = frozen-embedding linear probe (MarinDNA only). Different metrics — shown one at a time.",
+));
 ```
 
 ```js
@@ -51,10 +66,10 @@ display(html`<div class="card">
     <div><b>Positives:</b> ${meta.positives}</div>
     <div><b>Negatives:</b> ${meta.negatives}</div>
     <div><b>Matching:</b> ${meta.matching}</div>
-    <div><b>Metric:</b> ${meta.metric}</div>
+    <div><b>Metric:</b> ${mode === "supervised" ? meta.probe_metric : meta.metric}</div>
   </div>
   <div class="dataset-notes">
-    ${meta.notes.map((n) => html`<div>${n}</div>`)}
+    ${(mode === "supervised" ? meta.probe_notes : meta.notes).map((n) => html`<div>${n}</div>`)}
   </div>
 </div>`);
 ```
@@ -65,8 +80,21 @@ display(html`<div class="card">
 // Single source of truth: add/remove a key in `FAMILY_LABEL` (controls.js)
 // to surface a new family pill. Selecting a family reveals its protocol
 // chips inset in the pill (multi-protocol families only).
-const families = Object.keys(FAMILY_LABEL);
-const sel = view(FamilyProtocolToggle(families, PROTOCOL_OPTIONS, PROTOCOL_DEFAULTS));
+//
+// Supervised mode restricts to the families that actually have probe rows (only
+// `marin_dna` today) and drops the protocol chips — the probe is a single "probe"
+// protocol, so passing empty options makes FamilyProtocolToggle render plain pills.
+const supervisedFamilies = [
+  ...new Set(mendelian.filter(r => r.supervision === "supervised").map(r => r.family)),
+];
+const families = mode === "supervised"
+  ? Object.keys(FAMILY_LABEL).filter(f => supervisedFamilies.includes(f))
+  : Object.keys(FAMILY_LABEL);
+const sel = view(FamilyProtocolToggle(
+  families,
+  mode === "supervised" ? {} : PROTOCOL_OPTIONS,
+  mode === "supervised" ? {} : PROTOCOL_DEFAULTS,
+));
 ```
 
 ```js
@@ -84,11 +112,15 @@ const bestOnly = view(PillToggle("Best per family", false));
 
 ```js
 const filtered = mendelian.filter(r => {
+  if (r.supervision !== mode) return false;
   if (!sel.families.includes(r.family)) return false;
-  // One protocol per family. Falls back to DEFAULTS for families that
-  // don't appear in `sel.protocols` (single-option families).
-  const wantedProtocol = sel.protocols[r.family] ?? PROTOCOL_DEFAULTS[r.family];
-  if (r.protocol !== wantedProtocol) return false;
+  // Unsupervised: one protocol per family (LLR / JSD / cLLR …), falling back to DEFAULTS
+  // for single-option families. Supervised has a single "probe" protocol, so there is no
+  // protocol chip to match against — skip the check.
+  if (mode !== "supervised") {
+    const wantedProtocol = sel.protocols[r.family] ?? PROTOCOL_DEFAULTS[r.family];
+    if (r.protocol !== wantedProtocol) return false;
+  }
   if (search && !r.method_display.toLowerCase().includes(search.toLowerCase())) return false;
   return true;
 });
@@ -309,6 +341,10 @@ display(
     sortKey: sortKeyState,
     onSortChange: setSortKey,
     leadingAggregate: meta.leading_aggregate === "macro_avg" ? "_macro_avg_" : "_global_",
+    // Supervised probe has no pooled Global (separate per-subset classifiers); drop the
+    // column so it doesn't render as an all-"—" ghost. The ±1 SE forest plot stays on —
+    // probe rows carry the chromosome-cluster bootstrap SE (#347).
+    showGlobal: mode !== "supervised",
   }),
 );
 ```

--- a/src/marin_dna/pipelines/evals/leaderboard.py
+++ b/src/marin_dna/pipelines/evals/leaderboard.py
@@ -37,6 +37,12 @@ from marin_dna.pipelines.evals.models import ALL_DATASETS, Model, models_for_dat
 S3 = "s3://oa-bolinas"
 SPLIT = "train"
 
+# Positives gate for a subset to count toward the probe Supervised view's macro `n` (the
+# heatmap's "K subsets" header). Matches the leaderboard display threshold (heatmap.js
+# `N_POSITIVES_MIN`) and the probe pipeline's macro `n_min` (#347), so K = the subsets the
+# heatmap actually renders as columns.
+_MACRO_MIN_POSITIVES = 30
+
 # `family: gpn_star` AUPRC metrics now come from the frozen S3 results of the
 # `gpn_star_eval` pipeline (refreshed in #278; the pipeline itself now runs from a
 # branch — #332), same as the conservation / alphagenome / marin_dna families — one
@@ -302,6 +308,106 @@ def normalized_rows(dataset: str) -> pl.DataFrame:
                     }
                 )
     return pl.DataFrame(rows)
+
+
+# Explicit schema so an empty result (no marin_dna model has a probe parquet yet) still
+# concatenates cleanly with `normalized_rows` in the dashboard loader. Mirrors the column
+# order and dtypes `normalized_rows` produces.
+_PROBE_ROW_SCHEMA: dict = {
+    "method_id": pl.String,
+    "method_display": pl.String,
+    "family": pl.String,
+    "protocol": pl.String,
+    "subset": pl.String,
+    "value": pl.Float64,
+    "se": pl.Float64,
+    "n": pl.Int64,
+    "n_positives": pl.Int64,
+}
+
+
+def probe_normalized_rows(dataset: str) -> pl.DataFrame:
+    """Long-form linear-probe (supervised) rows for the dashboard's Supervised mode.
+
+    Reads the frozen-embedding probe metrics (``probe_metrics/{id}/{dataset}.parquet`` from
+    the ``evals_v2`` pipeline — per-subset per-chromosome-weighted AUPRC + chromosome-cluster
+    bootstrap SE + a ``_macro_avg_`` row, #347) for every ``marin_dna`` model registered for
+    ``dataset``, keeps the ``probe_score`` rows on the ``train`` split, and maps them onto the
+    same schema as ``normalized_rows`` so the leaderboard heatmap renders them unchanged.
+
+    Only ``marin_dna`` has probes (they need our ``emb_ref``/``emb_alt`` embeddings), so no
+    other family contributes supervised rows. The pipeline already emits the ``_macro_avg_``
+    aggregate (**no** ``_global_`` — probe scores come from a separate per-subset classifier),
+    so nothing is synthesized here. Models whose probe parquet isn't on S3 yet are skipped
+    with a warning (same soft-fail posture as ``normalized_rows``).
+
+    Emits ``[method_id, method_display, family, protocol, subset, value, se, n, n_positives]``
+    with ``protocol == "probe"`` (the Supervised view has a single protocol). On the
+    ``_macro_avg_`` row ``n`` / ``n_positives`` are overloaded to K = the number of subsets
+    entering the macro (the heatmap's "K subsets" header), mirroring ``fetch_method_metrics``'s
+    matched-pair macro; per-subset ``n`` / ``n_positives`` are the probe parquet's total
+    variants / positives.
+    """
+    # OSError covers the S3-404 case (a marin_dna model registered for the dataset whose probe
+    # run hasn't landed); the others mirror `normalized_rows`' soft-fail set.
+    soft_fail = (LookupError, pl.exceptions.ComputeError, FileNotFoundError, OSError)
+    rows: list[dict] = []
+    for method in models_for_dataset(dataset):
+        if method.family != "marin_dna":
+            continue
+        path = (
+            f"{S3}/snakemake/analysis/evals_v2/results/probe_metrics/"
+            f"{method.id}/{dataset}.parquet"
+        )
+        try:
+            df = _read_parquet(path).filter(
+                (pl.col("score_type") == "probe_score") & (pl.col("split") == SPLIT)
+            )
+        except soft_fail as exc:
+            print(f"  ! probe skip for {method.id} ({dataset}): {exc}", file=sys.stderr)
+            continue
+        if df.height == 0:
+            print(
+                f"  ! probe no probe_score rows for {method.id} ({dataset}) in {path}",
+                file=sys.stderr,
+            )
+            continue
+        # Require the #347 schema — an `se` column and the pipeline-emitted `_macro_avg_`
+        # row. A pre-#347 parquet (per-subset only, no SE, no aggregate — e.g. a #341
+        # scaling-ladder run) is skipped rather than shown with blank error bars and no
+        # Macro Avg column; re-run its `compute_probe_metrics` to surface it.
+        if "se" not in df.columns or not (df["subset"] == MACRO_AVG_SUBSET).any():
+            print(
+                f"  ! probe stale-schema for {method.id} ({dataset}): missing se/_macro_avg_ "
+                f"(pre-#347) — re-run compute_probe_metrics to surface it",
+                file=sys.stderr,
+            )
+            continue
+        # K = subsets entering the macro: per-subset rows with a finite value that clear the
+        # display gate — the same set the probe pipeline's `n_min` averaged and the heatmap
+        # renders as columns. Overloaded onto the macro row's n / n_positives (the "K subsets"
+        # header), matching `fetch_method_metrics`'s matched-pair macro.
+        k = df.filter(
+            (pl.col("subset") != MACRO_AVG_SUBSET)
+            & pl.col("value").is_not_null()
+            & (pl.col("n_pos") >= _MACRO_MIN_POSITIVES)
+        ).height
+        for row in df.iter_rows(named=True):
+            is_macro = row["subset"] == MACRO_AVG_SUBSET
+            rows.append(
+                {
+                    "method_id": method.id,
+                    "method_display": method.display,
+                    "family": method.family,
+                    "protocol": "probe",
+                    "subset": row["subset"],
+                    "value": _nan_float(row["value"]),
+                    "se": _nan_float(row["se"]),
+                    "n": k if is_macro else int(row["n"]),
+                    "n_positives": k if is_macro else int(row["n_pos"]),
+                }
+            )
+    return pl.DataFrame(rows, schema=_PROBE_ROW_SCHEMA)
 
 
 # Columns kept from each method's SGE metrics parquet, in output order.

--- a/src/marin_dna/pipelines/evals/leaderboard.py
+++ b/src/marin_dna/pipelines/evals/leaderboard.py
@@ -37,12 +37,6 @@ from marin_dna.pipelines.evals.models import ALL_DATASETS, Model, models_for_dat
 S3 = "s3://oa-bolinas"
 SPLIT = "train"
 
-# Positives gate for a subset to count toward the probe Supervised view's macro `n` (the
-# heatmap's "K subsets" header). Matches the leaderboard display threshold (heatmap.js
-# `N_POSITIVES_MIN`) and the probe pipeline's macro `n_min` (#347), so K = the subsets the
-# heatmap actually renders as columns.
-_MACRO_MIN_POSITIVES = 30
-
 # `family: gpn_star` AUPRC metrics now come from the frozen S3 results of the
 # `gpn_star_eval` pipeline (refreshed in #278; the pipeline itself now runs from a
 # branch — #332), same as the conservation / alphagenome / marin_dna families — one
@@ -313,7 +307,7 @@ def normalized_rows(dataset: str) -> pl.DataFrame:
 # Explicit schema so an empty result (no marin_dna model has a probe parquet yet) still
 # concatenates cleanly with `normalized_rows` in the dashboard loader. Mirrors the column
 # order and dtypes `normalized_rows` produces.
-_PROBE_ROW_SCHEMA: dict = {
+_PROBE_ROW_SCHEMA: dict[str, pl.DataType] = {
     "method_id": pl.String,
     "method_display": pl.String,
     "family": pl.String,
@@ -383,14 +377,14 @@ def probe_normalized_rows(dataset: str) -> pl.DataFrame:
                 file=sys.stderr,
             )
             continue
-        # K = subsets entering the macro: per-subset rows with a finite value that clear the
-        # display gate — the same set the probe pipeline's `n_min` averaged and the heatmap
-        # renders as columns. Overloaded onto the macro row's n / n_positives (the "K subsets"
-        # header), matching `fetch_method_metrics`'s matched-pair macro.
+        # K = subsets entering the macro = per-subset rows with a finite value. A finite probe
+        # value already implies the subset cleared `min_variants=300` (⇒ ≥30 positives under
+        # 1:9), i.e. exactly the set the pipeline's macro `n_min` averaged and the heatmap
+        # renders as columns — so no separate positives threshold is needed here. Overloaded
+        # onto the macro row's n / n_positives (the "K subsets" header), matching
+        # `fetch_method_metrics`'s matched-pair macro.
         k = df.filter(
-            (pl.col("subset") != MACRO_AVG_SUBSET)
-            & pl.col("value").is_not_null()
-            & (pl.col("n_pos") >= _MACRO_MIN_POSITIVES)
+            (pl.col("subset") != MACRO_AVG_SUBSET) & pl.col("value").is_not_null()
         ).height
         for row in df.iter_rows(named=True):
             is_macro = row["subset"] == MACRO_AVG_SUBSET

--- a/tests/pipelines/evals/test_leaderboard.py
+++ b/tests/pipelines/evals/test_leaderboard.py
@@ -18,6 +18,7 @@ from marin_dna.pipelines.evals.leaderboard import (
     PROTOCOLS,
     fetch_method_metrics,
     normalized_rows,
+    probe_normalized_rows,
     score_type_for,
 )
 from marin_dna.pipelines.evals.models import Model
@@ -563,3 +564,149 @@ def test_sge_normalized_rows_skips_missing_parquet(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(leaderboard, "_read_parquet", fake)
     df = leaderboard.sge_normalized_rows("sge")
     assert set(df["method_id"].to_list()) == {"phyloP_100v"}
+
+
+# ---- probe_normalized_rows (supervised linear-probe view, #348) --------------
+
+
+def _probe_path(method_id: str, dataset: str = "mendelian_traits") -> str:
+    return (
+        f"{leaderboard.S3}/snakemake/analysis/evals_v2/results/probe_metrics/"
+        f"{method_id}/{dataset}.parquet"
+    )
+
+
+def _probe_parquet(
+    *, model: str = "m1", with_se: bool = True, with_macro: bool = True
+) -> pl.DataFrame:
+    """Synthetic ``compute_probe_metrics`` output: two qualifying subsets (missense,
+    splicing) + one below-gate subset (mature_miRNA, null probe value) for both the
+    ``probe_score`` and its ``minus_llr_avg`` baseline, plus the pipeline's ``_macro_avg_``
+    row. ``with_se=False`` / ``with_macro=False`` reproduce a pre-#347 (stale) parquet."""
+    # (subset, n, n_pos, probe_value, baseline_value)
+    subs = [
+        ("missense_variant", 500, 50, 0.55, 0.50),
+        ("splicing", 400, 40, 0.60, 0.55),
+        ("mature_miRNA_variant", 40, 4, None, 0.80),  # below gate; probe skipped (null)
+    ]
+    value_idx = {"probe_score": 3, "minus_llr_avg": 4}
+    rows: list[dict] = []
+    for score_type, vi in value_idx.items():
+        for s in subs:
+            rows.append(
+                dict(
+                    score_type=score_type,
+                    subset=s[0],
+                    value=s[vi],
+                    se=0.03,
+                    n=s[1],
+                    n_pos=s[2],
+                    n_chrom=10,
+                    model=model,
+                    dataset="mendelian_traits",
+                    split="train",
+                )
+            )
+        if with_macro:
+            qual = [s for s in subs if s[vi] is not None and s[2] >= 30]
+            rows.append(
+                dict(
+                    score_type=score_type,
+                    subset=MACRO_AVG_SUBSET,
+                    value=sum(s[vi] for s in qual) / len(qual),
+                    se=0.015,
+                    n=sum(s[1] for s in qual),
+                    n_pos=sum(s[2] for s in qual),
+                    n_chrom=12,
+                    model=model,
+                    dataset="mendelian_traits",
+                    split="train",
+                )
+            )
+    df = pl.DataFrame(rows)
+    return df.drop("se") if not with_se else df
+
+
+_PROBE_COLS = {
+    "method_id",
+    "method_display",
+    "family",
+    "protocol",
+    "subset",
+    "value",
+    "se",
+    "n",
+    "n_positives",
+}
+
+
+def test_probe_normalized_rows_maps_supervised_schema(monkeypatch: pytest.MonkeyPatch):
+    """A marin_dna model with a #347-schema probe parquet → probe_score per-subset + macro
+    rows, protocol='probe', no _global_, macro n/n_positives overloaded to K (qualifying
+    subsets), and the below-gate subset kept as a NaN row."""
+    m = _mk_method(id="m1", display="M1", family="marin_dna")
+    _patch_methods(monkeypatch, (m,))
+    _patch_read_parquet(monkeypatch, {_probe_path("m1"): _probe_parquet(model="m1")})
+
+    df = probe_normalized_rows("mendelian_traits")
+    assert set(df.columns) == _PROBE_COLS
+    assert df["protocol"].unique().to_list() == ["probe"]
+    # Only probe_score survives (the baseline is dropped); no _global_ row.
+    assert GLOBAL_SUBSET not in df["subset"].to_list()
+    assert MACRO_AVG_SUBSET in df["subset"].to_list()
+
+    macro = df.filter(pl.col("subset") == MACRO_AVG_SUBSET)
+    assert macro["n"].to_list() == [2] and macro["n_positives"].to_list() == [2]  # K
+    assert macro["value"][0] == pytest.approx((0.55 + 0.60) / 2)
+
+    mis = df.filter(pl.col("subset") == "missense_variant")
+    assert mis["n"][0] == 500 and mis["n_positives"][0] == 50  # per-subset totals
+    mir = df.filter(pl.col("subset") == "mature_miRNA_variant")
+    assert mir.height == 1 and mir["value"][0] != mir["value"][0]  # NaN, still emitted
+
+
+def test_probe_normalized_rows_only_marin_dna(monkeypatch: pytest.MonkeyPatch):
+    """Only marin_dna contributes supervised rows; other families are skipped before any
+    read (their probe path is never even requested)."""
+    marin = _mk_method(id="m1", family="marin_dna")
+    cons = _mk_method(id="phyloP_100v", family="conservation")
+    _patch_methods(monkeypatch, (marin, cons))
+    _patch_read_parquet(monkeypatch, {_probe_path("m1"): _probe_parquet(model="m1")})
+
+    df = probe_normalized_rows("mendelian_traits")
+    assert df["family"].unique().to_list() == ["marin_dna"]
+
+
+def test_probe_normalized_rows_skips_stale_schema(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+):
+    """A pre-#347 parquet (no `se` column, no `_macro_avg_` row) is skipped with a warning
+    rather than shown with blank error bars / no aggregate."""
+    fresh = _mk_method(id="fresh", family="marin_dna")
+    stale = _mk_method(id="stale", family="marin_dna")
+    _patch_methods(monkeypatch, (fresh, stale))
+    _patch_read_parquet(
+        monkeypatch,
+        {
+            _probe_path("fresh"): _probe_parquet(model="fresh"),
+            _probe_path("stale"): _probe_parquet(
+                model="stale", with_se=False, with_macro=False
+            ),
+        },
+    )
+
+    df = probe_normalized_rows("mendelian_traits")
+    assert df["method_id"].unique().to_list() == ["fresh"]
+    assert "stale-schema" in capsys.readouterr().err
+
+
+def test_probe_normalized_rows_skips_missing_parquet(monkeypatch: pytest.MonkeyPatch):
+    """A marin_dna model whose probe parquet isn't on S3 yet is skipped (soft-fail), and
+    the empty result still carries the explicit schema so it concatenates downstream."""
+    m = _mk_method(id="pending", family="marin_dna")
+    _patch_methods(monkeypatch, (m,))
+    _patch_read_parquet(monkeypatch, {})  # every read raises FileNotFoundError
+
+    df = probe_normalized_rows("mendelian_traits")
+    assert df.height == 0
+    assert set(df.columns) == _PROBE_COLS


### PR DESCRIPTION
Closes #348. Builds on #347 (merged) — reads the probe metric's `se` + `_macro_avg_` row.

## What

A top-level **`Unsupervised | Supervised`** toggle on the [Mendelian leaderboard](https://github.com/Open-Athena/marin-dna/blob/e279f19ccc7fd5b60aacff376a842b796f18ee43/dashboard/src/leaderboards/mendelian.md) that swaps the whole page between the two metric-worlds. They are **not level-comparable** (zero-shot cluster-bootstrap matched-pair AUPRC vs the probe's per-chromosome-weighted AUPRC), so the page shows one at a time — never mixed in a ranked column. Default is **Unsupervised** (current behaviour unchanged).

## How

- **Data layer** — [`probe_normalized_rows`](https://github.com/Open-Athena/marin-dna/blob/e279f19ccc7fd5b60aacff376a842b796f18ee43/src/marin_dna/pipelines/evals/leaderboard.py#L329-L406): reads the frozen-embedding probe metrics (`probe_metrics/{id}/{dataset}.parquet`, #347) for every `marin_dna` model registered for the dataset, keeps `probe_score` on `train`, and maps to `normalized_rows`' schema with `protocol="probe"`. Emits the per-subset rows + the pipeline's `_macro_avg_` (**no `_global_`** — separate per-subset classifiers), with the macro `n`/`n_positives` overloaded to K (the "K subsets" header) like `fetch_method_metrics`' matched-pair macro.
- **Loader** — `leaderboard.parquet.py` tags `normalized_rows` `unsupervised` and concatenates `probe_normalized_rows` `supervised`, emitting a `supervision` column.
- **Heatmap** — passes `supervision` through, and a new [`showGlobal` gate](https://github.com/Open-Athena/marin-dna/blob/e279f19ccc7fd5b60aacff376a842b796f18ee43/dashboard/src/components/heatmap.js#L183-L189) drops the empty Global column in supervised mode. `showForest` stays on — probe rows carry the #347 SE.
- **Page** — the [mode toggle](https://github.com/Open-Athena/marin-dna/blob/e279f19ccc7fd5b60aacff376a842b796f18ee43/dashboard/src/leaderboards/mendelian.md#L31-L44) drives everything: supervised restricts to `marin_dna`, drops the protocol chips + protocol filter, hides Global, and swaps the metric caption/notes (`controls.js` `SUPERVISION_LABEL`; `datasets.json.py` `probe_metric`/`probe_notes`).

## What the Supervised view shows

MarinDNA probe results only — **`exp135-1B-m5.1` and `scaling-v0.5-4B` today** (2 models), with more appearing as they're probed. Per-subset per-chromosome-weighted AUPRC + a Macro Avg column with a ±1 SE forest plot; no Global column.

The loader **requires the #347 schema** (an `se` column + a `_macro_avg_` row): a pre-#347 parquet is skipped with a warning rather than shown with blank error bars. `scaling-v0.5-4B` (registered in `models.yaml`) has been **re-run** through `compute_probe_metrics`, so it now carries SE and shows alongside exp135. The 7 smaller scaling-ladder rungs (46M–2B, unregistered) are intentionally left out.

## Verification

- `uv run pytest` — 209 evals tests pass, including 6 new `probe_normalized_rows` tests (schema + macro-K overload, no-`_global_`, non-`marin_dna` ignored, **stale-schema skipped**, missing-parquet soft-fail).
- `probe_normalized_rows("mendelian_traits")` against real S3: 1 method (exp135), 9 per-subset + macro, macro `n`=K=8, `mature_miRNA` below-gate NaN row, stale scaling model skipped.
- Full `observable build` succeeds and renders the Mendelian page; the built leaderboard parquet carries **1232 unsupervised + 10 supervised** mendelian rows and a `supervision` column.

The build validates compile/imports/loaders; the **interactive runtime** (toggling modes, the forest in supervised, the dropped Global column) is best confirmed in a local `npm run dev` preview — I couldn't headless-screenshot it from the dev box (no browser installed). Happy to walk through a preview if useful.



## Refinements from live preview

- The toggle sits **under the Leaderboard heading** as the first control (a modern segmented pill), so mode → family/protocol → search reads top-down.
- The dataset card lists **both** the Unsupervised and Supervised metric descriptions (mode-independent), rather than swapping on the toggle.
- Fixed a Supervised-only bug: the Macro Avg header read **"0 subsets"** because the heatmap's header-count logic required a Global row (which the probe view lacks) — it now requires only the Macro row.
