### PR TITLE
skill(marin-experiment): torchvision/tpu-extra recipe + executor-API-churn lessons

### DIFF
--- a/.agents/skills/marin-experiment/SKILL.md
+++ b/.agents/skills/marin-experiment/SKILL.md
@@ -23,13 +23,15 @@ dependencies = [
     # iris/zephyr worker's plain `uv sync` install them. In an *extra* the
     # tokenize worker fails: `ModuleNotFoundError: No module named 'zephyr'`.
     #
-    # PIN these to the NEWEST build that (a) clears the controller freshness floor
-    # AND (b) still has the marin.execution symbols your launch.py imports. marin
-    # 0.2.32+ removed ExecutorStep / executor_main / this_output_path /
-    # ensure_versioned → an old launch.py submits fine then dies on the coordinator
-    # with `ImportError: cannot import name 'ExecutorStep'`. The floor advances
-    # daily (deploy−14d) so this window shrinks — 0.2.31 below is a CURRENT example
-    # (will rot); check #356 for today's build, or migrate launch.py to the new API.
+    # PIN these to the NEWEST build that clears the controller freshness floor while
+    # (a) keeping the marin.execution symbols your launch.py imports AND (b) staying
+    # on transformers-4. Two separate refactors bound the window: marin 0.2.33+ removed
+    # ExecutorStep / executor_main / this_output_path / ensure_versioned (an old
+    # launch.py then submits fine but dies on the coordinator with `ImportError: cannot
+    # import name 'ExecutorStep'`), and 0.2.32+ declares transformers-5 (breaks lm-eval
+    # — see the override below). So 0.2.31 (06-29) is the newest clearing BOTH. The floor
+    # advances daily (deploy−14d) so this shrinks — 0.2.31 WILL rot; check #356 for
+    # today's build, or migrate launch.py to the new API.
     "marin-core==0.2.31.*",       # NB: PyPI name is marin-core, not `marin`
     "marin-levanter==0.2.31.*",
     "marin-iris==0.2.31.*",
@@ -37,7 +39,8 @@ dependencies = [
     "marin-rigging==0.2.31.*",
     "marin-dupekit",              # PyPI name is marin-dupekit, not `dupekit`
     # finelog 06-17: iris (<=0.2.31) imports finelog.client.proxy, which finelog
-    # 0.2.12 (06-28+) dropped → "No module named 'finelog.client.proxy'".
+    # dropped at its 06-23 build (0.2.12.dev202606230935; last-good 06-22) → "No
+    # module named 'finelog.client.proxy'". The 06-17 pin below is safely before it.
     "marin-finelog==0.2.11.dev202606171051",
     "marin-finelog-server==0.2.11.dev202606171051",
     # marin-levanter[lm_eval]'s extra is a URL dep; uv requires URL deps top-level.
@@ -143,7 +146,7 @@ Anchored to specific worker-log messages so they survive iris/marin churn.
 |---|---|
 | `ModuleNotFoundError: No module named 'zephyr'` in the tokenize worker's `cloudpickle.loads` | marin is in an **extra**, not base deps. Move `marin-*` into base `dependencies` (see the template). The worker's `--no-group dev` sync (no `--extra`) then installs it. |
 | `marin-iris client is too old (build <date>; minimum <floor>)` at submit | The controller's freshness floor (deploy − 14 d) **advances daily**. Bump the marin pin to the newest build that BOTH still has your launch.py's `marin.execution` symbols (ExecutorStep row below) AND resolves the tpu extra (torchvision row below). Not a blind `uv lock --upgrade` — that jumps to a head whose executor API breaks your launch.py. Wheels are on **PyPI** (`marin-core`, not GitHub find-links). |
-| `ImportError: cannot import name 'ExecutorStep' from 'marin.execution'` — the job **submits OK then fails on the coordinator** (before any dispatch; `iris job summary` shows the coordinator task errored) | marin **0.2.32+ refactored the executor API** (`ExecutorStep` / `executor_main` / `this_output_path` / `ensure_versioned` removed). Pin marin to the newest build that still has them (`0.2.31`, early July — the closing "old-API window"), or migrate launch.py to the new API. Verify with `uv run python -c "import launch"` before relaunching. |
+| `ImportError: cannot import name 'ExecutorStep' from 'marin.execution'` — the job **submits OK then fails on the coordinator** (before any dispatch; `iris job summary` shows the coordinator task errored) | marin **0.2.33+ removed the executor API** (`ExecutorStep` / `executor_main` / `this_output_path` / `ensure_versioned`). Pin marin to the newest build that still has them **and** stays on transformers-4 — that's **`0.2.31` (06-29)**: 0.2.32 keeps the executor API but declares transformers-5 (breaks lm-eval), and 0.2.33 drops the API. Or migrate launch.py to the new API. Verify with `uv run python -c "import launch"` before relaunching. |
 | `no version of torchvision==0.26.0+cpu` / the tpu closure only resolves at a too-old marin (e.g. 0.2.19) | `marin-core[tpu]` (>=0.2.20) pins torch/torchvision `==…+cpu`, published only on **PyTorch's CPU index**. Add a `pytorch-cpu` **explicit** index AND list `torch`/`torchvision` as **direct deps of the `tpu` extra** (uv only routes an extra's *direct* deps — routing them only in `[tool.uv.sources]` isn't enough). Also set `environments = ["sys_platform == 'linux'"]` (the darwin branch has no such wheels and derails resolution). See template. |
 | `error: Extra "cpu" is not defined…` on a `remote(...)` step | `pip_dependency_groups` names a non-existent extra. Use `[]` (marin is base) for CPU/tokenize, `["tpu"]` for TPU-train. |
 | `Timeout (Ns) waiting for lock on /uv/cache/.../lm-eval...` | `-e UV_LOCK_TIMEOUT 7200` on `job run` **and** in the step's `env_vars=`. Many zephyr workers share a uv cache; the first build serializes and the 300 s default races. |
@@ -156,7 +159,7 @@ Anchored to specific worker-log messages so they survive iris/marin churn.
 
 ## Sources & the fast-churn caveat
 
-marin/iris infra changes **rapidly** — the build/pin choices here rot fast; verify against the current known-good build (tracked in [#328](https://github.com/Open-Athena/marin-dna/issues/328)) before trusting them.
+marin/iris infra changes **rapidly** — the build/pin choices here rot fast; verify against the current known-good build (the live recipe in [#356](https://github.com/Open-Athena/marin-dna/issues/356); [#328](https://github.com/Open-Athena/marin-dna/issues/328) is the older migration hub) before trusting them.
 
 - **Reference consumer repos** (our per-experiment pyproject mirrors theirs): [`marin-community/marin-experiments`](https://github.com/marin-community/marin-experiments) (e.g. `tiny-stories/`) and [`Open-Athena/MarinFold`](https://github.com/Open-Athena/MarinFold).
 - **marin Discord** — public read-only mirror at `https://marin-discord.pages.dev/archive.db`; download the SQLite and query it locally for "what's been said about X".

--- a/.agents/skills/marin-experiment/SKILL.md
+++ b/.agents/skills/marin-experiment/SKILL.md
@@ -22,14 +22,22 @@ dependencies = [
     # marin packages in BASE deps (NOT an extra) — this is what makes the
     # iris/zephyr worker's plain `uv sync` install them. In an *extra* the
     # tokenize worker fails: `ModuleNotFoundError: No module named 'zephyr'`.
-    "marin-core",          # NB: PyPI name is marin-core, not `marin`
-    "marin-levanter",
-    "marin-iris",
-    "marin-zephyr",
-    "marin-rigging",
-    "marin-dupekit",       # PyPI name is marin-dupekit, not `dupekit`
-    # INTERIM PINS — see the callout below. iris 0.2.19 imports
-    # finelog.client.proxy which newer finelog dropped, so pin the 06-17 build.
+    #
+    # PIN these to the NEWEST build that (a) clears the controller freshness floor
+    # AND (b) still has the marin.execution symbols your launch.py imports. marin
+    # 0.2.32+ removed ExecutorStep / executor_main / this_output_path /
+    # ensure_versioned → an old launch.py submits fine then dies on the coordinator
+    # with `ImportError: cannot import name 'ExecutorStep'`. The floor advances
+    # daily (deploy−14d) so this window shrinks — 0.2.31 below is a CURRENT example
+    # (will rot); check #356 for today's build, or migrate launch.py to the new API.
+    "marin-core==0.2.31.*",       # NB: PyPI name is marin-core, not `marin`
+    "marin-levanter==0.2.31.*",
+    "marin-iris==0.2.31.*",
+    "marin-zephyr==0.2.31.*",
+    "marin-rigging==0.2.31.*",
+    "marin-dupekit",              # PyPI name is marin-dupekit, not `dupekit`
+    # finelog 06-17: iris (<=0.2.31) imports finelog.client.proxy, which finelog
+    # 0.2.12 (06-28+) dropped → "No module named 'finelog.client.proxy'".
     "marin-finelog==0.2.11.dev202606171051",
     "marin-finelog-server==0.2.11.dev202606171051",
     # marin-levanter[lm_eval]'s extra is a URL dep; uv requires URL deps top-level.
@@ -45,7 +53,17 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-tpu = ["marin-core[tpu]; sys_platform == 'linux'"]
+# List torch/torchvision here as DIRECT deps of the extra (not only in
+# [tool.uv.sources]) — uv only applies an index source to a package that is a
+# direct dep of the extra. marin-core[tpu] (>=0.2.20) pins torch/torchvision
+# ==...+cpu wheels that live ONLY on PyTorch's CPU index; without this listing
+# the whole tpu closure silently backtracks to a too-old marin
+# (`no version of torchvision==0.26.0+cpu`). This was the load-bearing step.
+tpu = [
+    "marin-core[tpu]; sys_platform == 'linux'",
+    "torch; sys_platform == 'linux'",
+    "torchvision; sys_platform == 'linux'",
+]
 
 # Iris's remote worker runs `uv sync --all-packages --no-group dev`, which errors
 # if the dev group is undefined — define an empty one.
@@ -56,23 +74,37 @@ dev = []
 package = false
 fork-strategy = "fewest"
 prerelease = "allow"
-environments = ["sys_platform == 'darwin'", "sys_platform == 'linux'"]
+# Linux-only: workers are always linux; the darwin branch has no libtpu/+cpu
+# wheels, so it makes the tpu extra unsatisfiable and derails the whole resolution.
+environments = ["sys_platform == 'linux'"]
 # Mirrored from marin's pyproject — omitting these makes uv resolution fail the
 # same way it does for marin itself (+ pandas<3 to keep parquet dtypes stable).
+# transformers<5: fresh marin (>=0.2.32) declares transformers-5, which breaks
+# lm-eval@d5e3391 (its hf_vlms uses AutoModelForVision2Seq, renamed in tf5). The
+# override keeps uv on the working tf4 line.
 override-dependencies = [
     "omegaconf>=2.4.0.dev4", "antlr4-python3-runtime==4.11",
     "python-multipart>=0.0.22", "wheel>=0.46.2",
     "datasets>=3.1.0,<4.0.0", "equinox>=0.11.10", "pandas>=2.0,<3.0",
+    "transformers>=4.57,<5",
 ]
 # marin depends on resiliparse>=0.17.2, which only exists on this custom index.
 [[tool.uv.index]]
 name = "marin-resiliparse"
 url = "https://marin-community.github.io/chatnoir-resiliparse/simple"
+# marin-core[tpu]'s torch/torchvision ==...+cpu wheels live only here. explicit
+# so it doesn't shadow PyPI globally (only the routed torch/torchvision use it).
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
 [tool.uv.sources]
 resiliparse = { index = "marin-resiliparse" }
+torch = { index = "pytorch-cpu" }
+torchvision = { index = "pytorch-cpu" }
 ```
 
-> ⚠️ **The marin 0.2.x line and the exact pins churn fast.** The `marin-finelog` version, the `lm-eval` rev, and even whether the head resolves at all change week to week. **Before trusting the pins above, get the current known-good marin build from [#328](https://github.com/Open-Athena/marin-dna/issues/328)** (the marin-migration tracking issue). The shape (marin in base deps, git-dep'd lib, empty `dev` group) is stable; the versions are not.
+> ⚠️ **The marin 0.2.x line churns fast, and the controller freshness floor advances DAILY (deploy − 14 days)** — a pin that launches today ages out in days (it moved 06-18 → 06-19 within one session). The template's *shape* is durable (marin in base deps; the tpu-extra torch/torchvision routing; linux-only; transformers<5); the exact versions are not — the `0.2.31` example **will rot**. **Before trusting the versions, get the current build from [#356](https://github.com/Open-Athena/marin-dna/issues/356)** (the live launch-blocker issue, carrying the full working recipe) or [#328](https://github.com/Open-Athena/marin-dna/issues/328). The *durable* fix, once the old-executor-API pin window closes (floor passes the last build with `ExecutorStep` et al.), is **migrating `launch.py` to marin's new `marin.execution` API** rather than chasing an ever-aging pin.
 
 ## Launch
 
@@ -99,7 +131,7 @@ Two things the `launch.py` must declare on **every** `remote(...)` call (workers
 
 ## Babysit (first minutes + the whole run)
 
-- **Watch the launch actively.** Confirm: coordinator syncs + dispatches; the **tokenize worker imports `zephyr` and runs `marin.processing.tokenize`** (the moment of truth for the base-deps setup); the TPU-train step logs `TPU detected` (not CPU fallback) + a wandb run URL + advancing `global_step`/`loss`.
+- **Watch the launch actively.** A successful *submit* is not a successful *run* — a job can submit fine then **fail on the coordinator with an `ImportError`** (marin API mismatch) *before* dispatching anything, so check `iris job summary` state, not just "did it submit". Confirm the chain: coordinator imports launch.py + builds the DAG (no `ExecutorStep` ImportError); **tokenize worker imports `zephyr` and runs `marin.processing.tokenize`** (the moment of truth for the base-deps setup); the TPU-train step logs `TPU detected` (not CPU fallback) + a wandb run URL + advancing `global_step`/`loss`.
 - **Use a detached on-box poller, not a background sleep.** `run_in_background` Bash `sleep` loops get reaped when the session idles; a `setsid nohup bash poller.sh </dev/null &>log &` process reparents to init and survives. Poll `iris job summary` / `job logs` every ~10 min; flag `No accelerator found` / `RESOURCE_EXHAUSTED` / `JOB_STATE_FAILED`.
 - **A "failed" job may be complete.** A JAX/TPU **teardown SIGSEGV (exit 139)** often fires *after* the final checkpoint + eval. Before EVER relaunching a `State: failed` job, check the logs for `Finished saving HF-compatible checkpoint to gs://…/hf/step-<final>` and `gsutil ls` that dir (expect `config.json` + `model.safetensors` + tokenizer). If present, it's done — relaunching wastes the whole run.
 
@@ -110,7 +142,9 @@ Anchored to specific worker-log messages so they survive iris/marin churn.
 | Symptom (worker logs) | Fix |
 |---|---|
 | `ModuleNotFoundError: No module named 'zephyr'` in the tokenize worker's `cloudpickle.loads` | marin is in an **extra**, not base deps. Move `marin-*` into base `dependencies` (see the template). The worker's `--no-group dev` sync (no `--extra`) then installs it. |
-| `marin-iris client is too old (build <date>; minimum <floor>)` at submit | The controller has a ~14-day freshness floor. Re-lock to a fresh marin build (`uv lock --upgrade-package marin-iris`), or pin a recent known-good build (see #328). Wheels are on **PyPI** now (`marin-core`, not GitHub find-links). |
+| `marin-iris client is too old (build <date>; minimum <floor>)` at submit | The controller's freshness floor (deploy − 14 d) **advances daily**. Bump the marin pin to the newest build that BOTH still has your launch.py's `marin.execution` symbols (ExecutorStep row below) AND resolves the tpu extra (torchvision row below). Not a blind `uv lock --upgrade` — that jumps to a head whose executor API breaks your launch.py. Wheels are on **PyPI** (`marin-core`, not GitHub find-links). |
+| `ImportError: cannot import name 'ExecutorStep' from 'marin.execution'` — the job **submits OK then fails on the coordinator** (before any dispatch; `iris job summary` shows the coordinator task errored) | marin **0.2.32+ refactored the executor API** (`ExecutorStep` / `executor_main` / `this_output_path` / `ensure_versioned` removed). Pin marin to the newest build that still has them (`0.2.31`, early July — the closing "old-API window"), or migrate launch.py to the new API. Verify with `uv run python -c "import launch"` before relaunching. |
+| `no version of torchvision==0.26.0+cpu` / the tpu closure only resolves at a too-old marin (e.g. 0.2.19) | `marin-core[tpu]` (>=0.2.20) pins torch/torchvision `==…+cpu`, published only on **PyTorch's CPU index**. Add a `pytorch-cpu` **explicit** index AND list `torch`/`torchvision` as **direct deps of the `tpu` extra** (uv only routes an extra's *direct* deps — routing them only in `[tool.uv.sources]` isn't enough). Also set `environments = ["sys_platform == 'linux'"]` (the darwin branch has no such wheels and derails resolution). See template. |
 | `error: Extra "cpu" is not defined…` on a `remote(...)` step | `pip_dependency_groups` names a non-existent extra. Use `[]` (marin is base) for CPU/tokenize, `["tpu"]` for TPU-train. |
 | `Timeout (Ns) waiting for lock on /uv/cache/.../lm-eval...` | `-e UV_LOCK_TIMEOUT 7200` on `job run` **and** in the step's `env_vars=`. Many zephyr workers share a uv cache; the first build serializes and the 300 s default races. |
 | `requests.exceptions.ReadTimeout: huggingface.co ... timeout=10` | `-e HF_HUB_DOWNLOAD_TIMEOUT 120` (also in the step's `env_vars=`). HF's 10 s default is too short for parquet-manifest fetches. |


### PR DESCRIPTION
🤖 Persists the durable marin-launch lessons from exp351 (#351) into the `marin-experiment` skill. Derived from resolving the launch deadlock in #356 (which a stale interim pin can no longer clear).

## What changed (`.agents/skills/marin-experiment/SKILL.md`)
- **Template — the tpu-extra torchvision recipe** (the thing that actually unblocks a fresh, floor-satisfying marin): list `torch`/`torchvision` as **direct deps of the `tpu` extra** (not only in `[tool.uv.sources]`) — uv only applies an index source to an extra's *direct* deps; plus a `pytorch-cpu` explicit index. Also `environments = ["sys_platform == 'linux'"]` and a `transformers>=4.57,<5` override, and guidance to pin marin to the newest build that still has the old `marin.execution` API.
- **Lessons table** — two new rows: `ImportError: cannot import name 'ExecutorStep'` (marin 0.2.32+ refactored the executor API; the job *submits OK then fails on the coordinator*), and `no version of torchvision==0.26.0+cpu` (tpu closure backtracks to a too-old marin).
- **Babysit** — a successful submit isn't a successful run; check `iris job summary` for a coordinator-side `ImportError` before dispatch.
- **Churn callout** — the controller freshness floor advances **daily** (deploy−14d); the *durable* fix, once the old-executor-API window closes, is migrating `launch.py` to marin's new `marin.execution` API rather than chasing an aging pin.

The recipe **shape** is durable; exact versions stay pinned-by-reference to #356/#328 (they rot).

Related: #356 (the live launch-blocker + full recipe), #351 (the experiment it came from), #328 (marin migration).