### PR TITLE
evals_v2: SGE linear-probing metrics path

### DIFF
--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -303,11 +303,17 @@ metric. It emits, per consequence `subset`, the **per-chromosome-weighted AUPRC*
 TraitGym / #314 headline; `marin_dna.pipelines.evals.metrics.per_chrom_ap_table` →
 `per_chrom_weighted_ap`) for two score types: `probe_score` and the dataset's
 zero-shot baseline (its `score_protocol` applied to the FWD/RC-averaged LLR, e.g.
-`minus_llr_avg` for mendelian). `matched_pair` datasets only (needs `subset` + `chrom`;
-`qtl_global`/`sge` are rejected).
+`minus_llr_avg` for mendelian). Routed by `eval_protocol`: **`matched_pair`** (mendelian /
+complex; needs `subset` + `chrom`) takes the per-chromosome-weighted path above, while
+**`sge`** takes a per-accession (`mavedb_urn`) × consequence-subset AUPRC macro-averaged over
+genes (`compute_sge_probe_metrics` → `compute_sge_metrics`) — dropping the pooled `both`
+scope, since the separate per-subset probe classifiers aren't comparable across subsets.
+`qtl_global` is rejected.
 
 ```
-results/probe_metrics/{model}/{dataset}.parquet   # [score_type, subset, value, n, n_pos, n_chrom, model, dataset, split]
+# matched_pair: [score_type, subset, value, se, n, n_pos, n_chrom, model, dataset, split]
+results/probe_metrics/{model}/{dataset}.parquet
+# sge:          [metric, subset, accession, gene, score_type, value, se, n, n_pos, model, dataset, split]
 ```
 
 ```bash

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -18,6 +18,7 @@ from marin_dna.pipelines.evals.metrics import (
     compute_auprc_metrics,
     compute_qtl_metrics,
     compute_sge_metrics,
+    compute_sge_probe_metrics,
     per_chrom_ap_table,
 )
 from marin_dna.pipelines.evals.variant_probe import PAIR_COMBOS, run_subset_probes

--- a/snakemake/analysis/evals_v2/workflow/rules/probe.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/probe.smk
@@ -85,23 +85,32 @@ rule probe:
 
 
 rule compute_probe_metrics:
-    """Per-subset per-chromosome-weighted AUPRC + chromosome-cluster bootstrap SE and a
-    `_macro_avg_` aggregate row (#331 / TraitGym; SE + macro per #347) for the probe vs
-    its matched zero-shot LLR baseline — the metrics step of the #320/#331 protocol (wires
-    #319; #341).
+    """Probe-vs-zero-shot AUPRC for a probe cell — the metrics step of the #320/#331
+    protocol (wires #319; #341; matched-pair SE + `_macro_avg_` row per #347), routed by
+    eval_protocol:
 
-    The probe predictions parquet carries BOTH `probe_score` AND the raw `llr_fwd`/
-    `llr_rc` atoms (`compute_probe` drops only `emb_ref`/`emb_alt`), so the probe and
-    its zero-shot baseline are scored on IDENTICAL rows under the identical metric — a
-    paired probe-vs-LLR comparison in one parquet. The baseline is the dataset's own
-    `score_protocol` applied to the FWD/RC-averaged LLR (`minus_llr_avg` for mendelian),
-    matching `compute_metrics`'s `_avg` semantics. The per-subset per-chrom-weighted
-    metric is the matched_pair (subset + chrom) path, so qtl_global/sge are rejected.
+    - **matched_pair** (mendelian / complex): per-subset per-chromosome-weighted AUPRC
+      (TraitGym / #331), via `per_chrom_ap_table` — needs `subset` + `chrom`.
+    - **sge**: per-accession (mavedb_urn) × consequence-subset AUPRC, macro-averaged,
+      via `compute_sge_metrics` on the probe score — the same per-accession path the
+      zero-shot SGE metrics use (#353), needs `mavedb_urn` + `gene` + `subset`. Rows
+      the probe skipped (NaN `probe_score`, a subset that failed the
+      min-variants/min-chroms gate) are dropped so the per-accession AUPRC and its
+      paired baseline cover only probe-scored cells.
 
-    Thin glue over `marin_dna.pipelines.evals.metrics.per_chrom_ap_table`. CPU-only; off
-    `rule all`. Reads a probe parquet, so the same `--rerun-triggers mtime` note as
-    `compute_probe` applies (its upstream scores parquet was built with the #318
-    overlay)."""
+    `qtl_global` has no subset/accession structure and is rejected.
+
+    In every case the probe predictions parquet carries BOTH `probe_score` AND the raw
+    `llr_fwd`/`llr_rc` atoms (`compute_probe` drops only `emb_ref`/`emb_alt`), so the
+    probe and its zero-shot baseline are scored on IDENTICAL rows under the identical
+    metric — a paired comparison in one parquet. The baseline is the dataset's own
+    `score_protocol` applied to the FWD/RC-averaged LLR (`minus_llr_avg` for mendelian /
+    sge), matching `compute_metrics`'s `_avg` semantics.
+
+    Thin glue over `marin_dna.pipelines.evals.metrics.{per_chrom_ap_table,
+    compute_sge_metrics}`. CPU-only; off `rule all`. Reads a probe parquet, so the same
+    `--rerun-triggers mtime` note as `compute_probe` applies (its upstream scores parquet
+    was built with the #318 overlay)."""
     input:
         "results/probe/{model}/{dataset}.parquet",
     output:
@@ -115,39 +124,54 @@ rule compute_probe_metrics:
         n_min=config["probe"]["n_min"],
     run:
         eval_protocol = get_dataset_protocol(wildcards.dataset)
-        assert eval_protocol == "matched_pair", (
-            f"compute_probe_metrics is the per-subset per-chrom-weighted AUPRC "
-            f"(matched_pair / TraitGym) path — needs subset + chrom; dataset "
-            f"{wildcards.dataset!r} is eval_protocol {eval_protocol!r}"
+        assert eval_protocol in ("matched_pair", "sge"), (
+            f"compute_probe_metrics supports matched_pair (per-chrom AUPRC) + sge "
+            f"(per-accession AUPRC); dataset {wildcards.dataset!r} is eval_protocol "
+            f"{eval_protocol!r}"
         )
-        transform = SCORE_PROTOCOLS[params.score_protocol]
         df = pd.read_parquet(input[0])
-        for col in ("probe_score", "label", "subset", "chrom", "llr_fwd", "llr_rc"):
+        for col in ("probe_score", "label", "subset", "llr_fwd", "llr_rc"):
             assert col in df.columns, (
                 f"{input[0]} missing column {col!r} — expected a compute_probe "
                 f"predictions parquet"
             )
-        # Zero-shot baseline on the identical rows: the dataset's score protocol applied
-        # to the FWD/RC-averaged raw LLR (== compute_metrics `_avg`).
-        baseline_col = f"{params.score_protocol}_avg"
-        df[baseline_col] = transform((df["llr_fwd"] + df["llr_rc"]) / 2)
 
-        metrics = per_chrom_ap_table(
-            df,
-            ["probe_score", baseline_col],
-            n_bootstrap=params.n_bootstrap,
-            rng=0,
-            n_min=params.n_min,
-        )
+        if eval_protocol == "matched_pair":
+            # Per-subset per-chromosome-weighted AUPRC + chromosome-cluster bootstrap SE +
+            # `_macro_avg_` row (TraitGym / #331 / #347). Zero-shot baseline on the identical
+            # rows = the dataset's score protocol applied to the FWD/RC-averaged raw LLR.
+            assert "chrom" in df.columns, (
+                f"{input[0]} missing 'chrom' — matched_pair per-chrom AUPRC needs it"
+            )
+            transform = SCORE_PROTOCOLS[params.score_protocol]
+            baseline_col = f"{params.score_protocol}_avg"
+            df[baseline_col] = transform((df["llr_fwd"] + df["llr_rc"]) / 2)
+            metrics = per_chrom_ap_table(
+                df,
+                ["probe_score", baseline_col],
+                n_bootstrap=params.n_bootstrap,
+                rng=0,
+                n_min=params.n_min,
+            )
+        else:  # sge — per-accession × subset AUPRC (probe vs its paired zero-shot).
+            for col in ("mavedb_urn", "gene"):
+                assert col in df.columns, (
+                    f"{input[0]} missing {col!r} — sge per-accession AUPRC needs the "
+                    f"accession key + gene"
+                )
+            metrics = compute_sge_probe_metrics(
+                df,
+                params.score_protocol,
+                n_bootstrap=params.n_bootstrap,
+                rng=0,
+            )
         metrics["model"] = wildcards.model
         metrics["dataset"] = wildcards.dataset
         metrics["split"] = config["split"]
         metrics.to_parquet(output[0], index=False)
         print(
-            f"[evals_v2] probe_metrics {wildcards.model} {wildcards.dataset}: "
-            f"{len(metrics)} rows (per-subset + macro_avg × 2 score types: "
-            f"probe_score, {baseline_col}); SE from {params.n_bootstrap} "
-            f"chromosome-cluster bootstraps"
+            f"[evals_v2] probe_metrics {wildcards.model} {wildcards.dataset} "
+            f"({eval_protocol}): {len(metrics)} rows"
         )
 
 

--- a/src/marin_dna/pipelines/evals/metrics.py
+++ b/src/marin_dna/pipelines/evals/metrics.py
@@ -1277,8 +1277,10 @@ def compute_sge_probe_metrics(
 
     Returns:
         The ``compute_sge_metrics`` frame (``[metric, subset, accession, gene,
-        score_type, value, se, n, n_pos]``) for two ``score_type``s: ``probe_score`` and
-        the baseline ``f"{score_protocol}_avg"``.
+        score_type, value, se, n, n_pos]``) for two ``score_type``s (``probe_score`` and
+        the baseline ``f"{score_protocol}_avg"``), **with the pooled ``SGE_POOLED_SUBSET``
+        ("both") scope removed** — the per-subset probes are separate classifiers whose
+        scores are not comparable across subsets, so a pooled ranking would be confounded.
     """
     assert score_protocol in SCORE_PROTOCOLS, (
         f"score_protocol must be one of {sorted(SCORE_PROTOCOLS)}, got {score_protocol!r}"
@@ -1291,13 +1293,19 @@ def compute_sge_probe_metrics(
     df[baseline_col] = transform((df["llr_fwd"] + df["llr_rc"]) / 2)
     scored = df[df["probe_score"].notna()].reset_index(drop=True)
     assert len(scored) > 0, "no rows with a non-NaN probe_score to evaluate"
-    return compute_sge_metrics(
+    out = compute_sge_metrics(
         dataset=scored[["mavedb_urn", "gene", "subset", "label"]],
         scores=scored[["probe_score", baseline_col]],
-        score_columns=["probe_score", baseline_col],
         n_bootstrap=n_bootstrap,
         rng=rng,
     )
+    # Drop the pooled ``SGE_POOLED_SUBSET`` ("both") scope. The per-subset probes are
+    # SEPARATE per-subset leave-one-chromosome-out classifiers, so their ``probe_score``
+    # scales are not comparable ACROSS subsets — a pooled missense+splicing ranking would
+    # be a calibration-confounded, silently-wrong AUPRC. (The matched-pair probe path omits
+    # its analogous ``_global_`` row for exactly this reason.) The per-subset cells and the
+    # subset ``_macro_avg_`` — a mean of within-subset AUPRCs — remain valid.
+    return out[out["subset"] != SGE_POOLED_SUBSET].reset_index(drop=True)
 
 
 def compute_pairwise_metrics(

--- a/src/marin_dna/pipelines/evals/metrics.py
+++ b/src/marin_dna/pipelines/evals/metrics.py
@@ -1245,6 +1245,61 @@ def compute_sge_metrics(
     return pd.DataFrame(rows)
 
 
+def compute_sge_probe_metrics(
+    probe_df: pd.DataFrame,
+    score_protocol: str,
+    n_bootstrap: int = 1000,
+    rng: int = 0,
+) -> pd.DataFrame:
+    """Per-accession × consequence-subset AUPRC for an SGE linear probe vs its paired
+    zero-shot baseline (#353).
+
+    The linear-probe path (issue #320) trains per-subset leave-one-chromosome-out probes
+    and emits a ``probe_score`` alongside the raw ``llr_fwd``/``llr_rc`` atoms. For SGE the
+    headline is the same per-accession (``mavedb_urn``) × subset AUPRC that
+    ``compute_sge_metrics`` computes for the zero-shot score — so this reuses it on two
+    score columns: the ``probe_score`` and its zero-shot baseline (the dataset's
+    ``score_protocol`` applied to the FWD/RC-averaged LLR), scored on identical rows for a
+    paired probe-vs-zero-shot comparison.
+
+    Rows whose ``probe_score`` is NaN — subsets the probe skipped because they failed the
+    min-variants / min-chromosomes gate — are dropped, so sklearn's AUPRC never sees a NaN
+    score and the paired baseline covers exactly the probe-scored rows.
+
+    Args:
+        probe_df: A ``compute_probe`` predictions frame for an SGE dataset — carries
+            ``probe_score`` + the SGE keys (``mavedb_urn``, ``gene``, ``subset``,
+            ``label``) + the raw ``llr_fwd``/``llr_rc`` atoms.
+        score_protocol: The dataset's score protocol (``minus_llr`` for SGE); selects the
+            LLR→score transform for the zero-shot baseline column.
+        n_bootstrap: Bootstrap resamples for the AUPRC SE (passed through).
+        rng: Bootstrap seed (passed through).
+
+    Returns:
+        The ``compute_sge_metrics`` frame (``[metric, subset, accession, gene,
+        score_type, value, se, n, n_pos]``) for two ``score_type``s: ``probe_score`` and
+        the baseline ``f"{score_protocol}_avg"``.
+    """
+    assert score_protocol in SCORE_PROTOCOLS, (
+        f"score_protocol must be one of {sorted(SCORE_PROTOCOLS)}, got {score_protocol!r}"
+    )
+    for col in ("probe_score", "llr_fwd", "llr_rc"):
+        assert col in probe_df.columns, f"probe_df missing required column {col!r}"
+    transform = SCORE_PROTOCOLS[score_protocol]
+    baseline_col = f"{score_protocol}_avg"
+    df = probe_df.copy()
+    df[baseline_col] = transform((df["llr_fwd"] + df["llr_rc"]) / 2)
+    scored = df[df["probe_score"].notna()].reset_index(drop=True)
+    assert len(scored) > 0, "no rows with a non-NaN probe_score to evaluate"
+    return compute_sge_metrics(
+        dataset=scored[["mavedb_urn", "gene", "subset", "label"]],
+        scores=scored[["probe_score", baseline_col]],
+        score_columns=["probe_score", baseline_col],
+        n_bootstrap=n_bootstrap,
+        rng=rng,
+    )
+
+
 def compute_pairwise_metrics(
     dataset: pd.DataFrame,
     scores: pd.DataFrame,

--- a/tests/pipelines/evals/test_metrics.py
+++ b/tests/pipelines/evals/test_metrics.py
@@ -23,6 +23,7 @@ from marin_dna.pipelines.evals.metrics import (
     compute_metrics,
     compute_qtl_metrics,
     compute_sge_metrics,
+    compute_sge_probe_metrics,
     paired_metric_delta_bootstrap,
     per_chrom_ap_table,
     per_chrom_weighted_ap,
@@ -807,6 +808,68 @@ def test_sge_accession_macro_is_mean_over_accessions():
     )
     assert macro["value"] == pytest.approx(sum(vals) / 2)
     assert macro["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# compute_sge_probe_metrics (SGE linear-probe vs paired zero-shot baseline, #353)
+# ---------------------------------------------------------------------------
+
+
+def _sge_probe_df(
+    *, seed: int = 0, perfect_probe: bool = True, nan_subset: str | None = None
+) -> pd.DataFrame:
+    """A ``compute_probe`` predictions frame for SGE: the ``_sge_data`` keys +
+    ``probe_score`` (separates ``label`` when ``perfect_probe``) + the raw
+    ``llr_fwd``/``llr_rc`` atoms the baseline is built from. If ``nan_subset`` is set,
+    that subset's ``probe_score`` is all-NaN (a subset the probe skipped)."""
+    dataset, _ = _sge_data(seed=seed)
+    rng = np.random.default_rng(seed + 100)
+    n = len(dataset)
+    label = dataset["label"].to_numpy()
+    df = dataset.copy()
+    df["probe_score"] = (
+        np.where(label, 1.0, 0.0) + rng.normal(0, 1e-6, n)
+        if perfect_probe
+        else rng.normal(size=n)
+    )
+    # Raw LLR atoms: impactful (label True) gets negative LLR → minus_llr high (the SGE
+    # deleteriousness orientation), so the zero-shot baseline is weakly informative.
+    signal = np.where(label, -1.0, 1.0)
+    df["llr_fwd"] = signal + rng.normal(0, 0.5, n)
+    df["llr_rc"] = signal + rng.normal(0, 0.5, n)
+    if nan_subset is not None:
+        df.loc[df["subset"] == nan_subset, "probe_score"] = np.nan
+    return df
+
+
+def test_sge_probe_metrics_shape_and_paired_baseline():
+    """Reuses the per-accession × subset SGE grid, emitting BOTH the probe score and its
+    paired zero-shot baseline (minus_llr_avg); a perfect probe → AUPRC ≈ 1."""
+    df = _sge_probe_df(seed=0, perfect_probe=True)
+    out = compute_sge_probe_metrics(df, "minus_llr", n_bootstrap=20, rng=0)
+    # Exactly two score types on identical rows: the probe + its zero-shot baseline.
+    assert set(out["score_type"]) == {"probe_score", "minus_llr_avg"}
+    # Same per-accession × subset structure as compute_sge_metrics.
+    assert set(out["subset"]) <= {
+        "missense_variant",
+        "splicing",
+        SGE_POOLED_SUBSET,
+        MACRO_AVG_SUBSET,
+    }
+    assert {"urn:1", "urn:2", MACRO_AVG_SUBSET} <= set(out["accession"])
+    probe_cells = out[(out["score_type"] == "probe_score") & out["value"].notna()]
+    assert (probe_cells["value"] > 0.999).all()
+
+
+def test_sge_probe_metrics_drops_skipped_subset():
+    """Rows the probe skipped (all-NaN ``probe_score`` for a subset below the gate) are
+    dropped, so that subset is absent while the scored subset is still evaluated for both
+    score types."""
+    df = _sge_probe_df(seed=1, perfect_probe=True, nan_subset="splicing")
+    out = compute_sge_probe_metrics(df, "minus_llr", n_bootstrap=20, rng=0)
+    assert "splicing" not in set(out["subset"])
+    assert "missense_variant" in set(out["subset"])
+    assert set(out["score_type"]) == {"probe_score", "minus_llr_avg"}
 
 
 def test_sge_n_min_auprc_gates_small_cells():

--- a/tests/pipelines/evals/test_metrics.py
+++ b/tests/pipelines/evals/test_metrics.py
@@ -849,13 +849,12 @@ def test_sge_probe_metrics_shape_and_paired_baseline():
     out = compute_sge_probe_metrics(df, "minus_llr", n_bootstrap=20, rng=0)
     # Exactly two score types on identical rows: the probe + its zero-shot baseline.
     assert set(out["score_type"]) == {"probe_score", "minus_llr_avg"}
-    # Same per-accession × subset structure as compute_sge_metrics.
-    assert set(out["subset"]) <= {
-        "missense_variant",
-        "splicing",
-        SGE_POOLED_SUBSET,
-        MACRO_AVG_SUBSET,
-    }
+    # Per-subset cells + the subset-macro, but NOT the pooled cross-subset `both` scope —
+    # separate per-subset probe classifiers aren't comparable across subsets.
+    assert set(out["subset"]) <= {"missense_variant", "splicing", MACRO_AVG_SUBSET}
+    assert SGE_POOLED_SUBSET not in set(out["subset"]), (
+        "pooled 'both' scope must be dropped for per-subset probe scores"
+    )
     assert {"urn:1", "urn:2", MACRO_AVG_SUBSET} <= set(out["accession"])
     probe_cells = out[(out["score_type"] == "probe_score") & out["value"].notna()]
     assert (probe_cells["value"] > 0.999).all()


### PR DESCRIPTION
🤖 Wire **linear probing for SGE** in `evals_v2` — it was matched-pair-only (`compute_probe_metrics` hard-asserted `eval_protocol == "matched_pair"`, rejecting SGE).

## What changed

- **`compute_sge_probe_metrics`** (`src/marin_dna/pipelines/evals/metrics.py`) — a thin library helper that reuses the existing `compute_sge_metrics` on two score columns: the probe's `probe_score` and its paired zero-shot baseline (`{score_protocol}_avg`), dropping probe-skipped (NaN) rows so sklearn never sees a NaN score and the baseline covers exactly the probe-scored cells. Output is the same per-accession (`mavedb_urn`) × consequence-subset AUPRC (macro-averaged) the zero-shot SGE metrics already produce.
- **`compute_probe_metrics`** (`probe.smk`) now **branches on `eval_protocol`**: `matched_pair` → the existing per-chromosome-weighted AUPRC path (now with #349's chromosome-cluster bootstrap SE + `_macro_avg_` row, preserved); `sge` → `compute_sge_probe_metrics`. `qtl_global` is still rejected.
- **`compute_probe` is unchanged** — it already runs on SGE (feature `concat_ref_delta` for the directional `minus_llr`; leave-one-chromosome-out, which for SGE = leave-one-gene-out since each MaveDB study is one gene on one chromosome → leak-proof).
- **Tests**: 2 new (`test_sge_probe_metrics_shape_and_paired_baseline`, `test_sge_probe_metrics_drops_skipped_subset`); `tests/pipelines/evals/test_metrics.py` is green (**70 passed**).

## Provenance

Built and validated end-to-end in #353 (exp353): scored + probed 4 checkpoints on mendelian + SGE on a CPU box, producing real per-accession SGE probe AUPRC (8 saturation-mutagenesis genes). This PR extracts only the reusable `evals_v2` core; the experiment-specific config registration, plots, and training dir stay on that experiment branch.

## Related

- #320 (frozen-embedding linear-probe productionization) · #292 (SGE eval wiring into `evals_v2`) · #314 (linear-probe VEP)
- #349 (probe metric chromosome-cluster bootstrap SE + macro-avg) — this composes with it; the matched-pair path keeps #349's SE/macro.
- #353 (the experiment that built + exercised this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
