### PR TITLE
dashboard(mendelian): surface Evo 2 (1B / 7B / 40B) linear-probe results in the Supervised view

### DIFF
--- a/dashboard/src/data/datasets.json.py
+++ b/dashboard/src/data/datasets.json.py
@@ -25,9 +25,9 @@ _PROBE_METRIC = (
     "Per-chromosome-weighted AUPRC (TraitGym) ± chromosome-cluster bootstrap SE (#347) — "
     "AUPRC is computed within each chromosome then size-weighted, and Macro Avg is the "
     "unweighted mean over subsets (no Global column: the probe fits a separate classifier "
-    "per subset). MarinDNA only, since probes read our per-allele embeddings; a subset is "
-    "probed only with at least 300 variants and 3 chromosomes. Not level-comparable to the "
-    "Unsupervised metric above — different weighting and matching."
+    "per subset). MarinDNA and Evo 2, since a probe reads that model's own per-allele "
+    "embeddings; a subset is probed only with at least 300 variants and 3 chromosomes. Not "
+    "level-comparable to the Unsupervised metric above — different weighting and matching."
 )
 
 # caQTL/dsQTL moved to the supervised official-metrics Accessibility QTL page (#312),

--- a/dashboard/src/data/leaderboard.parquet.py
+++ b/dashboard/src/data/leaderboard.parquet.py
@@ -10,7 +10,8 @@ dashboard to read via DuckDB. The Mendelian page's top-level mode toggle filters
 
 Emits one parquet covering the matched-pair leaderboard datasets (mendelian_traits,
 complex_traits). Each page filters by ``dataset``, so they coexist in one file. Supervised
-rows exist only where a marin_dna model has probe metrics on S3 (mendelian today). eQTL
+rows exist where a probe-capable model (marin_dna on S3, Evo 2 on the pinned gist) has probe
+metrics (mendelian today). eQTL
 was retired in PR #194 (issue #172); the caQTL/dsQTL zero-shot path was retired in #312
 (the supervised official-metrics benchmark now lives on its own Accessibility QTL page,
 fed by ``accessibility_qtl.parquet.py``).

--- a/dashboard/src/leaderboards/mendelian.md
+++ b/dashboard/src/leaderboards/mendelian.md
@@ -72,7 +72,7 @@ display(html`<div class="card">
 const mode = view(labeledRow(
   "Supervision",
   PillSelect(Object.keys(SUPERVISION_LABEL), "unsupervised", (m) => SUPERVISION_LABEL[m]),
-  "Unsupervised = zero-shot likelihood. Supervised = frozen-embedding linear probe (MarinDNA only). Different metrics — shown one at a time.",
+  "Unsupervised = zero-shot likelihood. Supervised = frozen-embedding linear probe (MarinDNA + Evo 2). Different metrics — shown one at a time.",
 ));
 ```
 

--- a/scripts/evo2_eval/recompute_probe_metrics_with_se.py
+++ b/scripts/evo2_eval/recompute_probe_metrics_with_se.py
@@ -1,0 +1,167 @@
+"""Recompute the Evo 2 frozen-embedding probe metrics WITH chromosome-cluster bootstrap SE
+and a ``_macro_avg_`` row (#349), so they carry the exact schema the dashboard Supervised
+loader (``probe_normalized_rows``) requires.
+
+The #335 Evo 2 probe metrics (`s3://oa-bolinas/analysis/evo2_embeddings/mendelian_traits/
+probe/{model}_train_probe_metrics.parquet`) were produced by the one-off `train_variant_probe.py`
+script in a *wide* format (`probe_per_chrom_ap`, `probe_global_ap_se`, ...) with the
+pre-#349 `per_chrom_weighted_ap` — point estimates only, no per-chrom-weighted SE, no
+`_macro_avg_` row. This script re-runs the **metrics step only** over the existing per-variant
+probe **predictions** (`{model}_train_probe.parquet`, already on S3) through the same
+`per_chrom_ap_table` call that evals_v2's `compute_probe_metrics` rule makes, emitting the
+long `[score_type, subset, value, se, n, n_pos, n_chrom] + model/dataset/split` schema. CPU
+only — no GPU re-inference, no probe re-training.
+
+Only reconciliation vs the evals_v2 rule: the #335 bundle names its reverse-complement LLR
+atom ``llr_rev``; `compute_probe_metrics` expects ``llr_rc``. The FWD/RC-averaged baseline is
+otherwise identical (``minus_llr = -(llr_fwd + llr_rev)/2`` in the bundle).
+
+Provenance: issues #131 / #352. Run from the repo root:
+
+    uv run python scripts/evo2_eval/recompute_probe_metrics_with_se.py
+
+Outputs land in ``scratch/evo2_probe_metrics_se/`` named exactly as the gist expects
+(`mendelian_{model}_train_probe_metrics.parquet`), ready to push to EVO2_METRICS_GIST.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pandas as pd
+import polars as pl
+
+from marin_dna.pipelines.evals.metrics import SCORE_PROTOCOLS, per_chrom_ap_table
+
+DATASET = "mendelian_traits"
+SHORT = "mendelian"  # EVO2_DATASET_SHORT[mendelian_traits]; the gist filename prefix
+SPLIT = "train"
+# Mendelian is directional (concat_ref_delta feature): the zero-shot baseline is -LLR on the
+# FWD/RC-averaged raw LLR, exactly as compute_probe_metrics derives it (score_protocol=minus_llr).
+SCORE_PROTOCOL = "minus_llr"
+MODELS = ["evo2_1b_base", "evo2_7b", "evo2_40b"]
+
+S3_PROBE = "s3://oa-bolinas/analysis/evo2_embeddings/mendelian_traits/probe"
+OUT = pathlib.Path("scratch/evo2_probe_metrics_se")
+
+# per_chrom_ap_table knobs — must match config/config.yaml `probe:` (n_bootstrap/n_min) and the
+# rule's rng=0 pin, so the SE is bit-stable and comparable to the marin_dna probe rows.
+N_BOOTSTRAP = 1000
+N_MIN = 30
+MACRO = "_macro_avg_"
+
+
+def recompute(model: str) -> pd.DataFrame:
+    """Load one model's probe predictions and return the SE-carrying metrics table."""
+    preds = pl.read_parquet(f"{S3_PROBE}/{model}_train_probe.parquet").to_pandas()
+    # #335 bundle uses the `_rev` suffix; evals_v2 compute_probe_metrics uses `_rc`.
+    preds = preds.rename(columns={"llr_rev": "llr_rc"})
+    for col in ("probe_score", "label", "subset", "chrom", "llr_fwd", "llr_rc"):
+        assert col in preds.columns, f"{model}: predictions missing column {col!r}"
+
+    # Zero-shot baseline on the identical rows: dataset score protocol on the FWD/RC-avg raw
+    # LLR (== compute_metrics `_avg`), mirroring compute_probe_metrics exactly.
+    transform = SCORE_PROTOCOLS[SCORE_PROTOCOL]
+    baseline_col = f"{SCORE_PROTOCOL}_avg"
+    preds[baseline_col] = transform((preds["llr_fwd"] + preds["llr_rc"]) / 2)
+
+    metrics = per_chrom_ap_table(
+        preds,
+        ["probe_score", baseline_col],
+        n_bootstrap=N_BOOTSTRAP,
+        rng=0,
+        n_min=N_MIN,
+    )
+    metrics["model"] = model
+    metrics["dataset"] = DATASET
+    metrics["split"] = SPLIT
+    return metrics
+
+
+def verify(model: str, metrics: pd.DataFrame) -> None:
+    """Correctness gate: the recomputed per-subset point estimates must reproduce the #335
+    wide metrics parquet (== the #131 results table) exactly — we only *add* SE."""
+    old = pl.read_parquet(f"{S3_PROBE}/{model}_train_probe_metrics.parquet").to_pandas()
+    baseline_col = f"{SCORE_PROTOCOL}_avg"
+
+    new_probe = metrics[
+        (metrics.score_type == "probe_score") & (metrics.subset != MACRO)
+    ].set_index("subset")["value"]
+    new_llr = metrics[
+        (metrics.score_type == baseline_col) & (metrics.subset != MACRO)
+    ].set_index("subset")["value"]
+    old_probe = old.set_index("subset")["probe_per_chrom_ap"]
+    old_llr = old.set_index("subset")["llr_per_chrom_ap"]
+
+    # `per_chrom_ap_table` emits a row for EVERY subset in the predictions, incl. below-gate
+    # ones the #335 wide table dropped (e.g. mature_miRNA_variant, n<300 → NaN probe row).
+    # That's the evals_v2 `compute_probe_metrics` schema, so we require ⊆, not ==, and surface
+    # the extras.
+    assert set(old_probe.index) <= set(new_probe.index), (
+        f"{model}: #335 subsets not all reproduced: "
+        f"{set(old_probe.index) - set(new_probe.index)}"
+    )
+    extra = sorted(set(new_probe.index) - set(old_probe.index))
+    if extra:
+        print(
+            f"    [{model}] extra (below-gate) subsets emitted by per_chrom_ap_table:"
+        )
+        for s in extra:
+            print(
+                f"        {s}: probe value={new_probe[s]!r} (expected NaN, below 300 gate)"
+            )
+    for subset in old_probe.index:
+        assert abs(new_probe[subset] - old_probe[subset]) < 1e-9, (
+            f"{model} {subset}: probe AUPRC drift "
+            f"{new_probe[subset]:.6f} vs #335 {old_probe[subset]:.6f}"
+        )
+        assert abs(new_llr[subset] - old_llr[subset]) < 1e-9, (
+            f"{model} {subset}: LLR AUPRC drift "
+            f"{new_llr[subset]:.6f} vs #335 {old_llr[subset]:.6f}"
+        )
+
+    # Schema the dashboard loader requires: an `se` column + a `_macro_avg_` row.
+    assert "se" in metrics.columns, f"{model}: no se column"
+    macro = metrics[(metrics.score_type == "probe_score") & (metrics.subset == MACRO)]
+    assert len(macro) == 1, f"{model}: expected exactly one probe _macro_avg_ row"
+    assert pd.notna(macro["se"].iloc[0]), f"{model}: macro se is NaN"
+    # Every subset that cleared the gate carries a finite SE.
+    finite = metrics[(metrics.score_type == "probe_score") & metrics["value"].notna()]
+    assert finite["se"].notna().all(), f"{model}: a finite probe value has NaN se"
+
+
+def main() -> None:
+    OUT.mkdir(parents=True, exist_ok=True)
+    for model in MODELS:
+        metrics = recompute(model)
+        verify(model, metrics)
+        out = OUT / f"{SHORT}_{model}_train_probe_metrics.parquet"
+        metrics.to_parquet(out, index=False)
+
+        macro = metrics[
+            (metrics.score_type == "probe_score") & (metrics.subset == MACRO)
+        ].iloc[0]
+        # K = gated per-subset probe rows with a finite value (the set entering the macro);
+        # excludes the below-gate NaN subset the pipeline still emits as a row.
+        k = int(
+            (
+                (metrics.score_type == "probe_score")
+                & (metrics.subset != MACRO)
+                & metrics["value"].notna()
+            ).sum()
+        )
+        print(f"[{model}] wrote {out}  ({len(metrics)} rows)")
+        print(
+            f"    probe macro AUPRC = {macro['value']:.4f} ± {macro['se']:.4f} "
+            f"(K={k} gated subsets)"
+        )
+        with pd.option_context("display.width", 160, "display.max_columns", 20):
+            show = metrics[metrics.score_type == "probe_score"][
+                ["subset", "value", "se", "n", "n_pos", "n_chrom"]
+            ]
+            print(show.to_string(index=False))
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/marin_dna/pipelines/evals/leaderboard.py
+++ b/src/marin_dna/pipelines/evals/leaderboard.py
@@ -55,9 +55,9 @@ EVO2_METRICS_GIST_BASE = (
     f"{EVO2_METRICS_GIST_ID}/raw/{EVO2_METRICS_GIST_COMMIT}"
 )
 # `family: evo2` frozen-embedding probe (supervised) metrics — SAME gist, a SEPARATE pinned
-# commit (uploaded later than the zero-shot metrics above; the gist HEAD is a placeholder and
-# every artifact is pinned to its own upload commit, so this is decoupled from the zero-shot
-# pin on purpose). Bump when re-uploading probe metrics. See #352 / #131.
+# commit (uploaded later than the zero-shot metrics above, at its own commit; each artifact is
+# pinned independently, so this is decoupled from the zero-shot pin on purpose — bumping one
+# never disturbs the other). Bump when re-uploading probe metrics. See #352 / #131.
 EVO2_PROBE_METRICS_GIST_COMMIT = "3ac60cd5e37148fd135c4d55bed12386dc065dc6"
 EVO2_PROBE_METRICS_GIST_BASE = (
     f"https://gist.githubusercontent.com/{EVO2_METRICS_GIST_OWNER}/"
@@ -389,8 +389,13 @@ def probe_normalized_rows(dataset: str) -> pl.DataFrame:
     for method in models_for_dataset(dataset):
         if method.family not in PROBE_FAMILIES:
             continue
-        path = _probe_parquet_path(method, dataset)
         try:
+            # Inside the try so a per-model path-construction LookupError (e.g. a probe family
+            # registered for a dataset absent from `EVO2_DATASET_SHORT`) soft-fails that one
+            # model — matching the zero-shot path — rather than aborting the whole build. A
+            # non-probe family reaching `_probe_parquet_path` still raises `ValueError` (not in
+            # `soft_fail`) so a `PROBE_FAMILIES`/dispatch mismatch fails loud.
+            path = _probe_parquet_path(method, dataset)
             df = _read_parquet(path).filter(
                 (pl.col("score_type") == "probe_score") & (pl.col("split") == SPLIT)
             )

--- a/src/marin_dna/pipelines/evals/leaderboard.py
+++ b/src/marin_dna/pipelines/evals/leaderboard.py
@@ -54,6 +54,15 @@ EVO2_METRICS_GIST_BASE = (
     f"https://gist.githubusercontent.com/{EVO2_METRICS_GIST_OWNER}/"
     f"{EVO2_METRICS_GIST_ID}/raw/{EVO2_METRICS_GIST_COMMIT}"
 )
+# `family: evo2` frozen-embedding probe (supervised) metrics — SAME gist, a SEPARATE pinned
+# commit (uploaded later than the zero-shot metrics above; the gist HEAD is a placeholder and
+# every artifact is pinned to its own upload commit, so this is decoupled from the zero-shot
+# pin on purpose). Bump when re-uploading probe metrics. See #352 / #131.
+EVO2_PROBE_METRICS_GIST_COMMIT = "3ac60cd5e37148fd135c4d55bed12386dc065dc6"
+EVO2_PROBE_METRICS_GIST_BASE = (
+    f"https://gist.githubusercontent.com/{EVO2_METRICS_GIST_OWNER}/"
+    f"{EVO2_METRICS_GIST_ID}/raw/{EVO2_PROBE_METRICS_GIST_COMMIT}"
+)
 # Dataset → metric-parquet filename prefix. Extend when adding complex_traits.
 EVO2_DATASET_SHORT: dict[str, str] = {
     "mendelian_traits": "mendelian",
@@ -304,7 +313,7 @@ def normalized_rows(dataset: str) -> pl.DataFrame:
     return pl.DataFrame(rows)
 
 
-# Explicit schema so an empty result (no marin_dna model has a probe parquet yet) still
+# Explicit schema so an empty result (no probe-capable model has a probe parquet yet) still
 # concatenates cleanly with `normalized_rows` in the dashboard loader. Mirrors the column
 # order and dtypes `normalized_rows` produces.
 _PROBE_ROW_SCHEMA: dict[str, pl.DataType] = {
@@ -319,20 +328,50 @@ _PROBE_ROW_SCHEMA: dict[str, pl.DataType] = {
     "n_positives": pl.Int64,
 }
 
+# Families whose per-allele embeddings we probe. `marin_dna` metrics come from the evals_v2
+# pipeline on S3; `evo2` runs off-pipeline (Vortex backend, no HF KV-cache) and is published to
+# the pinned Evo 2 gist — see `_probe_parquet_path`. Zero-shot-only families (conservation,
+# gpn_star, alphagenome) have no probe (no per-allele embedding to read).
+PROBE_FAMILIES = ("marin_dna", "evo2")
+
+
+def _probe_parquet_path(method: Model, dataset: str) -> str:
+    """Path to one model's frozen-embedding probe-metrics parquet, dispatched by family.
+
+    ``marin_dna`` probes are the ``evals_v2`` pipeline's ``probe_metrics`` output on S3; ``evo2``
+    probes are computed off-pipeline and published to the pinned Evo 2 gist, mirroring
+    ``_parquet_path``'s zero-shot ``case "evo2"``.
+    """
+    match method.family:
+        case "marin_dna":
+            return (
+                f"{S3}/snakemake/analysis/evals_v2/results/probe_metrics/"
+                f"{method.id}/{dataset}.parquet"
+            )
+        case "evo2":
+            short = EVO2_DATASET_SHORT[dataset]
+            return (
+                f"{EVO2_PROBE_METRICS_GIST_BASE}/"
+                f"{short}_{method.id}_train_probe_metrics.parquet"
+            )
+        case _:
+            raise ValueError(f"family {method.family!r} has no probe-metrics source")
+
 
 def probe_normalized_rows(dataset: str) -> pl.DataFrame:
     """Long-form linear-probe (supervised) rows for the dashboard's Supervised mode.
 
-    Reads the frozen-embedding probe metrics (``probe_metrics/{id}/{dataset}.parquet`` from
-    the ``evals_v2`` pipeline — per-subset per-chromosome-weighted AUPRC + chromosome-cluster
-    bootstrap SE + a ``_macro_avg_`` row, #347) for every ``marin_dna`` model registered for
-    ``dataset``, keeps the ``probe_score`` rows on the ``train`` split, and maps them onto the
-    same schema as ``normalized_rows`` so the leaderboard heatmap renders them unchanged.
+    Reads the frozen-embedding probe metrics (per-subset per-chromosome-weighted AUPRC +
+    chromosome-cluster bootstrap SE + a ``_macro_avg_`` row, #347) for every probe-capable model
+    (``PROBE_FAMILIES``) registered for ``dataset``, keeps the ``probe_score`` rows on the
+    ``train`` split, and maps them onto the same schema as ``normalized_rows`` so the leaderboard
+    heatmap renders them unchanged. Source is per family (``_probe_parquet_path``): ``marin_dna``
+    from the ``evals_v2`` pipeline on S3, ``evo2`` from the pinned Evo 2 gist.
 
-    Only ``marin_dna`` has probes (they need our ``emb_ref``/``emb_alt`` embeddings), so no
-    other family contributes supervised rows. The pipeline already emits the ``_macro_avg_``
+    Only families with per-allele ``emb_ref``/``emb_alt`` embeddings have probes; zero-shot-only
+    families contribute nothing here. Each family's metrics already carry the ``_macro_avg_``
     aggregate (**no** ``_global_`` — probe scores come from a separate per-subset classifier),
-    so nothing is synthesized here. Models whose probe parquet isn't on S3 yet are skipped
+    so nothing is synthesized here. Models whose probe parquet isn't published yet are skipped
     with a warning (same soft-fail posture as ``normalized_rows``).
 
     Emits ``[method_id, method_display, family, protocol, subset, value, se, n, n_positives]``
@@ -342,17 +381,15 @@ def probe_normalized_rows(dataset: str) -> pl.DataFrame:
     matched-pair macro; per-subset ``n`` / ``n_positives`` are the probe parquet's total
     variants / positives.
     """
-    # OSError covers the S3-404 case (a marin_dna model registered for the dataset whose probe
-    # run hasn't landed); the others mirror `normalized_rows`' soft-fail set.
+    # OSError covers the 404 case (a probe-capable model registered for the dataset whose probe
+    # run hasn't landed — S3 for marin_dna, gist for evo2); the others mirror `normalized_rows`'
+    # soft-fail set.
     soft_fail = (LookupError, pl.exceptions.ComputeError, FileNotFoundError, OSError)
     rows: list[dict] = []
     for method in models_for_dataset(dataset):
-        if method.family != "marin_dna":
+        if method.family not in PROBE_FAMILIES:
             continue
-        path = (
-            f"{S3}/snakemake/analysis/evals_v2/results/probe_metrics/"
-            f"{method.id}/{dataset}.parquet"
-        )
+        path = _probe_parquet_path(method, dataset)
         try:
             df = _read_parquet(path).filter(
                 (pl.col("score_type") == "probe_score") & (pl.col("split") == SPLIT)

--- a/tests/pipelines/evals/test_leaderboard.py
+++ b/tests/pipelines/evals/test_leaderboard.py
@@ -665,16 +665,54 @@ def test_probe_normalized_rows_maps_supervised_schema(monkeypatch: pytest.Monkey
     assert mir.height == 1 and mir["value"][0] != mir["value"][0]  # NaN, still emitted
 
 
-def test_probe_normalized_rows_only_marin_dna(monkeypatch: pytest.MonkeyPatch):
-    """Only marin_dna contributes supervised rows; other families are skipped before any
-    read (their probe path is never even requested)."""
+def test_probe_parquet_path_dispatches_by_family():
+    """marin_dna probe metrics come from the evals_v2 S3 tree; evo2 from the pinned gist; a
+    zero-shot-only family has no probe source (ValueError)."""
     marin = _mk_method(id="m1", family="marin_dna")
+    evo = _mk_method(id="evo2_7b", family="evo2")
     cons = _mk_method(id="phyloP_100v", family="conservation")
-    _patch_methods(monkeypatch, (marin, cons))
-    _patch_read_parquet(monkeypatch, {_probe_path("m1"): _probe_parquet(model="m1")})
+
+    assert leaderboard._probe_parquet_path(marin, "mendelian_traits") == (
+        f"{leaderboard.S3}/snakemake/analysis/evals_v2/results/probe_metrics/"
+        f"m1/mendelian_traits.parquet"
+    )
+    assert leaderboard._probe_parquet_path(evo, "mendelian_traits") == (
+        f"{leaderboard.EVO2_PROBE_METRICS_GIST_BASE}/"
+        f"mendelian_evo2_7b_train_probe_metrics.parquet"
+    )
+    with pytest.raises(ValueError, match="no probe-metrics source"):
+        leaderboard._probe_parquet_path(cons, "mendelian_traits")
+
+
+def test_probe_normalized_rows_probe_families(monkeypatch: pytest.MonkeyPatch):
+    """Both probe-capable families contribute supervised rows — marin_dna from S3 and evo2
+    from the gist — while a zero-shot-only family (conservation) is skipped before any read
+    (it has no per-allele embedding to probe)."""
+    marin = _mk_method(id="m1", family="marin_dna")
+    evo = _mk_method(id="evo2_1b_base", family="evo2")
+    cons = _mk_method(id="phyloP_100v", family="conservation")
+    _patch_methods(monkeypatch, (marin, evo, cons))
+    _patch_read_parquet(
+        monkeypatch,
+        {
+            leaderboard._probe_parquet_path(marin, "mendelian_traits"): _probe_parquet(
+                model="m1"
+            ),
+            leaderboard._probe_parquet_path(evo, "mendelian_traits"): _probe_parquet(
+                model="evo2_1b_base"
+            ),
+        },
+    )
 
     df = probe_normalized_rows("mendelian_traits")
-    assert df["family"].unique().to_list() == ["marin_dna"]
+    assert sorted(df["family"].unique().to_list()) == ["evo2", "marin_dna"]
+    assert "conservation" not in df["family"].to_list()
+    # evo2 rows are the gist-sourced probe rows (macro n/n_positives overloaded to K=2).
+    evo_macro = df.filter(
+        (pl.col("family") == "evo2") & (pl.col("subset") == MACRO_AVG_SUBSET)
+    )
+    assert evo_macro.height == 1
+    assert evo_macro["n"][0] == 2 and evo_macro["n_positives"][0] == 2
 
 
 def test_probe_normalized_rows_skips_stale_schema(

--- a/tests/pipelines/evals/test_leaderboard.py
+++ b/tests/pipelines/evals/test_leaderboard.py
@@ -748,3 +748,22 @@ def test_probe_normalized_rows_skips_missing_parquet(monkeypatch: pytest.MonkeyP
     df = probe_normalized_rows("mendelian_traits")
     assert df.height == 0
     assert set(df.columns) == _PROBE_COLS
+
+
+def test_probe_normalized_rows_soft_fails_unknown_dataset_short(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+):
+    """A probe-family model registered for a dataset with no `EVO2_DATASET_SHORT` entry
+    soft-fails that one model (the path-construction `LookupError` is caught) rather than
+    aborting the whole build — the `_probe_parquet_path` call sits inside the try, symmetric
+    with the zero-shot loader."""
+    # evo2 has no `complex_traits` entry in EVO2_DATASET_SHORT, so path construction raises
+    # KeyError (⊂ LookupError). The read is never reached.
+    evo = _mk_method(id="evo2_1b_base", family="evo2", datasets=("complex_traits",))
+    _patch_methods(monkeypatch, (evo,))
+    _patch_read_parquet(monkeypatch, {})
+
+    df = probe_normalized_rows("complex_traits")  # must not raise
+    assert df.height == 0
+    assert set(df.columns) == _PROBE_COLS
+    assert "probe skip" in capsys.readouterr().err


### PR DESCRIPTION
🤖 Closes #352.

Adds the three Evo 2 baselines — `evo2_1b_base`, `evo2_7b`, `evo2_40b` — to the Mendelian **Supervised** (frozen-embedding linear-probe) view (#350), alongside the MarinDNA probes, on the same per-chromosome-weighted AUPRC metric. The probe results already existed ([#131](https://github.com/Open-Athena/marin-dna/issues/131#issuecomment-4869179889) / #335) but carried no SE and weren't wired into the dashboard.

## What

### 1. Recompute the probe metrics with SE (no GPU)

The #131/#335 Evo 2 probe metrics were the one-off script's *wide* format computed with the pre-#349 `per_chrom_weighted_ap` — point estimates only, no per-chrom SE, no `_macro_avg_` row, so `probe_normalized_rows` would skip them as "stale-schema". [`scripts/evo2_eval/recompute_probe_metrics_with_se.py`](https://github.com/Open-Athena/marin-dna/blob/bd9867d98429c4915cc762b191c62fa7099fd358/scripts/evo2_eval/recompute_probe_metrics_with_se.py) re-runs the **metrics step only** over the existing per-variant probe predictions (`s3://oa-bolinas/analysis/evo2_embeddings/mendelian_traits/probe/`) through `per_chrom_ap_table` (#349: chromosome-cluster bootstrap SE + joint-bootstrap `_macro_avg_`; `n_bootstrap=1000`, `rng=0`, `n_min=30`) — the same call `compute_probe_metrics` makes. CPU-only, no re-inference / re-training. Only reconciliation vs the rule: the Evo 2 bundle names its reverse-complement LLR atom `llr_rev`; the rule expects `llr_rc`.

**Correctness gate (asserted in the script):** the recomputed per-subset AUPRC reproduces the [#131 table](https://github.com/Open-Athena/marin-dna/issues/131#issuecomment-4869179889) to `1e-9` — we only *add* SE.

| model | macro AUPRC ± SE (8 gated subsets) |
|---|---|
| Evo 2 (1B base) | 0.285 ± 0.015 |
| Evo 2 (7B) | 0.380 ± 0.021 |
| Evo 2 (40B) | 0.367 ± 0.025 |

### 2. Publish to the pinned Evo 2 gist

The three SE-carrying parquets were uploaded to the existing `EVO2_METRICS_GIST` (`3649e68f`) at a **new, separate commit** (`3ac60cd`). It is pinned independently of the zero-shot `EVO2_METRICS_GIST_COMMIT` — same gist, its own upload commit — so the working zero-shot path (still pinned at `1bce02fe`) is **untouched**. This mirrors how the zero-shot Evo 2 metrics already reach the dashboard (a pinned gist, not the `evals_v2` tree — Evo 2 can't run our HF-inference path).

### 3. Wire the loader

- `probe_normalized_rows` now admits `PROBE_FAMILIES = ("marin_dna", "evo2")` via a new `_probe_parquet_path` family dispatch (marin_dna → `evals_v2` S3, evo2 → gist), mirroring `_parquet_path`'s zero-shot `case "evo2"`. The Supervised pill list is data-driven (`mendelian.md` derives families from the rows present), so the **Evo 2** pill appears automatically — no frontend change.
- Supervised caption (`_PROBE_METRIC`) updated to "MarinDNA and Evo 2" (was "MarinDNA only").

## Verification

- `uv run pytest tests/pipelines/evals/` → **210 passed, 3 skipped**. New/updated probe tests cover the `_probe_parquet_path` dispatch (marin_dna S3 / evo2 gist / non-probe family → `ValueError`) and both probe-capable families contributing (conservation excluded before any read).
- The dashboard data loader (`leaderboard.parquet.py`), run against the live gist, emits **50 supervised mendelian rows — 30 evo2 (3 models) + 20 marin_dna (2 models)** — the evo2 macros carrying finite SE and display names "Evo 2 (1B base / 7B / 40B)"; `datasets.json.py` emits the updated caption as valid JSON.
- Confirmed the zero-shot pin (`1bce02fe`) still resolves (HTTP 200) after the gist push.

The full `observable build` / interactive render is best confirmed in a local `npm run dev` preview — the dev box has no browser / `node_modules` (same caveat as #350). The data layer is fully validated above.

## Notes

- **mendelian_traits only** (the sole PROBE dataset, and the only dataset with Evo 2 probes); Supervised shows **probe scores only** (zero-shot Evo 2 stays in the Unsupervised view).
- **No `evals_v2` config changes** — Evo 2 stays a `scripts/` + gist baseline, consistent with "competitor baselines live on branches, not the pipeline".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
