### PR TITLE
Refine the VEP evaluation section

### DIFF
--- a/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
+++ b/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
@@ -143,9 +143,10 @@ VEP is also one of the few evaluations backed by decades of costly clinical gene
 That combination makes it a substantive test of whether a gLM has learned sequence constraints that actually matter for human biology.
 If a model has learned useful sequence-level constraints from DNA alone, it should help rank variants in places where direct experimental evidence is weak or nonexistent.
 
-- In this work, we focus on predicting deleteriousness, pathogenicity, or more generally functional constraint.
-- This task is the most directly connected to the language modeling training objective, and is therefore easy to evaluate with zero-shot or linear probing protocols.
-- We leave predicting changes in gene expression (the main application of sequence-to-function models) to follow up work, as this requires more complex finetuning protocols (and much larger context sizes) (insert footnote about how chromatin accessibility is a more tractable intermediate step, ARSENAL work showing very promising results).
+In this work, we focus on predicting deleteriousness, pathogenicity, or, more generally, functional constraint.
+This task is the one most directly connected to the language-modeling training objective and is therefore easy to evaluate with zero-shot or linear-probing protocols.
+We leave the prediction of changes in gene expression—the main application of sequence-to-function models—to follow-up work, as it requires more complex fine-tuning protocols and much larger context sizes.[^sequence-to-function-follow-up]
+
 - We use two complementary sources of evidence: clinically curated Mendelian variants (footnote with a few key differences with published TraitGym) and saturation genome-editing (SGE) measurements.
 - The Mendelian benchmark compares pathogenic and putatively benign variants across broad coding and non-coding consequence types.
 - The SGE benchmark uses experimentally measured variant effects from a few genes in MaveDB, currently covering missense and splicing variants.
@@ -168,6 +169,8 @@ If a model has learned useful sequence-level constraints from DNA alone, it shou
 [^vep-therapeutic]: Examples include fine-mapped GWAS and broader human-genetics results in [GPN-Star](https://doi.org/10.1101/2025.09.21.677619), regulatory variant-effect prediction in [AlphaGenome](https://doi.org/10.1101/2025.06.25.661532) and [ChromBPNet](https://www.biorxiv.org/content/10.1101/2024.12.25.630221v2), and the broader observation that human genetic evidence can support target-disease hypotheses in drug discovery in [Nelson et al.](https://doi.org/10.1038/ng.3314).
 
 [^human-variant-curation]: [ClinVar](https://www.ncbi.nlm.nih.gov/clinvar/intro/) archives submitted reports relating human genomic variation to disease, cancer, drug response, and supporting evidence; [OMIM](https://doi.org/10.1093/nar/gku1205) is a curated catalog of human genes, genetic disorders, and gene-phenotype relationships. Nothing comparable exists for any other species: this depth reflects decades of clinical genetics effort directed specifically at human disease, an investment that has simply not been made for non-human genomes.
+
+[^sequence-to-function-follow-up]: One promising intermediate sequence-to-function target is chromatin accessibility. [ARSENAL](https://doi.org/10.64898/2026.02.05.703637) showed that embeddings from a short-context regulatory gLM improved supervised chromatin-accessibility prediction over strong ab initio baselines across multiple cell types, while also improving regulatory-variant scoring.
 
 ### Why Evo 2 40B baseline?
 

--- a/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
+++ b/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
@@ -156,8 +156,9 @@ The SGE benchmark uses experimentally measured variant effects from a few genes 
 <figcaption>The benchmarks use different labels and sampling, so their absolute scores are not directly comparable.</figcaption>
 </figure>
 
-- We evaluate each frozen gLM with two readouts: a zero-shot sequence log-likelihood ratio and a linear probe trained on paired reference/alternate embeddings.
-- The zero-shot score asks what the language model itself prefers (TODO: this could be improved); the probe asks what variant-relevant information is present in its learned representation.
+We evaluate each frozen gLM with two readouts: a zero-shot sequence log-likelihood ratio and a linear probe trained on paired reference/alternate embeddings.
+The zero-shot score tests whether the model's learned sequence likelihood reflects functional constraint: deleterious alternate alleles should incur larger likelihood penalties relative to the reference allele.
+The probe instead asks what variant-relevant information is encoded in the model's learned representation, including information that may not be directly reflected in its sequence likelihoods.
 
 <figure>
 <img src="/assets/images/blog/genomic-lm-optimization/eval_apparatus.svg" alt="Reference and alternate sequences scored using likelihoods or frozen-model embeddings." />

--- a/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
+++ b/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
@@ -147,9 +147,9 @@ In this work, we focus on predicting deleteriousness, pathogenicity, or, more ge
 This task is the one most directly connected to the language-modeling training objective and is therefore easy to evaluate with zero-shot or linear-probing protocols.
 We leave the prediction of changes in gene expression—the main application of sequence-to-function models—to follow-up work, as it requires more complex fine-tuning protocols and much larger context sizes.[^sequence-to-function-follow-up]
 
-- We use two complementary sources of evidence: clinically curated Mendelian variants (footnote with a few key differences with published TraitGym) and saturation genome-editing (SGE) measurements.
-- The Mendelian benchmark compares pathogenic and putatively benign variants across broad coding and non-coding consequence types.
-- The SGE benchmark uses experimentally measured variant effects from a few genes in MaveDB, currently covering missense and splicing variants.
+We use two complementary sources of evidence: clinically curated Mendelian variants[^mendelian-traitgym-differences] and saturation genome-editing (SGE) measurements.
+The Mendelian benchmark compares pathogenic and putatively benign variants across broad coding and non-coding consequence types.
+The SGE benchmark uses experimentally measured variant effects from a few genes in MaveDB, currently covering missense and splicing variants.
 
 <figure>
 <img src="/assets/images/blog/genomic-lm-optimization/eval_datasets.svg" alt="Clinical Mendelian and experimental SGE benchmarks, including labels and subset counts." />
@@ -171,6 +171,12 @@ We leave the prediction of changes in gene expression—the main application of 
 [^human-variant-curation]: [ClinVar](https://www.ncbi.nlm.nih.gov/clinvar/intro/) archives submitted reports relating human genomic variation to disease, cancer, drug response, and supporting evidence; [OMIM](https://doi.org/10.1093/nar/gku1205) is a curated catalog of human genes, genetic disorders, and gene-phenotype relationships. Nothing comparable exists for any other species: this depth reflects decades of clinical genetics effort directed specifically at human disease, an investment that has simply not been made for non-human genomes.
 
 [^sequence-to-function-follow-up]: One promising intermediate sequence-to-function target is chromatin accessibility. [ARSENAL](https://doi.org/10.64898/2026.02.05.703637) showed that embeddings from a short-context regulatory gLM improved supervised chromatin-accessibility prediction over strong ab initio baselines across multiple cell types, while also improving regulatory-variant scoring.
+
+[^mendelian-traitgym-differences]: Our Mendelian benchmark is inspired by the published [TraitGym](https://doi.org/10.1101/2025.02.11.637758) benchmark.
+Relative to TraitGym, we broadened the gnomAD control set by lowering the minimum allele frequency from 5% to 0.1%; we refer to variants above this threshold as non-rare.
+The larger control pool allowed us to match potential confounders within each consequence class—including TSS distance and, for splicing variants, exon distance—so that these features are largely non-predictive of the label.
+We also expanded the benchmark to include missense and splicing variants, incorporated additional sources of pathogenic variants, and created chromosome-disjoint splits for development and final testing.
+See the [pinned dataset card](https://huggingface.co/datasets/bolinas-dna/evals_mendelian_traits/tree/4aed58e50c5dea0b878a665007af2ef9e5108e9f) for the full construction and matching diagnostics.
 
 ### Why Evo 2 40B baseline?
 

--- a/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
+++ b/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
@@ -143,6 +143,9 @@ VEP is also one of the few evaluations backed by decades of costly clinical gene
 That combination makes it a substantive test of whether a gLM has learned sequence constraints that actually matter for human biology.
 If a model has learned useful sequence-level constraints from DNA alone, it should help rank variants in places where direct experimental evidence is weak or nonexistent.
 
+This creates a deliberate mismatch between evaluation and intended use: although we expect gLMs to be especially valuable for non-model organisms in the near term, we evaluate them in humans because comparable variant-effect data are not yet available across species.
+Human VEP is therefore the most rigorous available test of learned functional constraint, but it does not by itself establish transfer to other organisms; evaluating that transfer will require broader population-genetic or experimental datasets.
+
 In this work, we focus on predicting deleteriousness, pathogenicity, or, more generally, functional constraint.
 This task is the one most directly connected to the language-modeling training objective and is therefore easy to evaluate with zero-shot or linear-probing protocols.
 We leave the prediction of changes in gene expression—the main application of sequence-to-function models—to follow-up work, as it requires more complex fine-tuning protocols and much larger context sizes.[^sequence-to-function-follow-up]

--- a/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
+++ b/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
@@ -142,14 +142,17 @@ VEP is arguably the most important application of gLMs. A useful VEP model can h
 - The SGE benchmark uses experimentally measured variant effects from MaveDB, currently covering missense and splicing variants.
 - These benchmarks have different evidence sources, matching designs, and class definitions, so their absolute AUPRC values should not be compared directly.
 
-![Mendelian and SGE evaluation datasets](/assets/images/blog/genomic-lm-optimization/eval_datasets.svg)
+<figure>
+<img src="/assets/images/blog/genomic-lm-optimization/eval_datasets.svg" alt="Clinical Mendelian and experimental SGE benchmarks, including labels and subset counts." />
+<figcaption>The benchmarks use different labels and sampling, so their absolute scores are not directly comparable.</figcaption>
+</figure>
 
 - We evaluate each frozen gLM with two readouts: a zero-shot sequence log-likelihood ratio and a linear probe trained on paired reference/alternate embeddings.
 - The zero-shot score asks what the language model itself prefers; the probe asks what variant-relevant information is present in its learned representation.
 
 <figure>
-<img src="/assets/images/blog/genomic-lm-optimization/eval_apparatus.svg" alt="Zero-shot and linear-probe variant scoring" />
-<figcaption>The two readouts ask different questions of the same frozen model: zero-shot scoring tests whether reference-to-alternate likelihood changes track variant deleteriousness, while linear probing asks whether the paired allele embeddings contain variant-relevant information.</figcaption>
+<img src="/assets/images/blog/genomic-lm-optimization/eval_apparatus.svg" alt="Reference and alternate sequences scored using likelihoods or frozen-model embeddings." />
+<figcaption>Zero-shot scoring uses REF-to-ALT likelihood changes; linear probing uses paired allele embeddings.</figcaption>
 </figure>
 
 [^vep-clinical]: Examples include zero-shot or disease-focused variant interpretation results in [Evo 2](https://doi.org/10.1101/2025.02.18.638918), [GPN-Star](https://doi.org/10.1101/2025.09.21.677619), [Carbon](https://doi.org/10.64898/2026.05.22.727119), and [EnTao-GPM](https://arxiv.org/abs/2507.21706).

--- a/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
+++ b/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
@@ -134,13 +134,21 @@ We leave to future work how best to extend context, either through additional lo
 
 ### Why VEP evaluation?
 
-VEP is arguably the most important application of gLMs. A useful VEP model can help scale clinical interpretation for rare disease, hereditary cancer, and variants of uncertain significance.[^vep-clinical] It can also help connect genetic association signals to disease mechanisms, target selection, and causal-variant prioritization in GWAS fine-mapping.[^vep-therapeutic] The same kind of evidence is relevant to clinical trial design when genetics can inform patient stratification, enrollment criteria, or mechanism-based cohort definition. Together, these are commonly used levers for improving the efficiency of pharmaceutical development, and it is uncommon for other gLM evaluations to have such a direct connection to commercially relevant research tasks. VEP is also one of the few evaluations backed by decades of costly clinical genetics curation, with resources such as ClinVar and OMIM providing a level of human variant evidence that has no real analogue in other species.[^human-variant-curation] That combination makes it a substantive test of whether a gLM has learned sequence constraints that actually matter for human biology. If a model has learned useful sequence-level constraints from DNA alone, it should help rank variants in places where direct experimental evidence is weak or nonexistent.
+Variant effect prediction (VEP) is one the most important application of gLMs.
+A useful VEP model can help scale clinical interpretation for rare disease, hereditary cancer, and variants of uncertain significance.[^vep-clinical]
+It can also help connect genetic association signals to disease mechanisms, target selection, and causal-variant prioritization in GWAS fine-mapping.[^vep-therapeutic]
+The same kind of evidence is relevant to clinical trial design when genetics can inform patient stratification, enrollment criteria, or mechanism-based cohort definition.
+Together, these are commonly used levers for improving the efficiency of pharmaceutical development, and it is uncommon for other gLM evaluations to have such a direct connection to commercially relevant research tasks.
+VEP is also one of the few evaluations backed by decades of costly clinical genetics curation, with resources such as ClinVar and OMIM providing a level of human variant evidence that has no real analogue in other species.[^human-variant-curation]
+That combination makes it a substantive test of whether a gLM has learned sequence constraints that actually matter for human biology.
+If a model has learned useful sequence-level constraints from DNA alone, it should help rank variants in places where direct experimental evidence is weak or nonexistent.
 
-- By VEP, we mean estimating whether a sequence variant is likely to disrupt biological function—for example through deleteriousness, pathogenicity, or evidence of evolutionary constraint.
-- We use two complementary sources of evidence: clinically curated Mendelian variants and saturation genome-editing measurements.
-- The Mendelian benchmark compares pathogenic and putatively benign variants across coding and non-coding consequence types.
-- The SGE benchmark uses experimentally measured variant effects from MaveDB, currently covering missense and splicing variants.
-- These benchmarks have different evidence sources, matching designs, and class definitions, so their absolute AUPRC values should not be compared directly.
+- In this work, we focus on predicting deleteriousness, pathogenicity, or more generally functional constraint.
+- This task is the most directly connected to the language modeling training objective, and is therefore easy to evaluate with zero-shot or linear probing protocols.
+- We leave predicting changes in gene expression (the main application of sequence-to-function models) to follow up work, as this requires more complex finetuning protocols (and much larger context sizes) (insert footnote about how chromatin accessibility is a more tractable intermediate step, ARSENAL work showing very promising results).
+- We use two complementary sources of evidence: clinically curated Mendelian variants (footnote with a few key differences with published TraitGym) and saturation genome-editing (SGE) measurements.
+- The Mendelian benchmark compares pathogenic and putatively benign variants across broad coding and non-coding consequence types.
+- The SGE benchmark uses experimentally measured variant effects from a few genes in MaveDB, currently covering missense and splicing variants.
 
 <figure>
 <img src="/assets/images/blog/genomic-lm-optimization/eval_datasets.svg" alt="Clinical Mendelian and experimental SGE benchmarks, including labels and subset counts." />
@@ -148,7 +156,7 @@ VEP is arguably the most important application of gLMs. A useful VEP model can h
 </figure>
 
 - We evaluate each frozen gLM with two readouts: a zero-shot sequence log-likelihood ratio and a linear probe trained on paired reference/alternate embeddings.
-- The zero-shot score asks what the language model itself prefers; the probe asks what variant-relevant information is present in its learned representation.
+- The zero-shot score asks what the language model itself prefers (TODO: this could be improved); the probe asks what variant-relevant information is present in its learned representation.
 
 <figure>
 <img src="/assets/images/blog/genomic-lm-optimization/eval_apparatus.svg" alt="Reference and alternate sequences scored using likelihoods or frozen-model embeddings." />

--- a/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
+++ b/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
@@ -174,10 +174,10 @@ The probe instead asks what variant-relevant information is encoded in the model
 [^sequence-to-function-follow-up]: One promising intermediate sequence-to-function target is chromatin accessibility. [ARSENAL](https://doi.org/10.64898/2026.02.05.703637) showed that embeddings from a short-context regulatory gLM improved supervised chromatin-accessibility prediction over strong ab initio baselines across multiple cell types, while also improving regulatory-variant scoring.
 
 [^mendelian-traitgym-differences]: Our Mendelian benchmark is inspired by the published [TraitGym](https://doi.org/10.1101/2025.02.11.637758) benchmark.
-Relative to TraitGym, we broadened the gnomAD control set by lowering the minimum allele frequency from 5% to 0.1%; we refer to variants above this threshold as non-rare.
-The larger control pool allowed us to match potential confounders within each consequence class—including TSS distance and, for splicing variants, exon distance—so that these features are largely non-predictive of the label.
-We also expanded the benchmark to include missense and splicing variants, incorporated additional sources of pathogenic variants, and created chromosome-disjoint splits for development and final testing.
-See the [pinned dataset card](https://huggingface.co/datasets/bolinas-dna/evals_mendelian_traits/tree/4aed58e50c5dea0b878a665007af2ef9e5108e9f) for the full construction and matching diagnostics.
+    Relative to TraitGym, we broadened the gnomAD control set by lowering the minimum allele frequency from 5% to 0.1%; we refer to variants above this threshold as non-rare.
+    The larger control pool allowed us to match potential confounders within each consequence class—including TSS distance and, for splicing variants, exon distance—so that these features are largely non-predictive of the label.
+    We also expanded the benchmark to include missense and splicing variants, incorporated additional sources of pathogenic variants, and created chromosome-disjoint splits for development and final testing.
+    See the [pinned dataset card](https://huggingface.co/datasets/bolinas-dna/evals_mendelian_traits/tree/4aed58e50c5dea0b878a665007af2ef9e5108e9f) for the full construction and matching diagnostics.
 
 ### Why Evo 2 40B baseline?
 

--- a/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
+++ b/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
@@ -147,7 +147,10 @@ VEP is arguably the most important application of gLMs. A useful VEP model can h
 - We evaluate each frozen gLM with two readouts: a zero-shot sequence log-likelihood ratio and a linear probe trained on paired reference/alternate embeddings.
 - The zero-shot score asks what the language model itself prefers; the probe asks what variant-relevant information is present in its learned representation.
 
-![Reference/alternate inference with zero-shot and probe readouts](/assets/images/blog/genomic-lm-optimization/eval_apparatus.svg)
+<figure>
+<img src="/assets/images/blog/genomic-lm-optimization/eval_apparatus.svg" alt="Zero-shot and linear-probe variant scoring" />
+<figcaption>The two readouts ask different questions of the same frozen model: zero-shot scoring tests whether reference-to-alternate likelihood changes track variant deleteriousness, while linear probing asks whether the paired allele embeddings contain variant-relevant information.</figcaption>
+</figure>
 
 [^vep-clinical]: Examples include zero-shot or disease-focused variant interpretation results in [Evo 2](https://doi.org/10.1101/2025.02.18.638918), [GPN-Star](https://doi.org/10.1101/2025.09.21.677619), [Carbon](https://doi.org/10.64898/2026.05.22.727119), and [EnTao-GPM](https://arxiv.org/abs/2507.21706).
 

--- a/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/eval_apparatus.svg
+++ b/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/eval_apparatus.svg
@@ -1,165 +1,67 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 548" role="img" aria-labelledby="title desc" font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
-  <title id="title">Variant evaluation — one frozen genomic language model, two readouts</title>
-  <desc id="desc">A reference and alternate allele window are passed through the same frozen genomic language model in forward and reverse-complement orientations. The shared inference produces a zero-shot log-likelihood ratio and mean-pooled allele embeddings. The embeddings feed an L2 logistic linear probe evaluated with nested leave-one-chromosome-out cross-validation. Both readouts are compared with AUPRC.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 840 350" role="img" aria-labelledby="title desc" font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title id="title">Two ways to score a variant with a frozen genomic language model</title>
+  <desc id="desc">Reference and alternate DNA sequences that differ at one base pass through a frozen genomic language model. A zero-shot readout compares their sequence likelihoods, while a linear probe learns a score from their embeddings.</desc>
 
   <defs>
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#8a7d68"/>
     </marker>
-    <marker id="arrow-rust" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#9c4f2f"/>
-    </marker>
-    <marker id="arrow-teal" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#2f6f63"/>
-    </marker>
-    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
-      <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="#5b4a36" flood-opacity="0.10"/>
-    </filter>
   </defs>
 
-  <!-- Warm blog panel -->
-  <rect x="1" y="1" width="978" height="546" rx="16" fill="#f6f0e4" stroke="#ddd3bf"/>
-  <text x="28" y="35" font-size="20" font-weight="750" fill="#1f1e1b">Variant evaluation — one frozen gLM, two readouts</text>
-  <text x="28" y="57" font-size="11.5" fill="#7a6f5f">Paired ref/alt inference is shared · model weights never update · forward + reverse-complement scores are averaged</text>
+  <rect x="1" y="1" width="838" height="348" rx="16" fill="#f6f0e4" stroke="#ddd3bf"/>
+  <text x="28" y="39" font-size="20" font-weight="750" fill="#1f1e1b">Two ways to score a variant with a frozen gLM</text>
 
-  <!-- Input pair -->
-  <text x="28" y="93" font-size="9.5" font-weight="700" letter-spacing="0.8" fill="#a89a80">PAIRED ALLELE WINDOWS</text>
-  <g filter="url(#shadow)">
-    <rect x="28" y="106" width="207" height="139" rx="12" fill="#fcfaf5" stroke="#ddd3bf"/>
-  </g>
-  <text x="44" y="127" font-size="10" fill="#8a7d68">same genomic context · one SNV</text>
-
-  <text x="44" y="151" font-size="10" font-weight="700" fill="#465c6e">REF</text>
-  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="14" fill="#1f1e1b">
-    <text x="80" y="152">A C G T</text>
-    <rect x="130" y="136" width="21" height="22" rx="4" fill="#e9edf0" stroke="#465c6e"/>
-    <text x="136" y="152" font-weight="700" fill="#465c6e">C</text>
-    <text x="158" y="152">G T C A</text>
+  <!-- Reference and alternate sequence -->
+  <rect x="28" y="72" width="210" height="220" rx="13" fill="#fcfaf5" stroke="#d9cbb1"/>
+  <text x="46" y="104" font-size="10" font-weight="700" fill="#465c6e">REFERENCE</text>
+  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="15" fill="#1f1e1b">
+    <text x="46" y="132">ACGT</text>
+    <rect x="89" y="113" width="23" height="25" rx="4" fill="#e9edf0" stroke="#8394a1"/>
+    <text x="97" y="132" font-weight="700" fill="#465c6e">C</text>
+    <text x="119" y="132">GTCA</text>
   </g>
 
-  <line x1="140.5" y1="162" x2="140.5" y2="177" stroke="#c0883a" stroke-width="1.5" stroke-dasharray="3 3"/>
-  <text x="44" y="198" font-size="10" font-weight="700" fill="#c0883a">ALT</text>
-  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="14" fill="#1f1e1b">
-    <text x="80" y="199">A C G T</text>
-    <rect x="130" y="183" width="21" height="22" rx="4" fill="#f5e6cf" stroke="#c0883a"/>
-    <text x="136" y="199" font-weight="700" fill="#9c4f2f">T</text>
-    <text x="158" y="199">G T C A</text>
-  </g>
-  <text x="44" y="226" font-size="9.5" fill="#8a7d68">The highlighted base is the only change</text>
+  <line x1="100.5" y1="144" x2="100.5" y2="165" stroke="#a89a80" stroke-width="1.4" stroke-dasharray="3 3"/>
 
-  <!-- Frozen model -->
-  <path d="M 235 175 C 250 175, 251 175, 264 175" fill="none" stroke="#8a7d68" stroke-width="1.8" marker-end="url(#arrow)"/>
-  <text x="266" y="93" font-size="9.5" font-weight="700" letter-spacing="0.8" fill="#a89a80">SHARED INFERENCE</text>
-  <g filter="url(#shadow)">
-    <rect x="266" y="106" width="142" height="139" rx="14" fill="#fcfaf5" stroke="#9c4f2f" stroke-width="1.4"/>
-  </g>
-  <circle cx="337" cy="145" r="22" fill="#f0ded2"/>
-  <path d="M 326 132 C 342 140, 331 151, 348 159 M 348 132 C 332 140, 343 151, 326 159 M 329 137 L 345 137 M 329 154 L 345 154" fill="none" stroke="#9c4f2f" stroke-width="1.7" stroke-linecap="round"/>
-  <text x="337" y="186" font-size="16" font-weight="750" text-anchor="middle" fill="#1f1e1b">frozen gLM</text>
-  <text x="337" y="204" font-size="10" text-anchor="middle" fill="#7a6f5f">same weights · ref + alt</text>
-  <g>
-    <rect x="286" y="216" width="45" height="17" rx="8.5" fill="#e8efec"/>
-    <text x="308.5" y="228" font-size="8.5" font-weight="700" text-anchor="middle" fill="#2f6f63">FWD</text>
-    <rect x="340" y="216" width="48" height="17" rx="8.5" fill="#e8efec"/>
-    <text x="364" y="228" font-size="8.5" font-weight="700" text-anchor="middle" fill="#2f6f63">RC</text>
+  <text x="46" y="189" font-size="10" font-weight="700" fill="#465c6e">ALTERNATE</text>
+  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="15" fill="#1f1e1b">
+    <text x="46" y="217">ACGT</text>
+    <rect x="89" y="198" width="23" height="25" rx="4" fill="#e9edf0" stroke="#8394a1"/>
+    <text x="97" y="217" font-weight="700" fill="#465c6e">T</text>
+    <text x="119" y="217">GTCA</text>
   </g>
 
-  <!-- Shared output split -->
-  <path d="M 408 175 L 432 175 L 432 150 L 454 150" fill="none" stroke="#8a7d68" stroke-width="1.8" marker-end="url(#arrow)"/>
-  <path d="M 432 175 L 432 315 L 454 315" fill="none" stroke="#8a7d68" stroke-width="1.8" marker-end="url(#arrow)"/>
-  <circle cx="432" cy="175" r="4" fill="#8a7d68"/>
-  <text x="419" y="254" font-size="8.5" fill="#a89a80" text-anchor="middle" transform="rotate(-90 419 254)">same model passes</text>
+  <text x="46" y="258" font-size="10.5" fill="#7a6f5f">One changed base</text>
+  <text x="46" y="275" font-size="10.5" fill="#7a6f5f">in the same DNA context</text>
 
-  <!-- Zero-shot branch -->
-  <g filter="url(#shadow)">
-    <rect x="455" y="86" width="346" height="159" rx="13" fill="#fcfaf5" stroke="#dbc4b5"/>
-  </g>
-  <rect x="455" y="86" width="7" height="159" rx="3.5" fill="#9c4f2f"/>
-  <text x="478" y="111" font-size="9.5" font-weight="700" letter-spacing="0.7" fill="#9c4f2f">A · ZERO-SHOT READOUT</text>
-  <text x="478" y="133" font-size="14" font-weight="750" fill="#1f1e1b">Sequence log-likelihood ratio</text>
-  <rect x="478" y="146" width="295" height="41" rx="8" fill="#f4e9e1"/>
-  <text x="625.5" y="164" font-size="11.5" font-weight="700" text-anchor="middle" fill="#5b3424">Score = log P(REF) − log P(ALT)</text>
-  <text x="625.5" y="179" font-size="9.5" text-anchor="middle" fill="#8a624f">− mean raw LLR across FWD + RC</text>
-  <text x="478" y="207" font-size="9.5" fill="#7a6f5f">No labels · variant and downstream token predictions both contribute</text>
-  <g>
-    <rect x="478" y="217" width="87" height="17" rx="8.5" fill="#f0ded2"/>
-    <text x="521.5" y="229" font-size="8.5" font-weight="700" text-anchor="middle" fill="#9c4f2f">zero-shot score</text>
-  </g>
+  <!-- Compact frozen model -->
+  <path d="M 238 182 L 279 182" fill="none" stroke="#8a7d68" stroke-width="1.8" marker-end="url(#arrow)"/>
+  <rect x="282" y="119" width="144" height="126" rx="14" fill="#fcfaf5" stroke="#bdc7cf" stroke-width="1.4"/>
+  <circle cx="354" cy="156" r="23" fill="#e9edf0"/>
+  <text x="354" y="166" font-size="28" text-anchor="middle" fill="#465c6e">❄</text>
+  <text x="354" y="213" font-size="15" font-weight="750" text-anchor="middle" fill="#1f1e1b">frozen gLM</text>
 
-  <!-- Supervised branch -->
-  <g filter="url(#shadow)">
-    <rect x="455" y="270" width="390" height="237" rx="13" fill="#fcfaf5" stroke="#b9d2ca"/>
-  </g>
-  <rect x="455" y="270" width="7" height="237" rx="3.5" fill="#2f6f63"/>
-  <text x="478" y="295" font-size="9.5" font-weight="700" letter-spacing="0.7" fill="#2f6f63">B · SUPERVISED READOUT</text>
+  <!-- Split into two readouts -->
+  <path d="M 426 182 L 452 182 L 452 123 L 475 123" fill="none" stroke="#8a7d68" stroke-width="1.8" marker-end="url(#arrow)"/>
+  <path d="M 452 182 L 452 263 L 475 263" fill="none" stroke="#8a7d68" stroke-width="1.8" marker-end="url(#arrow)"/>
+  <circle cx="452" cy="182" r="4" fill="#8a7d68"/>
 
-  <!-- Probe feature pipeline -->
-  <rect x="478" y="308" width="101" height="55" rx="9" fill="#e9edf0" stroke="#bdc7cf"/>
-  <g fill="#465c6e">
-    <rect x="489" y="322" width="8" height="11" rx="1" opacity="0.45"/>
-    <rect x="499" y="318" width="8" height="15" rx="1" opacity="0.70"/>
-    <rect x="509" y="324" width="8" height="9" rx="1"/>
-    <rect x="489" y="339" width="8" height="11" rx="1" opacity="0.45"/>
-    <rect x="499" y="335" width="8" height="15" rx="1" opacity="0.70"/>
-    <rect x="509" y="341" width="8" height="9" rx="1"/>
-  </g>
-  <text x="525" y="327" font-size="8.5" font-weight="700" fill="#465c6e">e<tspan baseline-shift="sub" font-size="6.5">ref</tspan></text>
-  <text x="525" y="345" font-size="8.5" font-weight="700" fill="#465c6e">e<tspan baseline-shift="sub" font-size="6.5">alt</tspan></text>
-  <text x="528.5" y="357" font-size="8" text-anchor="middle" fill="#7a6f5f">mean-pooled window</text>
+  <!-- Zero-shot readout -->
+  <rect x="478" y="65" width="330" height="116" rx="13" fill="#fcfaf5" stroke="#dbc4b5"/>
+  <rect x="478" y="65" width="7" height="116" rx="3.5" fill="#9c4f2f"/>
+  <text x="502" y="91" font-size="9.5" font-weight="700" letter-spacing="0.7" fill="#9c4f2f">ZERO-SHOT</text>
+  <text x="502" y="116" font-size="15" font-weight="750" fill="#1f1e1b">Sequence likelihoods</text>
+  <text x="502" y="138" font-size="11" fill="#5b3424">Which allele does the model prefer?</text>
+  <rect x="502" y="149" width="282" height="22" rx="7" fill="#f4e9e1"/>
+  <text x="643" y="165" font-size="10" font-weight="700" text-anchor="middle" fill="#7a4a35">P(REF) vs P(ALT)</text>
 
-  <path d="M 579 335 L 592 335" fill="none" stroke="#2f6f63" stroke-width="1.5" marker-end="url(#arrow-teal)"/>
-  <rect x="595" y="308" width="103" height="55" rx="9" fill="#e8efec" stroke="#9fc3b8"/>
-  <text x="646.5" y="328" font-size="9" font-weight="700" text-anchor="middle" fill="#2f6f63">pair feature</text>
-  <text x="646.5" y="345" font-size="10" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" text-anchor="middle" fill="#1f1e1b">[ref ; alt−ref]</text>
-  <text x="646.5" y="357" font-size="8" text-anchor="middle" fill="#7a6f5f">directional task</text>
+  <!-- Linear-probe readout -->
+  <rect x="478" y="205" width="330" height="116" rx="13" fill="#fcfaf5" stroke="#b9d2ca"/>
+  <rect x="478" y="205" width="7" height="116" rx="3.5" fill="#2f6f63"/>
+  <text x="502" y="231" font-size="9.5" font-weight="700" letter-spacing="0.7" fill="#2f6f63">LINEAR PROBE</text>
+  <text x="502" y="256" font-size="15" font-weight="750" fill="#1f1e1b">Allele embeddings</text>
+  <text x="502" y="278" font-size="11" fill="#315f56">What variant signal is represented?</text>
+  <rect x="502" y="289" width="282" height="22" rx="7" fill="#e8efec"/>
+  <text x="643" y="305" font-size="10" font-weight="700" text-anchor="middle" fill="#2f6f63">REF / ALT embeddings → linear classifier</text>
 
-  <path d="M 698 335 L 711 335" fill="none" stroke="#2f6f63" stroke-width="1.5" marker-end="url(#arrow-teal)"/>
-  <rect x="714" y="308" width="108" height="55" rx="9" fill="#e8efec" stroke="#2f6f63"/>
-  <text x="768" y="329" font-size="10" font-weight="750" text-anchor="middle" fill="#1f1e1b">linear probe</text>
-  <text x="768" y="345" font-size="8.5" text-anchor="middle" fill="#2f6f63">standardize → L2 logit</text>
-  <text x="768" y="357" font-size="8" text-anchor="middle" fill="#7a6f5f">frozen embeddings</text>
-
-  <!-- LOCO block -->
-  <rect x="478" y="381" width="344" height="105" rx="10" fill="#f8f3e9" stroke="#d8c39f" stroke-dasharray="4 3"/>
-  <text x="494" y="402" font-size="10.5" font-weight="750" fill="#5b4a36">LOCO · leave one chromosome out</text>
-  <text x="806" y="402" font-size="8.5" text-anchor="end" fill="#8a7d68">nested, leakage-free</text>
-  <g font-size="8" font-weight="700" text-anchor="middle">
-    <rect x="494" y="414" width="34" height="22" rx="4" fill="#e8efec"/><text x="511" y="429" fill="#2f6f63">chr 1</text>
-    <rect x="534" y="414" width="34" height="22" rx="4" fill="#e8efec"/><text x="551" y="429" fill="#2f6f63">chr 2</text>
-    <text x="579" y="429" fill="#a89a80">···</text>
-    <rect x="592" y="411" width="46" height="28" rx="5" fill="#f5e6cf" stroke="#c0883a" stroke-width="1.4"/><text x="615" y="428" fill="#9c4f2f">chr k</text>
-    <text x="650" y="429" fill="#a89a80">···</text>
-    <rect x="663" y="414" width="39" height="22" rx="4" fill="#e8efec"/><text x="682.5" y="429" fill="#2f6f63">chr 22</text>
-    <path d="M 710 425 L 727 425" fill="none" stroke="#c0883a" stroke-width="1.4" marker-end="url(#arrow-rust)"/>
-    <text x="772" y="421" font-size="8.5" fill="#9c4f2f">predict held-out</text>
-    <text x="772" y="433" font-size="8.5" fill="#9c4f2f">chromosome</text>
-  </g>
-  <text x="494" y="455" font-size="9" fill="#7a6f5f"><tspan font-weight="700" fill="#2f6f63">TRAIN</tspan> on all other chromosomes · inner GroupKFold tunes C</text>
-  <text x="494" y="472" font-size="9" fill="#7a6f5f"><tspan font-weight="700" fill="#c0883a">TEST</tspan> on chr k · repeat k → one out-of-fold score per variant</text>
-
-  <!-- Shared metric -->
-  <path d="M 801 166 C 836 166, 838 199, 865 199" fill="none" stroke="#9c4f2f" stroke-width="1.8" marker-end="url(#arrow-rust)"/>
-  <path d="M 845 437 C 857 437, 854 369, 865 369" fill="none" stroke="#2f6f63" stroke-width="1.8" marker-end="url(#arrow-teal)"/>
-  <g filter="url(#shadow)">
-    <rect x="866" y="174" width="88" height="221" rx="13" fill="#eef0e4" stroke="#6f7d3f" stroke-width="1.3"/>
-  </g>
-  <text x="910" y="201" font-size="8.5" font-weight="700" letter-spacing="0.6" text-anchor="middle" fill="#6f7d3f">COMPARE</text>
-  <circle cx="910" cy="255" r="33" fill="#6f7d3f"/>
-  <text x="910" y="251" font-size="15" font-weight="800" text-anchor="middle" fill="#fff">AUPRC</text>
-  <text x="910" y="267" font-size="8.5" text-anchor="middle" fill="#fff">↑ better</text>
-  <text x="910" y="311" font-size="10" font-weight="700" text-anchor="middle" fill="#1f1e1b">rank variants</text>
-  <text x="910" y="329" font-size="9" text-anchor="middle" fill="#7a6f5f">same rows</text>
-  <text x="910" y="344" font-size="9" text-anchor="middle" fill="#7a6f5f">same metric</text>
-  <line x1="883" y1="354" x2="937" y2="354" stroke="#cbd0b0"/>
-  <circle cx="892" cy="368" r="4" fill="#9c4f2f"/><text x="901" y="371" font-size="8.5" fill="#5b4a36">zero-shot</text>
-  <circle cx="892" cy="382" r="4" fill="#2f6f63"/><text x="901" y="385" font-size="8.5" fill="#5b4a36">probe OOF</text>
-
-  <!-- Footer key -->
-  <g font-size="9" fill="#7a6f5f">
-    <rect x="28" y="520" width="10" height="10" rx="2" fill="#9c4f2f"/><text x="44" y="529">likelihood readout</text>
-    <rect x="157" y="520" width="10" height="10" rx="2" fill="#2f6f63"/><text x="173" y="529">supervised readout</text>
-    <rect x="301" y="520" width="10" height="10" rx="2" fill="#c0883a"/><text x="317" y="529">held-out chromosome</text>
-    <rect x="458" y="520" width="10" height="10" rx="2" fill="#465c6e"/><text x="474" y="529">allele embeddings</text>
-    <rect x="589" y="520" width="10" height="10" rx="2" fill="#6f7d3f"/><text x="605" y="529">shared evaluation metric</text>
-  </g>
 </svg>

--- a/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/eval_apparatus.svg
+++ b/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/eval_apparatus.svg
@@ -51,9 +51,9 @@
   <rect x="478" y="65" width="7" height="116" rx="3.5" fill="#9c4f2f"/>
   <text x="502" y="91" font-size="9.5" font-weight="700" letter-spacing="0.7" fill="#9c4f2f">ZERO-SHOT</text>
   <text x="502" y="116" font-size="15" font-weight="750" fill="#1f1e1b">Sequence likelihoods</text>
-  <text x="502" y="138" font-size="11" fill="#5b3424">Which allele does the model prefer?</text>
+  <text x="502" y="138" font-size="11" fill="#5b3424">How much does ALT change likelihood relative to REF?</text>
   <rect x="502" y="149" width="282" height="22" rx="7" fill="#f4e9e1"/>
-  <text x="643" y="165" font-size="10" font-weight="700" text-anchor="middle" fill="#7a4a35">P(REF) vs P(ALT)</text>
+  <text x="643" y="165" font-size="10" font-weight="700" text-anchor="middle" fill="#7a4a35">log P(ALT) − log P(REF)</text>
 
   <!-- Linear-probe readout -->
   <rect x="478" y="205" width="330" height="116" rx="13" fill="#fcfaf5" stroke="#b9d2ca"/>

--- a/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/eval_datasets.svg
+++ b/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/eval_datasets.svg
@@ -47,7 +47,7 @@
   <text x="160" y="216" font-size="10.5" fill="#5f574b">OMIM + Smedley et al. 2016 + HGMD · AF &lt; 0.1%</text>
   <circle cx="60" cy="244" r="5" fill="#f4e9e1" stroke="#9c4f2f"/>
   <text x="74" y="248" font-size="12" font-weight="750" fill="#1f1e1b">Control</text>
-  <text x="160" y="248" font-size="10.5" fill="#5f574b">gnomAD common SNVs · AF &gt; 0.1%</text>
+  <text x="160" y="248" font-size="10.5" fill="#5f574b">gnomAD non-rare SNVs · AF &gt; 0.1%</text>
 
   <line x1="245" y1="274" x2="245" y2="287" stroke="#8a7d68" stroke-width="1.5" marker-end="url(#arrow)"/>
   <rect x="40" y="292" width="410" height="68" rx="10" fill="#f3ead8" stroke="#d9cbb1"/>

--- a/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/eval_datasets.svg
+++ b/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/eval_datasets.svg
@@ -1,118 +1,178 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 650" role="img" aria-labelledby="t d" font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
-  <title id="t">Variant-effect evaluation datasets — Mendelian and saturation genome editing</title>
-  <desc id="d">Side-by-side overview of the Mendelian TraitGym-inspired benchmark and the MaveDB saturation-genome-editing benchmark. Mendelian pathogenic variants are matched one to nine to gnomAD common controls; saturation genome editing variants are experimentally measured and calibrated as abnormal or normal without matching. Counts are shown for every consequence subset.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 760" role="img" aria-labelledby="title desc" font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', sans-serif">
+  <title id="title">Two complementary sources of evidence for variant effects</title>
+  <desc id="desc">Side-by-side comparison of the Mendelian disease and saturation genome editing benchmarks. The diagram preserves their evidence sources, label construction, matching and calibration protocols, consequence-subset counts, totals, links, chromosome split, and relevant training-region legend.</desc>
+
   <defs>
     <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#8a7d68"/>
     </marker>
   </defs>
 
-  <rect x="1" y="1" width="1118" height="648" rx="14" fill="#f6f0e4" stroke="#ddd3bf"/>
-  <text x="26" y="36" font-size="18" font-weight="700" fill="#1f1e1b">Two views of variant effect — clinical evidence and experimental function</text>
-  <text x="26" y="56" font-size="11.5" fill="#7a6f5f">GRCh38 SNVs  ·  HIGH-impact consequences excluded  ·  counts include train + test  ·  odd chromosomes + X → train/val; even + Y → test</text>
+  <rect x="1" y="1" width="958" height="758" rx="16" fill="#f6f0e4" stroke="#ddd3bf"/>
+  <text x="28" y="36" font-size="21" font-weight="750" fill="#1f1e1b">Two complementary sources of evidence for variant effects</text>
 
-  <!-- Mendelian panel -->
-  <rect x="22" y="76" width="528" height="515" rx="12" fill="#fffaf0" stroke="#d9cbb1"/>
-  <rect x="22" y="76" width="528" height="44" rx="12" fill="#eadcc2"/>
-  <rect x="22" y="108" width="528" height="12" fill="#eadcc2"/>
-  <text x="42" y="101" font-size="16" font-weight="700" fill="#1f1e1b">Mendelian disease</text>
-  <text x="530" y="101" font-size="11" fill="#7a6f5f" text-anchor="end">TraitGym-inspired</text>
+  <!-- Shared benchmark metadata -->
+  <g font-size="10.5" font-weight="650" text-anchor="middle" fill="#5f574b">
+    <rect x="20" y="53" width="110" height="28" rx="14" fill="#ebe4d7" stroke="#ddd3bf"/>
+    <text x="75" y="72">GRCh38 SNVs</text>
 
-  <text x="42" y="143" font-size="11" font-weight="700" letter-spacing="0.8" fill="#8a7d68">DEFINE THE CLASSES</text>
-  <rect x="42" y="154" width="488" height="76" rx="8" fill="#f6f0e4" stroke="#e6dcc6"/>
-  <circle cx="59" cy="176" r="5" fill="#9c4f2f"/>
-  <text x="72" y="180" font-size="11.5" font-weight="700" fill="#1f1e1b">Pathogenic</text>
-  <text x="151" y="180" font-size="10.5" fill="#5f574b">OMIM + Smedley et al. 2016 + HGMD · AF &lt; 0.1%</text>
-  <circle cx="59" cy="205" r="5" fill="#9c4f2f" fill-opacity="0.22" stroke="#9c4f2f"/>
-  <text x="72" y="209" font-size="11.5" font-weight="700" fill="#1f1e1b">Control</text>
-  <text x="128" y="209" font-size="10.5" fill="#5f574b">gnomAD common SNVs · AF &gt; 0.1%</text>
+    <rect x="138" y="53" width="220" height="28" rx="14" fill="#ebe4d7" stroke="#ddd3bf"/>
+    <text x="248" y="72">HIGH-impact consequences excluded</text>
 
-  <line x1="286" y1="234" x2="286" y2="248" stroke="#8a7d68" stroke-width="1.4" marker-end="url(#arrow)"/>
-  <rect x="42" y="251" width="488" height="62" rx="8" fill="#f1eadb" stroke="#d9cbb1"/>
-  <text x="58" y="274" font-size="11.5" font-weight="700" fill="#1f1e1b">1 pathogenic + 9 controls</text>
-  <text x="58" y="294" font-size="10.5" fill="#5f574b">Matched on chromosome · consequence · TSS distance · exon distance</text>
+    <rect x="366" y="53" width="280" height="28" rx="14" fill="#ebe4d7" stroke="#ddd3bf"/>
+    <text x="506" y="72">odd chromosomes + X → train/val</text>
 
-  <text x="42" y="340" font-size="11" font-weight="700" letter-spacing="0.8" fill="#8a7d68">SUBSET COUNTS</text>
-  <text x="514" y="340" font-size="9.5" fill="#8a7d68" text-anchor="end">dark = pathogenic · tint = matched controls</text>
-
-  <!-- Every bar uses the same scale (120 px = 10,000 variants). -->
-  <g font-size="10.5" fill="#1f1e1b">
-    <text x="42" y="365">missense</text>
-    <rect x="173" y="353" width="12" height="14" rx="2" fill="#9c4f2f"/><rect x="185" y="353" width="108" height="14" rx="2" fill="#9c4f2f" fill-opacity="0.22"/><text x="301" y="365">10,000</text>
-    <text x="42" y="387">splicing</text>
-    <rect x="173" y="375" width="7" height="14" rx="2" fill="#9c4f2f"/><rect x="180" y="375" width="59" height="14" rx="2" fill="#9c4f2f" fill-opacity="0.22"/><text x="247" y="387">5,500</text>
-    <text x="42" y="409">5′ UTR</text>
-    <rect x="173" y="397" width="4" height="14" rx="2" fill="#2f6f63"/><rect x="177" y="397" width="33" height="14" rx="2" fill="#2f6f63" fill-opacity="0.22"/><text x="218" y="409">3,050</text>
-    <text x="42" y="431">TSS proximal</text>
-    <rect x="173" y="419" width="3" height="14" rx="2" fill="#2f6f63"/><rect x="176" y="419" width="29" height="14" rx="2" fill="#2f6f63" fill-opacity="0.22"/><text x="213" y="431">2,700</text>
-    <text x="42" y="453">ncRNA</text>
-    <rect x="173" y="441" width="2" height="14" rx="2" fill="#465c6e"/><rect x="175" y="441" width="17" height="14" rx="2" fill="#465c6e" fill-opacity="0.22"/><text x="200" y="453">1,590</text>
-    <text x="42" y="475">3′ UTR</text>
-    <rect x="173" y="463" width="2" height="14" rx="2" fill="#c0883a"/><rect x="175" y="463" width="11" height="14" rx="2" fill="#c0883a" fill-opacity="0.22"/><text x="194" y="475">1,100</text>
-    <text x="42" y="497">distal</text>
-    <rect x="173" y="485" width="2" height="14" rx="2" fill="#6f7d3f"/><rect x="175" y="485" width="10" height="14" rx="2" fill="#6f7d3f" fill-opacity="0.22"/><text x="193" y="497">990</text>
-    <text x="42" y="519">synonymous</text>
-    <rect x="173" y="507" width="2" height="14" rx="2" fill="#9c4f2f"/><rect x="175" y="507" width="6" height="14" rx="2" fill="#9c4f2f" fill-opacity="0.22"/><text x="189" y="519">650</text>
-    <text x="42" y="541">mature miRNA</text>
-    <rect x="173" y="529" width="2" height="14" rx="2" fill="#465c6e"/><text x="183" y="541">50</text>
+    <rect x="654" y="53" width="286" height="28" rx="14" fill="#ebe4d7" stroke="#ddd3bf"/>
+    <text x="797" y="72">even chromosomes + Y → test</text>
   </g>
 
-  <line x1="42" y1="555" x2="530" y2="555" stroke="#e6dcc6"/>
-  <text x="42" y="578" font-size="12" font-weight="700" fill="#1f1e1b">25,630 variants</text>
-  <text x="178" y="578" font-size="10.5" fill="#7a6f5f">2,563 pathogenic · 23,067 controls</text>
-  <a href="https://huggingface.co/datasets/bolinas-dna/evals_mendelian_traits" target="_blank"><text x="385" y="578" font-size="10.5" font-weight="700" fill="#2f6f63">HF</text><text x="404" y="578" font-size="10.5">🤗</text></a>
-  <a href="https://openathena.ai/marin-dna/leaderboards/mendelian" target="_blank"><text x="438" y="578" font-size="10.5" font-weight="700" fill="#2f6f63">Leaderboard</text><text x="508" y="578" font-size="10.5">🏆</text></a>
+  <!-- Mendelian panel -->
+  <rect x="20" y="99" width="450" height="594" rx="14" fill="#fffaf0" stroke="#d9cbb1"/>
+  <path d="M 20 113 Q 20 99 34 99 H 456 Q 470 99 470 113 V 160 H 20 Z" fill="#eadcc2"/>
+  <text x="40" y="135" font-size="16" font-weight="750" fill="#1f1e1b">Mendelian disease</text>
+  <a href="https://huggingface.co/datasets/bolinas-dna/evals_mendelian_traits" target="_blank">
+    <rect x="292" y="115" width="60" height="29" rx="14.5" fill="#fcfaf5" stroke="#d0c3aa"/>
+    <text x="322" y="134" font-size="10" font-weight="750" text-anchor="middle" fill="#2f6f63">HF 🤗</text>
+  </a>
+  <a href="https://openathena.ai/marin-dna/leaderboards/mendelian" target="_blank">
+    <rect x="358" y="115" width="92" height="29" rx="14.5" fill="#fcfaf5" stroke="#d0c3aa"/>
+    <text x="404" y="134" font-size="9.5" font-weight="750" text-anchor="middle" fill="#2f6f63">Leaderboard 🏆</text>
+  </a>
+
+  <text x="40" y="174" font-size="11" font-weight="750" letter-spacing="0.8" fill="#8a7d68">CLINICAL EVIDENCE</text>
+  <text x="450" y="174" font-size="10" font-weight="650" text-anchor="end" fill="#8a7d68">TraitGym-inspired</text>
+  <rect x="40" y="186" width="410" height="86" rx="10" fill="#fcfaf5" stroke="#e2d7c2"/>
+  <circle cx="60" cy="212" r="5" fill="#9c4f2f"/>
+  <text x="74" y="216" font-size="12" font-weight="750" fill="#1f1e1b">Pathogenic</text>
+  <text x="160" y="216" font-size="10.5" fill="#5f574b">OMIM + Smedley et al. 2016 + HGMD · AF &lt; 0.1%</text>
+  <circle cx="60" cy="244" r="5" fill="#f4e9e1" stroke="#9c4f2f"/>
+  <text x="74" y="248" font-size="12" font-weight="750" fill="#1f1e1b">Control</text>
+  <text x="160" y="248" font-size="10.5" fill="#5f574b">gnomAD common SNVs · AF &gt; 0.1%</text>
+
+  <line x1="245" y1="274" x2="245" y2="287" stroke="#8a7d68" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <rect x="40" y="292" width="410" height="68" rx="10" fill="#f3ead8" stroke="#d9cbb1"/>
+  <text x="56" y="317" font-size="12.5" font-weight="750" fill="#1f1e1b">1 pathogenic + 9 controls</text>
+  <text x="56" y="340" font-size="10.5" fill="#5f574b">Matched on chromosome · consequence · TSS distance · exon distance</text>
+
+  <text x="40" y="382" font-size="11" font-weight="750" letter-spacing="0.8" fill="#8a7d68">SUBSET COUNTS</text>
+  <text x="390" y="382" font-size="9.5" text-anchor="end" fill="#8a7d68">dark = pathogenic · tint = matched controls</text>
+  <text x="436" y="382" font-size="9.5" text-anchor="end" fill="#8a7d68">total</text>
+
+  <!-- Mendelian bars: one shared total-count scale; dark:tint = 1:9 matching. -->
+  <g font-size="10.5" fill="#1f1e1b">
+    <text x="42" y="408">missense</text>
+    <rect x="162" y="396" width="22" height="14" rx="2" fill="#9c4f2f"/>
+    <rect x="184" y="396" width="198" height="14" rx="2" fill="#9c4f2f" fill-opacity="0.22"/>
+    <text x="436" y="408" text-anchor="end">10,000</text>
+
+    <text x="42" y="430">splicing</text>
+    <rect x="162" y="418" width="12" height="14" rx="2" fill="#9c4f2f"/>
+    <rect x="174" y="418" width="109" height="14" rx="2" fill="#9c4f2f" fill-opacity="0.22"/>
+    <text x="436" y="430" text-anchor="end">5,500</text>
+
+    <text x="42" y="452">5′ UTR</text>
+    <rect x="162" y="440" width="6" height="14" rx="2" fill="#2f6f63"/>
+    <rect x="168" y="440" width="61" height="14" rx="2" fill="#2f6f63" fill-opacity="0.22"/>
+    <text x="436" y="452" text-anchor="end">3,050</text>
+
+    <text x="42" y="474">TSS proximal</text>
+    <rect x="162" y="462" width="6" height="14" rx="2" fill="#2f6f63"/>
+    <rect x="168" y="462" width="54" height="14" rx="2" fill="#2f6f63" fill-opacity="0.22"/>
+    <text x="436" y="474" text-anchor="end">2,700</text>
+
+    <text x="42" y="496">ncRNA</text>
+    <rect x="162" y="484" width="4" height="14" rx="2" fill="#465c6e"/>
+    <rect x="166" y="484" width="31" height="14" rx="2" fill="#465c6e" fill-opacity="0.22"/>
+    <text x="436" y="496" text-anchor="end">1,590</text>
+
+    <text x="42" y="518">3′ UTR</text>
+    <rect x="162" y="506" width="3" height="14" rx="2" fill="#c0883a"/>
+    <rect x="165" y="506" width="21" height="14" rx="2" fill="#c0883a" fill-opacity="0.22"/>
+    <text x="436" y="518" text-anchor="end">1,100</text>
+
+    <text x="42" y="540">distal</text>
+    <rect x="162" y="528" width="3" height="14" rx="2" fill="#6f7d3f"/>
+    <rect x="165" y="528" width="19" height="14" rx="2" fill="#6f7d3f" fill-opacity="0.22"/>
+    <text x="436" y="540" text-anchor="end">990</text>
+
+    <text x="42" y="562">synonymous</text>
+    <rect x="162" y="550" width="2" height="14" rx="2" fill="#9c4f2f"/>
+    <rect x="164" y="550" width="13" height="14" rx="2" fill="#9c4f2f" fill-opacity="0.22"/>
+    <text x="436" y="562" text-anchor="end">650</text>
+
+    <text x="42" y="584">mature miRNA</text>
+    <rect x="162" y="572" width="2" height="14" rx="2" fill="#465c6e"/>
+    <text x="436" y="584" text-anchor="end">50</text>
+  </g>
+
+  <line x1="40" y1="608" x2="450" y2="608" stroke="#e6dcc6"/>
+  <text x="40" y="634" font-size="12.5" font-weight="750" fill="#1f1e1b">25,630 variants</text>
+  <text x="40" y="657" font-size="10.5" fill="#7a6f5f">2,563 pathogenic · 23,067 controls</text>
 
   <!-- SGE panel -->
-  <rect x="570" y="76" width="528" height="515" rx="12" fill="#fffaf0" stroke="#d9cbb1"/>
-  <rect x="570" y="76" width="528" height="44" rx="12" fill="#dce6df"/>
-  <rect x="570" y="108" width="528" height="12" fill="#dce6df"/>
-  <text x="590" y="101" font-size="16" font-weight="700" fill="#1f1e1b">Saturation genome editing</text>
-  <text x="1078" y="101" font-size="11" fill="#5d7167" text-anchor="end">MaveDB · 11 studies</text>
+  <rect x="490" y="99" width="450" height="594" rx="14" fill="#fffaf0" stroke="#d9cbb1"/>
+  <path d="M 490 113 Q 490 99 504 99 H 926 Q 940 99 940 113 V 160 H 490 Z" fill="#dce6df"/>
+  <text x="510" y="135" font-size="16" font-weight="750" fill="#1f1e1b">Saturation genome editing</text>
+  <a href="https://huggingface.co/datasets/bolinas-dna/evals_sge" target="_blank">
+    <rect x="762" y="115" width="60" height="29" rx="14.5" fill="#fcfaf5" stroke="#b9d2ca"/>
+    <text x="792" y="134" font-size="10" font-weight="750" text-anchor="middle" fill="#2f6f63">HF 🤗</text>
+  </a>
+  <a href="https://openathena.ai/marin-dna/leaderboards/sge" target="_blank">
+    <rect x="828" y="115" width="92" height="29" rx="14.5" fill="#fcfaf5" stroke="#b9d2ca"/>
+    <text x="874" y="134" font-size="9.5" font-weight="750" text-anchor="middle" fill="#2f6f63">Leaderboard 🏆</text>
+  </a>
 
-  <text x="590" y="143" font-size="11" font-weight="700" letter-spacing="0.8" fill="#8a7d68">MEASURE FUNCTION AT THE ENDOGENOUS LOCUS</text>
-  <rect x="590" y="154" width="488" height="76" rx="8" fill="#f6f0e4" stroke="#e6dcc6"/>
-  <text x="606" y="178" font-size="11.5" font-weight="700" fill="#1f1e1b">CRISPR-HDR variant library</text>
-  <text x="606" y="198" font-size="10.5" fill="#5f574b">cell fitness / proliferation → continuous function score</text>
-  <text x="606" y="216" font-size="10" fill="#8a7d68">Only missense + near-exon splicing retained</text>
+  <text x="510" y="174" font-size="11" font-weight="750" letter-spacing="0.8" fill="#8a7d68">EXPERIMENTAL EVIDENCE</text>
+  <text x="920" y="174" font-size="10" font-weight="650" text-anchor="end" fill="#8a7d68">MaveDB · 11 studies</text>
+  <rect x="510" y="186" width="410" height="86" rx="10" fill="#fcfaf5" stroke="#d4e0db"/>
+  <text x="526" y="211" font-size="12.5" font-weight="750" fill="#1f1e1b">CRISPR-HDR variant library</text>
+  <text x="526" y="234" font-size="10.5" fill="#5f574b">cell fitness / proliferation → continuous function score</text>
+  <text x="526" y="255" font-size="10" fill="#8a7d68">Only missense + near-exon splicing retained</text>
 
-  <line x1="834" y1="234" x2="834" y2="248" stroke="#8a7d68" stroke-width="1.4" marker-end="url(#arrow)"/>
-  <rect x="590" y="251" width="488" height="62" rx="8" fill="#f1eadb" stroke="#d9cbb1"/>
-  <text x="606" y="274" font-size="11.5" font-weight="700" fill="#1f1e1b">Calibrated class → abnormal vs normal</text>
-  <text x="606" y="294" font-size="10.5" fill="#5f574b">ClinGen / ExCALIBR or author thresholds  ·  intermediate + uncalibrated rows dropped</text>
+  <line x1="715" y1="274" x2="715" y2="287" stroke="#8a7d68" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <rect x="510" y="292" width="410" height="68" rx="10" fill="#eaf1ed" stroke="#c8dbd4"/>
+  <text x="526" y="317" font-size="12.5" font-weight="750" fill="#1f1e1b">Calibrated class → abnormal vs normal</text>
+  <text x="526" y="340" font-size="10.5" fill="#5f574b">ClinGen / ExCALIBR or author thresholds</text>
 
-  <text x="590" y="340" font-size="11" font-weight="700" letter-spacing="0.8" fill="#8a7d68">SUBSET COUNTS</text>
-  <text x="1062" y="340" font-size="9.5" fill="#8a7d68" text-anchor="end">dark = abnormal · tint = normal</text>
+  <text x="510" y="382" font-size="11" font-weight="750" letter-spacing="0.8" fill="#8a7d68">SUBSET COUNTS</text>
+  <text x="920" y="382" font-size="9.5" text-anchor="end" fill="#8a7d68">dark = abnormal · tint = normal</text>
 
-  <text x="590" y="373" font-size="11.5" font-weight="700" fill="#1f1e1b">missense</text>
-  <rect x="672" y="357" width="51" height="18" rx="3" fill="#9c4f2f"/>
-  <rect x="723" y="357" width="325" height="18" rx="3" fill="#9c4f2f" fill-opacity="0.22"/>
-  <text x="672" y="397" font-size="10.5" fill="#5f574b">31,316 total</text>
-  <text x="800" y="397" font-size="10.5" fill="#9c4f2f">4,250 abnormal</text>
-  <text x="915" y="397" font-size="10.5" fill="#7a6f5f">27,066 normal</text>
+  <!-- SGE bars use one shared total-count scale. -->
+  <text x="510" y="412" font-size="11.5" font-weight="750" fill="#1f1e1b">missense</text>
+  <text x="920" y="412" font-size="10.5" text-anchor="end" fill="#1f1e1b">31,316 total</text>
+  <rect x="615" y="398" width="31" height="18" rx="3" fill="#9c4f2f"/>
+  <rect x="646" y="398" width="199" height="18" rx="3" fill="#9c4f2f" fill-opacity="0.22"/>
+  <text x="615" y="439" font-size="10.5" fill="#9c4f2f">4,250 abnormal</text>
+  <text x="740" y="439" font-size="10.5" fill="#7a6f5f">27,066 normal</text>
 
-  <text x="590" y="445" font-size="11.5" font-weight="700" fill="#1f1e1b">splicing</text>
-  <rect x="672" y="429" width="9" height="18" rx="3" fill="#9c4f2f"/>
-  <rect x="681" y="429" width="80" height="18" rx="3" fill="#9c4f2f" fill-opacity="0.22"/>
-  <text x="672" y="469" font-size="10.5" fill="#5f574b">7,425 total</text>
-  <text x="800" y="469" font-size="10.5" fill="#9c4f2f">735 abnormal</text>
-  <text x="915" y="469" font-size="10.5" fill="#7a6f5f">6,690 normal</text>
+  <text x="510" y="482" font-size="11.5" font-weight="750" fill="#1f1e1b">splicing</text>
+  <text x="920" y="482" font-size="10.5" text-anchor="end" fill="#1f1e1b">7,425 total</text>
+  <rect x="615" y="468" width="6" height="18" rx="3" fill="#9c4f2f"/>
+  <rect x="621" y="468" width="51" height="18" rx="3" fill="#9c4f2f" fill-opacity="0.22"/>
+  <text x="615" y="509" font-size="10.5" fill="#9c4f2f">735 abnormal</text>
+  <text x="740" y="509" font-size="10.5" fill="#7a6f5f">6,690 normal</text>
 
-  <rect x="590" y="493" width="488" height="49" rx="8" fill="#edf2ee" stroke="#dce6df"/>
-  <text x="606" y="514" font-size="11.5" font-weight="700" fill="#1f1e1b">No matching · no subsampling</text>
-  <text x="606" y="532" font-size="10.5" fill="#5f574b">AUPRC within each MaveDB study, then macro-average across studies</text>
+  <rect x="510" y="538" width="410" height="65" rx="10" fill="#eaf1ed" stroke="#c8dbd4"/>
+  <text x="526" y="563" font-size="12" font-weight="750" fill="#1f1e1b">No matching · no subsampling</text>
+  <text x="526" y="585" font-size="10.5" fill="#5f574b">AUPRC within each MaveDB study, then macro-average across studies</text>
 
-  <line x1="590" y1="555" x2="1078" y2="555" stroke="#e6dcc6"/>
-  <text x="590" y="578" font-size="12" font-weight="700" fill="#1f1e1b">38,741 variants</text>
-  <text x="732" y="578" font-size="10.5" fill="#7a6f5f">4,985 abnormal · 33,756 normal</text>
-  <a href="https://huggingface.co/datasets/bolinas-dna/evals_sge" target="_blank"><text x="925" y="578" font-size="10.5" font-weight="700" fill="#2f6f63">HF</text><text x="944" y="578" font-size="10.5">🤗</text></a>
-  <a href="https://openathena.ai/marin-dna/leaderboards/sge" target="_blank"><text x="970" y="578" font-size="10.5" font-weight="700" fill="#2f6f63">Leaderboard</text><text x="1050" y="578" font-size="10.5">🏆</text></a>
+  <line x1="510" y1="614" x2="920" y2="614" stroke="#e6dcc6"/>
+  <text x="510" y="640" font-size="12.5" font-weight="750" fill="#1f1e1b">38,741 variants</text>
+  <text x="510" y="663" font-size="10.5" fill="#7a6f5f">4,985 abnormal · 33,756 normal</text>
 
-  <!-- Training-region color key carried over from the provenance/scaling diagrams. -->
-  <text x="26" y="620" font-size="10" font-weight="700" fill="#7a6f5f">relevant training region</text>
-  <rect x="164" y="610" width="11" height="11" rx="2" fill="#9c4f2f"/><text x="181" y="620" font-size="10" fill="#5f574b">CDS</text>
-  <rect x="228" y="610" width="11" height="11" rx="2" fill="#2f6f63"/><text x="245" y="620" font-size="10" fill="#5f574b">Upstream</text>
-  <rect x="316" y="610" width="11" height="11" rx="2" fill="#c0883a"/><text x="333" y="620" font-size="10" fill="#5f574b">Downstream</text>
-  <rect x="420" y="610" width="11" height="11" rx="2" fill="#465c6e"/><text x="437" y="620" font-size="10" fill="#5f574b">ncRNA</text>
-  <rect x="491" y="610" width="11" height="11" rx="2" fill="#6f7d3f"/><text x="508" y="620" font-size="10" fill="#5f574b">Enhancer</text>
+  <!-- Region-color legend -->
+  <line x1="28" y1="708" x2="932" y2="708" stroke="#ddd3bf"/>
+  <text x="28" y="736" font-size="10.5" font-weight="750" fill="#7a6f5f">relevant training region</text>
+  <g font-size="10.5" fill="#5f574b">
+    <rect x="190" y="725" width="11" height="11" rx="2" fill="#9c4f2f"/>
+    <text x="208" y="735">CDS</text>
+    <rect x="256" y="725" width="11" height="11" rx="2" fill="#2f6f63"/>
+    <text x="274" y="735">Upstream</text>
+    <rect x="350" y="725" width="11" height="11" rx="2" fill="#c0883a"/>
+    <text x="368" y="735">Downstream</text>
+    <rect x="462" y="725" width="11" height="11" rx="2" fill="#465c6e"/>
+    <text x="480" y="735">ncRNA</text>
+    <rect x="540" y="725" width="11" height="11" rx="2" fill="#6f7d3f"/>
+    <text x="558" y="735">Enhancer</text>
+  </g>
 </svg>


### PR DESCRIPTION
## Summary

- simplify the VEP evaluation-apparatus and benchmark-dataset diagrams
- add concise captions and accessible descriptions for both figures
- clarify why deleteriousness and functional constraint are the VEP targets used here
- describe the TraitGym-inspired Mendelian benchmark, SGE evidence, and zero-shot versus linear-probe protocols

Part of #361.

## Why

This revision makes the “Why VEP evaluation?” subsection more focused and makes its two figures easier to interpret without adding unrelated evaluation concepts.

## Validation

- `uv run --no-project python src/marin_dna/blog_workspace.py validate`
- `uv run --no-project python src/marin_dna/blog_workspace.py build`
- rendered the local preview and verified that the multi-line TraitGym comparison remains inside its footnote
