### PR TITLE
Rewrite the short-context rationale as prose

### DIFF
--- a/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
+++ b/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
@@ -99,10 +99,10 @@ That choice also need not permanently constrain the model to left-to-right repre
 
 ### Why short context?
 
-- Our first goal is to model individual functional elements of the genome—such as an exon or an enhancer—well.
-- We deliberately use a short 255-bp context because it was sufficient for the functional-element tasks we tested while making training and evaluation much faster.
-- Centering each example on an individual functional element also makes the training data easier to construct, filter, audit, and interpret.
-- We leave to future work how best to extend context, either through additional long-context next-token pretraining or directly during downstream-task fine-tuning.
+Our first goal is to model individual functional elements of the genome—such as an exon or an enhancer—well.
+We therefore deliberately use a short 255-bp context: it was sufficient for the functional-element tasks we tested while making training and evaluation much faster.
+Centering each example on an individual functional element also makes the training data easier to construct, filter, audit, and interpret.
+We leave to future work how best to extend context, either through additional long-context next-token pretraining or directly during downstream-task fine-tuning.
 
 ### Why VEP evaluation?
 


### PR DESCRIPTION
## Summary

- Rewrite the [“Why short context?” section](https://github.com/Open-Athena/marin-dna/blob/bf215cda8c3cdb52906337685e4b2678f125ba6f/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md#L100-L105) from bullets into prose.
- Preserve the four original points while connecting the context-length choice more naturally to the functional-element goal.

## Why

This is a focused editorial pass for #361 in the permanent blog staging workspace tracked by #373.

## Validation

- `uv run --no-project python src/marin_dna/blog_workspace.py validate`
- `git diff --check`
- Independent read-only review: no findings; the pinned Mistune renderer emits one continuous paragraph.
