### PR TITLE
Add upstream and CDS specialist blog figure

### DIFF
--- a/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
+++ b/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
@@ -112,7 +112,7 @@ Because comparable annotations were not directly available across the target spe
 
 By GPT-style, we mean the dumb approach of training a stock causal, autoregressive, decoder-only language-model architecture on DNA that we pretend is text. In these experiments, that architecture is literally Qwen3 rather than a genomics-specific design. This approach is not new; a substantial line of prior gLM work has used causal language modeling with GPT- or Llama-like architectures.[^causal-glm-precedent] What is new here is the quality target. Even recent models in this family, such as Carbon, generally aim for non-inferiority to smaller Evo 2 checkpoints and still underperform Evo 2 40B on the broad zero-shot VEP setting we care about.[^carbon-eval] If the quality gap can be closed, GPT-style models have obvious advantages for deployment. They run through familiar training and inference stacks, move cleanly across hardware, and avoid model-specific kernels or bespoke architecture code, which matters a lot for cost, flexibility, and usability. E.g., the inference cost associated with the evaluations below is roughly $10 / billion tokens for our 1B model, compared with roughly $100 / billion tokens for Evo 2 40B (TODO: get real numbers).[^throughput-comparison]
 
-MarinDNA's first experiment compared masked language modeling, causal language modeling, and masked diffusion on promoter sequence ([issue #3](https://github.com/Open-Athena/marin-dna/issues/3)).
+MarinDNA's first experiment compared masked language modeling, causal language modeling, and masked diffusion on promoter sequence ([experiment #3](https://github.com/Open-Athena/marin-dna/issues/3)).
 Causal language modeling looked most promising in the initial training steps.
 This was not a definitive matched-compute comparison of objectives, but it provided enough direction-setting evidence to pursue a simple causal architecture.
 That choice also need not permanently constrain the model to left-to-right representations: decoder-only language models can be adapted into bidirectional encoders with further training.[^clm-bidirectional-adaptation]
@@ -192,23 +192,15 @@ Evo 2 40B (published ~Feb. 2025) is still the most formidable relevant baseline 
 
 ## Results
 
-### Promoter and CDS specialists
+### Upstream and CDS specialists
 
-- Promoter YOLO trained a modest causal Qwen3 specialist on an earlier animal-promoter dataset, using reasonable defaults rather than the systematic hyperparameter-transfer recipe developed later.[^promoter-yolo]
-- On promoter-relevant Mendelian variants, it exceeded Evo 2 40B's point estimates for both 5′ UTR and TSS-proximal variants.
-- CDS YOLO repeated the same specialist strategy on an earlier animal coding-sequence dataset.[^cds-yolo]
-- At the point-estimate level, CDS YOLO exceeded Evo 2 40B on missense variants, was nearly identical on splicing variants, and trailed it on synonymous variants.
-- GPN-Star remained stronger on TSS-proximal, missense, and synonymous variants, while the specialist point estimates were close to GPN-Star on 5′ UTR and splicing variants.
+We first trained a 1.7B upstream-region specialist, trying to replicate the success of GPN-Promoter ([experiment #21](https://github.com/Open-Athena/marin-dna/issues/21)). Although we used reasonable defaults rather than the systematic hyperparameter-transfer recipe developed later, performance was broadly comparable to Evo 2 40B. We saw a similar pattern when training a CDS specialist ([experiment #27](https://github.com/Open-Athena/marin-dna/issues/27)). Overall, however, GPN-Star remained stronger.
 
 ![Five independently scaled panels comparing upstream and CDS specialists with Evo 2 40B and GPN-Star on region-matched Mendelian variant classes](/assets/images/blog/genomic-lm-optimization/promoter_cds_specialists.svg)
 
 *Region-matched Mendelian VEP AUPRC under each model family's canonical zero-shot protocol (MarinDNA and Evo 2 LLR; GPN-Star cLLR).*
 *Promoter denotes the TSS-proximal subset; each panel has an independent y-axis beginning at the 10% prevalence baseline, so compare models only within a panel.*
 *Error bars are capless ±1 chromosome-cluster bootstrap SE.*
-
-[^promoter-yolo]: See [Open-Athena/marin-dna issue #21](https://github.com/Open-Athena/marin-dna/issues/21).
-
-[^cds-yolo]: See [Open-Athena/marin-dna issue #27](https://github.com/Open-Athena/marin-dna/issues/27).
 
 ### Balancing promoter and CDS data
 

--- a/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
+++ b/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
@@ -197,9 +197,14 @@ Evo 2 40B (published ~Feb. 2025) is still the most formidable relevant baseline 
 - Promoter YOLO trained a modest causal Qwen3 specialist on an earlier animal-promoter dataset, using reasonable defaults rather than the systematic hyperparameter-transfer recipe developed later.[^promoter-yolo]
 - On promoter-relevant Mendelian variants, it exceeded Evo 2 40B's point estimates for both 5′ UTR and TSS-proximal variants.
 - CDS YOLO repeated the same specialist strategy on an earlier animal coding-sequence dataset.[^cds-yolo]
-- On missense VEP, CDS YOLO matched Evo 2 40B.
-- Neither specialist beat GPN-Star, providing an early indication of the limitations of the alignment-free specialist approach.
-- **Image to add:** Create a paired Promoter YOLO/CDS YOLO figure in the blog palette, with region-matched AUPRC results and Evo 2 40B and GPN-Star references.
+- At the point-estimate level, CDS YOLO exceeded Evo 2 40B on missense variants, was nearly identical on splicing variants, and trailed it on synonymous variants.
+- GPN-Star remained stronger on TSS-proximal, missense, and synonymous variants, while the specialist point estimates were close to GPN-Star on 5′ UTR and splicing variants.
+
+![Five independently scaled panels comparing upstream and CDS specialists with Evo 2 40B and GPN-Star on region-matched Mendelian variant classes](/assets/images/blog/genomic-lm-optimization/promoter_cds_specialists.svg)
+
+*Region-matched Mendelian VEP AUPRC under each model family's canonical zero-shot protocol (MarinDNA and Evo 2 LLR; GPN-Star cLLR).*
+*Promoter denotes the TSS-proximal subset; each panel has an independent y-axis beginning at the 10% prevalence baseline, so compare models only within a panel.*
+*Error bars are capless ±1 chromosome-cluster bootstrap SE.*
 
 [^promoter-yolo]: See [Open-Athena/marin-dna issue #21](https://github.com/Open-Athena/marin-dna/issues/21).
 

--- a/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/promoter_cds_specialists.svg
+++ b/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/promoter_cds_specialists.svg
@@ -1,0 +1,762 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="365.98pt" height="227.494594pt" viewBox="0 0 365.98 227.494594" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-07-22T14:55:01.420542</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.0rc1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 227.494594
+L 365.98 227.494594
+L 365.98 0
+L 0 0
+L 0 227.494594
+z
+" style="fill: none"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 38.38 105.218346
+L 129.922857 105.218346
+L 129.922857 21.797656
+L 38.38 21.797656
+L 38.38 105.218346
+z
+" style="fill: none"/>
+   </g>
+   <g id="matplotlib.axis_1"/>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m22e3066cbb" d="M 0 0
+L -3.5 0
+" style="stroke: #1f1e1b; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m22e3066cbb" x="38.38" y="105.218346" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="31.38" y="108.257408" transform="rotate(-0 31.38 108.257408)">10</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="38.38" y="86.951831" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="31.38" y="89.990894" transform="rotate(-0 31.38 89.990894)">20</text>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="38.38" y="68.685317" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="31.38" y="71.72438" transform="rotate(-0 31.38 71.72438)">30</text>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="38.38" y="50.418803" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="31.38" y="53.457865" transform="rotate(-0 31.38 53.457865)">40</text>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="38.38" y="32.152288" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="31.38" y="35.191351" transform="rotate(-0 31.38 35.191351)">50</text>
+     </g>
+    </g>
+    <g id="text_6">
+     <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="14.797656" y="63.508001" transform="rotate(-90 14.797656 63.508001)">AUPRC (%)</text>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 42.541039 123.48486
+L 66.318404 123.48486
+L 66.318404 48.968917
+L 42.541039 48.968917
+z
+" clip-path="url(#p4040f5f663)" style="fill: #326c61; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 72.262746 123.48486
+L 96.040111 123.48486
+L 96.040111 59.732532
+L 72.262746 59.732532
+z
+" clip-path="url(#p4040f5f663)" style="fill: #999999; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 101.984453 123.48486
+L 125.761818 123.48486
+L 125.761818 32.94577
+L 101.984453 32.94577
+z
+" clip-path="url(#p4040f5f663)" style="fill: #555555; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 38.38 105.218346
+L 38.38 21.797656
+" style="fill: none; stroke: #1f1e1b; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 38.38 105.218346
+L 129.922857 105.218346
+" style="fill: none; stroke: #1f1e1b; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_7">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="54.429722" y="38.796391" transform="rotate(-0 54.429722 38.796391)">40.8</text>
+   </g>
+   <g id="text_8">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="84.151429" y="50.315386" transform="rotate(-0 84.151429 50.315386)">34.9</text>
+   </g>
+   <g id="text_9">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="113.873135" y="23.689223" transform="rotate(-0 113.873135 23.689223)">49.6</text>
+   </g>
+   <g id="text_10">
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #2f6f63" x="84.151429" y="14.797656" transform="rotate(-0 84.151429 14.797656)">Promoter</text>
+   </g>
+   <g id="LineCollection_1">
+    <path d="M 54.429722 55.575582
+L 54.429722 42.362252
+" clip-path="url(#p4040f5f663)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+   </g>
+   <g id="LineCollection_2">
+    <path d="M 84.151429 65.583816
+L 84.151429 53.881247
+" clip-path="url(#p4040f5f663)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+   </g>
+   <g id="LineCollection_3">
+    <path d="M 113.873135 38.636456
+L 113.873135 27.255085
+" clip-path="url(#p4040f5f663)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+   </g>
+   <g id="line2d_6">
+    <path d="M 54.429722 48.968917
+" clip-path="url(#p4040f5f663)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_7">
+    <path d="M 84.151429 59.732532
+" clip-path="url(#p4040f5f663)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_8">
+    <path d="M 113.873135 32.94577
+" clip-path="url(#p4040f5f663)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_8">
+    <path d="M 152.808571 105.218346
+L 244.351429 105.218346
+L 244.351429 21.797656
+L 152.808571 21.797656
+L 152.808571 105.218346
+z
+" style="fill: none"/>
+   </g>
+   <g id="matplotlib.axis_3"/>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_6">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="152.808571" y="105.218346" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="145.808571" y="108.257408" transform="rotate(-0 145.808571 108.257408)">10</text>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="152.808571" y="85.216158" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="145.808571" y="88.255221" transform="rotate(-0 145.808571 88.255221)">20</text>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="152.808571" y="65.21397" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="145.808571" y="68.253033" transform="rotate(-0 145.808571 68.253033)">30</text>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="152.808571" y="45.211783" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="145.808571" y="48.250845" transform="rotate(-0 145.808571 48.250845)">40</text>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="152.808571" y="25.209595" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="145.808571" y="28.248658" transform="rotate(-0 145.808571 28.248658)">50</text>
+     </g>
+    </g>
+   </g>
+   <g id="patch_9">
+    <path d="M 156.96961 125.220534
+L 180.746976 125.220534
+L 180.746976 34.111815
+L 156.96961 34.111815
+z
+" clip-path="url(#pb6cef3cb8f)" style="fill: #326c61; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 186.691317 125.220534
+L 210.468683 125.220534
+L 210.468683 49.512125
+L 186.691317 49.512125
+z
+" clip-path="url(#pb6cef3cb8f)" style="fill: #999999; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 216.413024 125.220534
+L 240.19039 125.220534
+L 240.19039 37.932736
+L 216.413024 37.932736
+z
+" clip-path="url(#pb6cef3cb8f)" style="fill: #555555; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 152.808571 105.218346
+L 152.808571 21.797656
+" style="fill: none; stroke: #1f1e1b; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 152.808571 105.218346
+L 244.351429 105.218346
+" style="fill: none; stroke: #1f1e1b; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_16">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="168.858293" y="23.533013" transform="rotate(-0 168.858293 23.533013)">45.5</text>
+   </g>
+   <g id="text_17">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="198.58" y="38.954968" transform="rotate(-0 198.58 38.954968)">37.9</text>
+   </g>
+   <g id="text_18">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="228.301707" y="27.38678" transform="rotate(-0 228.301707 27.38678)">43.6</text>
+   </g>
+   <g id="text_19">
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #2f6f63" x="198.58" y="14.797656" transform="rotate(-0 198.58 14.797656)">5′ UTR</text>
+   </g>
+   <g id="LineCollection_4">
+    <path d="M 168.858293 40.968545
+L 168.858293 27.255085
+" clip-path="url(#pb6cef3cb8f)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+   </g>
+   <g id="LineCollection_5">
+    <path d="M 198.58 56.34721
+L 198.58 42.67704
+" clip-path="url(#pb6cef3cb8f)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+   </g>
+   <g id="LineCollection_6">
+    <path d="M 228.301707 44.756621
+L 228.301707 31.108852
+" clip-path="url(#pb6cef3cb8f)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+   </g>
+   <g id="line2d_14">
+    <path d="M 168.858293 34.111815
+" clip-path="url(#pb6cef3cb8f)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_15">
+    <path d="M 198.58 49.512125
+" clip-path="url(#pb6cef3cb8f)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_16">
+    <path d="M 228.301707 37.932736
+" clip-path="url(#pb6cef3cb8f)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="legend_1">
+    <g id="text_20">
+     <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1f1e1b" x="276.09175" y="32.74482" transform="rotate(-0 276.09175 32.74482)">Specialists</text>
+    </g>
+    <g id="patch_14">
+     <path d="M 272.268 43.145445
+L 280.268 43.145445
+L 280.268 37.545445
+L 272.268 37.545445
+z
+" style="fill: #2f6f63; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_21">
+     <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1f1e1b" x="283.468" y="43.145445" transform="rotate(-0 283.468 43.145445)">Upstream</text>
+    </g>
+    <g id="patch_15">
+     <path d="M 272.268 53.54607
+L 280.268 53.54607
+L 280.268 47.94607
+L 272.268 47.94607
+z
+" style="fill: #9c4f2f; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_22">
+     <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1f1e1b" x="283.468" y="53.54607" transform="rotate(-0 283.468 53.54607)">CDS</text>
+    </g>
+   </g>
+   <g id="legend_2">
+    <g id="text_23">
+     <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1f1e1b" x="281.251125" y="66.113096" transform="rotate(-0 281.251125 66.113096)">Generalists</text>
+    </g>
+    <g id="patch_16">
+     <path d="M 272.268 76.513721
+L 280.268 76.513721
+L 280.268 70.913721
+L 272.268 70.913721
+z
+" style="fill: #999999; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_24">
+     <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1f1e1b" x="283.468" y="76.513721" transform="rotate(-0 283.468 76.513721)">Evo 2 (40B)</text>
+    </g>
+    <g id="patch_17">
+     <path d="M 272.268 86.914346
+L 280.268 86.914346
+L 280.268 81.314346
+L 272.268 81.314346
+z
+" style="fill: #555555; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_25">
+     <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start; fill: #1f1e1b" x="283.468" y="86.914346" transform="rotate(-0 283.468 86.914346)">GPN-Star (M)</text>
+    </g>
+   </g>
+  </g>
+  <g id="axes_4">
+   <g id="patch_18">
+    <path d="M 38.38 215.333656
+L 129.922857 215.333656
+L 129.922857 131.912967
+L 38.38 131.912967
+L 38.38 215.333656
+z
+" style="fill: none"/>
+   </g>
+   <g id="matplotlib.axis_5"/>
+   <g id="matplotlib.axis_6">
+    <g id="ytick_11">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="38.38" y="201.128894" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_26">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="31.38" y="204.167957" transform="rotate(-0 31.38 204.167957)">20</text>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="38.38" y="172.719371" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_27">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="31.38" y="175.758433" transform="rotate(-0 31.38 175.758433)">40</text>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="38.38" y="144.309847" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_28">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="31.38" y="147.348909" transform="rotate(-0 31.38 147.348909)">60</text>
+     </g>
+    </g>
+    <g id="text_29">
+     <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="14.797656" y="173.623311" transform="rotate(-90 14.797656 173.623311)">AUPRC (%)</text>
+    </g>
+   </g>
+   <g id="patch_19">
+    <path d="M 42.541039 229.538418
+L 66.318404 229.538418
+L 66.318404 162.089822
+L 42.541039 162.089822
+z
+" clip-path="url(#pd651c67db6)" style="fill: #975134; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 72.262746 229.538418
+L 96.040111 229.538418
+L 96.040111 178.918615
+L 72.262746 178.918615
+z
+" clip-path="url(#pd651c67db6)" style="fill: #999999; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 101.984453 229.538418
+L 125.761818 229.538418
+L 125.761818 139.938234
+L 101.984453 139.938234
+z
+" clip-path="url(#pd651c67db6)" style="fill: #555555; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 38.38 215.333656
+L 38.38 131.912967
+" style="fill: none; stroke: #1f1e1b; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 38.38 215.333656
+L 129.922857 215.333656
+" style="fill: none; stroke: #1f1e1b; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_30">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="54.429722" y="156.1605" transform="rotate(-0 54.429722 156.1605)">47.5</text>
+   </g>
+   <g id="text_31">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="84.151429" y="173.281866" transform="rotate(-0 84.151429 173.281866)">35.6</text>
+   </g>
+   <g id="text_32">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="113.873135" y="134.170091" transform="rotate(-0 113.873135 134.170091)">63.1</text>
+   </g>
+   <g id="text_33">
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #9c4f2f" x="84.151429" y="124.912967" transform="rotate(-0 84.151429 124.912967)">Missense</text>
+   </g>
+   <g id="LineCollection_7">
+    <path d="M 54.429722 164.818841
+L 54.429722 159.360803
+" clip-path="url(#pd651c67db6)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+   </g>
+   <g id="LineCollection_8">
+    <path d="M 84.151429 181.355059
+L 84.151429 176.48217
+" clip-path="url(#pd651c67db6)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+   </g>
+   <g id="LineCollection_9">
+    <path d="M 113.873135 142.506074
+L 113.873135 137.370395
+" clip-path="url(#pd651c67db6)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+   </g>
+   <g id="line2d_20">
+    <path d="M 54.429722 162.089822
+" clip-path="url(#pd651c67db6)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_21">
+    <path d="M 84.151429 178.918615
+" clip-path="url(#pd651c67db6)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_22">
+    <path d="M 113.873135 139.938234
+" clip-path="url(#pd651c67db6)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_5">
+   <g id="patch_24">
+    <path d="M 152.808571 215.333656
+L 244.351429 215.333656
+L 244.351429 131.912967
+L 152.808571 131.912967
+L 152.808571 215.333656
+z
+" style="fill: none"/>
+   </g>
+   <g id="matplotlib.axis_7"/>
+   <g id="matplotlib.axis_8">
+    <g id="ytick_14">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="152.808571" y="201.161903" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_34">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="145.808571" y="204.200966" transform="rotate(-0 145.808571 204.200966)">20</text>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="152.808571" y="172.818397" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_35">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="145.808571" y="175.857459" transform="rotate(-0 145.808571 175.857459)">40</text>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="152.808571" y="144.47489" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_36">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="145.808571" y="147.513953" transform="rotate(-0 145.808571 147.513953)">60</text>
+     </g>
+    </g>
+   </g>
+   <g id="patch_25">
+    <path d="M 156.96961 229.505409
+L 180.746976 229.505409
+L 180.746976 143.322853
+L 156.96961 143.322853
+z
+" clip-path="url(#p8a494e368e)" style="fill: #975134; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 186.691317 229.505409
+L 210.468683 229.505409
+L 210.468683 143.194027
+L 186.691317 143.194027
+z
+" clip-path="url(#p8a494e368e)" style="fill: #999999; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 216.413024 229.505409
+L 240.19039 229.505409
+L 240.19039 140.720874
+L 216.413024 140.720874
+z
+" clip-path="url(#p8a494e368e)" style="fill: #555555; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 152.808571 215.333656
+L 152.808571 131.912967
+" style="fill: none; stroke: #1f1e1b; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 152.808571 215.333656
+L 244.351429 215.333656
+" style="fill: none; stroke: #1f1e1b; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_37">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="168.858293" y="136.701544" transform="rotate(-0 168.858293 136.701544)">60.8</text>
+   </g>
+   <g id="text_38">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="198.58" y="135.899544" transform="rotate(-0 198.58 135.899544)">60.9</text>
+   </g>
+   <g id="text_39">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="228.301707" y="134.173062" transform="rotate(-0 228.301707 134.173062)">62.6</text>
+   </g>
+   <g id="text_40">
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #9c4f2f" x="198.58" y="124.912967" transform="rotate(-0 198.58 124.912967)">Splicing</text>
+   </g>
+   <g id="LineCollection_10">
+    <path d="M 168.858293 146.746829
+L 168.858293 139.898877
+" clip-path="url(#p8a494e368e)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+   </g>
+   <g id="LineCollection_11">
+    <path d="M 198.58 147.291177
+L 198.58 139.096877
+" clip-path="url(#p8a494e368e)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+   </g>
+   <g id="LineCollection_12">
+    <path d="M 228.301707 144.071354
+L 228.301707 137.370395
+" clip-path="url(#p8a494e368e)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+   </g>
+   <g id="line2d_26">
+    <path d="M 168.858293 143.322853
+" clip-path="url(#p8a494e368e)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_27">
+    <path d="M 198.58 143.194027
+" clip-path="url(#p8a494e368e)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_28">
+    <path d="M 228.301707 140.720874
+" clip-path="url(#p8a494e368e)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_6">
+   <g id="patch_30">
+    <path d="M 267.237143 215.333656
+L 358.78 215.333656
+L 358.78 131.912967
+L 267.237143 131.912967
+L 267.237143 215.333656
+z
+" style="fill: none"/>
+   </g>
+   <g id="matplotlib.axis_9"/>
+   <g id="matplotlib.axis_10">
+    <g id="ytick_17">
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="267.237143" y="215.333656" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_41">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="260.237143" y="218.372719" transform="rotate(-0 260.237143 218.372719)">10</text>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="267.237143" y="197.271729" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_42">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="260.237143" y="200.310792" transform="rotate(-0 260.237143 200.310792)">20</text>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="267.237143" y="179.209803" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_43">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="260.237143" y="182.248865" transform="rotate(-0 260.237143 182.248865)">30</text>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="267.237143" y="161.147876" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_44">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="260.237143" y="164.186938" transform="rotate(-0 260.237143 164.186938)">40</text>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#m22e3066cbb" x="267.237143" y="143.085949" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_45">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="260.237143" y="146.125012" transform="rotate(-0 260.237143 146.125012)">50</text>
+     </g>
+    </g>
+   </g>
+   <g id="patch_31">
+    <path d="M 271.398182 233.395583
+L 295.175547 233.395583
+L 295.175547 175.245264
+L 271.398182 175.245264
+z
+" clip-path="url(#p1f8a17c51a)" style="fill: #975134; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 301.119889 233.395583
+L 324.897254 233.395583
+L 324.897254 157.12062
+L 301.119889 157.12062
+z
+" clip-path="url(#p1f8a17c51a)" style="fill: #999999; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 330.841596 233.395583
+L 354.618961 233.395583
+L 354.618961 148.078007
+L 330.841596 148.078007
+z
+" clip-path="url(#p1f8a17c51a)" style="fill: #555555; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 267.237143 215.333656
+L 267.237143 131.912967
+" style="fill: none; stroke: #1f1e1b; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 267.237143 215.333656
+L 358.78 215.333656
+" style="fill: none; stroke: #1f1e1b; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_46">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="283.286865" y="161.218793" transform="rotate(-0 283.286865 161.218793)">32.2</text>
+   </g>
+   <g id="text_47">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="313.008571" y="141.266587" transform="rotate(-0 313.008571 141.266587)">42.2</text>
+   </g>
+   <g id="text_48">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="342.730278" y="133.822946" transform="rotate(-0 342.730278 133.822946)">47.2</text>
+   </g>
+   <g id="text_49">
+    <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #9c4f2f" x="313.008571" y="124.912967" transform="rotate(-0 313.008571 124.912967)">Synonymous</text>
+   </g>
+   <g id="LineCollection_13">
+    <path d="M 283.286865 185.724287
+L 283.286865 164.766241
+" clip-path="url(#p1f8a17c51a)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+   </g>
+   <g id="LineCollection_14">
+    <path d="M 313.008571 169.427205
+L 313.008571 144.814035
+" clip-path="url(#p1f8a17c51a)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+   </g>
+   <g id="LineCollection_15">
+    <path d="M 342.730278 158.78562
+L 342.730278 137.370395
+" clip-path="url(#p1f8a17c51a)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+   </g>
+   <g id="line2d_34">
+    <path d="M 283.286865 175.245264
+" clip-path="url(#p1f8a17c51a)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_35">
+    <path d="M 313.008571 157.12062
+" clip-path="url(#p1f8a17c51a)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_36">
+    <path d="M 342.730278 148.078007
+" clip-path="url(#p1f8a17c51a)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p4040f5f663">
+   <rect x="38.38" y="21.797656" width="91.542857" height="83.42069"/>
+  </clipPath>
+  <clipPath id="pb6cef3cb8f">
+   <rect x="152.808571" y="21.797656" width="91.542857" height="83.42069"/>
+  </clipPath>
+  <clipPath id="pd651c67db6">
+   <rect x="38.38" y="131.912967" width="91.542857" height="83.42069"/>
+  </clipPath>
+  <clipPath id="p8a494e368e">
+   <rect x="152.808571" y="131.912967" width="91.542857" height="83.42069"/>
+  </clipPath>
+  <clipPath id="p1f8a17c51a">
+   <rect x="267.237143" y="131.912967" width="91.542857" height="83.42069"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/promoter_cds_specialists.svg
+++ b/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/promoter_cds_specialists.svg
@@ -6,7 +6,6 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-22T14:55:01.420542</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -44,12 +43,12 @@ z
     <g id="ytick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m22e3066cbb" d="M 0 0
+       <path id="m7291acd6cf" d="M 0 0
 L -3.5 0
 " style="stroke: #1f1e1b; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m22e3066cbb" x="38.38" y="105.218346" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="38.38" y="105.218346" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -59,7 +58,7 @@ L -3.5 0
     <g id="ytick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m22e3066cbb" x="38.38" y="86.951831" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="38.38" y="86.951831" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -69,7 +68,7 @@ L -3.5 0
     <g id="ytick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m22e3066cbb" x="38.38" y="68.685317" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="38.38" y="68.685317" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -79,7 +78,7 @@ L -3.5 0
     <g id="ytick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m22e3066cbb" x="38.38" y="50.418803" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="38.38" y="50.418803" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -89,7 +88,7 @@ L -3.5 0
     <g id="ytick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m22e3066cbb" x="38.38" y="32.152288" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="38.38" y="32.152288" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -106,7 +105,7 @@ L 66.318404 123.48486
 L 66.318404 48.968917
 L 42.541039 48.968917
 z
-" clip-path="url(#p4040f5f663)" style="fill: #326c61; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+" clip-path="url(#pcc472b401d)" style="fill: #326c61; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 72.262746 123.48486
@@ -114,7 +113,7 @@ L 96.040111 123.48486
 L 96.040111 59.732532
 L 72.262746 59.732532
 z
-" clip-path="url(#p4040f5f663)" style="fill: #999999; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+" clip-path="url(#pcc472b401d)" style="fill: #999999; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 101.984453 123.48486
@@ -122,7 +121,7 @@ L 125.761818 123.48486
 L 125.761818 32.94577
 L 101.984453 32.94577
 z
-" clip-path="url(#p4040f5f663)" style="fill: #555555; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+" clip-path="url(#pcc472b401d)" style="fill: #555555; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 38.38 105.218346
@@ -149,29 +148,29 @@ L 129.922857 105.218346
    <g id="LineCollection_1">
     <path d="M 54.429722 55.575582
 L 54.429722 42.362252
-" clip-path="url(#p4040f5f663)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+" clip-path="url(#pcc472b401d)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 84.151429 65.583816
 L 84.151429 53.881247
-" clip-path="url(#p4040f5f663)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+" clip-path="url(#pcc472b401d)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 113.873135 38.636456
 L 113.873135 27.255085
-" clip-path="url(#p4040f5f663)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+" clip-path="url(#pcc472b401d)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
    </g>
    <g id="line2d_6">
     <path d="M 54.429722 48.968917
-" clip-path="url(#p4040f5f663)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+" clip-path="url(#pcc472b401d)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
    </g>
    <g id="line2d_7">
     <path d="M 84.151429 59.732532
-" clip-path="url(#p4040f5f663)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+" clip-path="url(#pcc472b401d)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
    </g>
    <g id="line2d_8">
     <path d="M 113.873135 32.94577
-" clip-path="url(#p4040f5f663)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+" clip-path="url(#pcc472b401d)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_2">
@@ -189,7 +188,7 @@ z
     <g id="ytick_6">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m22e3066cbb" x="152.808571" y="105.218346" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="152.808571" y="105.218346" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -199,7 +198,7 @@ z
     <g id="ytick_7">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m22e3066cbb" x="152.808571" y="85.216158" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="152.808571" y="85.216158" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -209,7 +208,7 @@ z
     <g id="ytick_8">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m22e3066cbb" x="152.808571" y="65.21397" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="152.808571" y="65.21397" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -219,7 +218,7 @@ z
     <g id="ytick_9">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m22e3066cbb" x="152.808571" y="45.211783" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="152.808571" y="45.211783" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -229,7 +228,7 @@ z
     <g id="ytick_10">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m22e3066cbb" x="152.808571" y="25.209595" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="152.808571" y="25.209595" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -243,7 +242,7 @@ L 180.746976 125.220534
 L 180.746976 34.111815
 L 156.96961 34.111815
 z
-" clip-path="url(#pb6cef3cb8f)" style="fill: #326c61; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+" clip-path="url(#p0c4277c3ca)" style="fill: #326c61; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 186.691317 125.220534
@@ -251,7 +250,7 @@ L 210.468683 125.220534
 L 210.468683 49.512125
 L 186.691317 49.512125
 z
-" clip-path="url(#pb6cef3cb8f)" style="fill: #999999; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+" clip-path="url(#p0c4277c3ca)" style="fill: #999999; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 216.413024 125.220534
@@ -259,7 +258,7 @@ L 240.19039 125.220534
 L 240.19039 37.932736
 L 216.413024 37.932736
 z
-" clip-path="url(#pb6cef3cb8f)" style="fill: #555555; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+" clip-path="url(#p0c4277c3ca)" style="fill: #555555; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 152.808571 105.218346
@@ -286,29 +285,29 @@ L 244.351429 105.218346
    <g id="LineCollection_4">
     <path d="M 168.858293 40.968545
 L 168.858293 27.255085
-" clip-path="url(#pb6cef3cb8f)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+" clip-path="url(#p0c4277c3ca)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 198.58 56.34721
 L 198.58 42.67704
-" clip-path="url(#pb6cef3cb8f)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+" clip-path="url(#p0c4277c3ca)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 228.301707 44.756621
 L 228.301707 31.108852
-" clip-path="url(#pb6cef3cb8f)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+" clip-path="url(#p0c4277c3ca)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
    </g>
    <g id="line2d_14">
     <path d="M 168.858293 34.111815
-" clip-path="url(#pb6cef3cb8f)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+" clip-path="url(#p0c4277c3ca)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
    </g>
    <g id="line2d_15">
     <path d="M 198.58 49.512125
-" clip-path="url(#pb6cef3cb8f)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+" clip-path="url(#p0c4277c3ca)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
    </g>
    <g id="line2d_16">
     <path d="M 228.301707 37.932736
-" clip-path="url(#pb6cef3cb8f)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+" clip-path="url(#p0c4277c3ca)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_3">
@@ -382,7 +381,7 @@ z
     <g id="ytick_11">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m22e3066cbb" x="38.38" y="201.128894" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="38.38" y="201.128894" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_26">
@@ -392,7 +391,7 @@ z
     <g id="ytick_12">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m22e3066cbb" x="38.38" y="172.719371" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="38.38" y="172.719371" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_27">
@@ -402,7 +401,7 @@ z
     <g id="ytick_13">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m22e3066cbb" x="38.38" y="144.309847" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="38.38" y="144.309847" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_28">
@@ -419,7 +418,7 @@ L 66.318404 229.538418
 L 66.318404 162.089822
 L 42.541039 162.089822
 z
-" clip-path="url(#pd651c67db6)" style="fill: #975134; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+" clip-path="url(#p5b91e5eb61)" style="fill: #975134; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
     <path d="M 72.262746 229.538418
@@ -427,7 +426,7 @@ L 96.040111 229.538418
 L 96.040111 178.918615
 L 72.262746 178.918615
 z
-" clip-path="url(#pd651c67db6)" style="fill: #999999; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+" clip-path="url(#p5b91e5eb61)" style="fill: #999999; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
     <path d="M 101.984453 229.538418
@@ -435,7 +434,7 @@ L 125.761818 229.538418
 L 125.761818 139.938234
 L 101.984453 139.938234
 z
-" clip-path="url(#pd651c67db6)" style="fill: #555555; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+" clip-path="url(#p5b91e5eb61)" style="fill: #555555; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
     <path d="M 38.38 215.333656
@@ -462,29 +461,29 @@ L 129.922857 215.333656
    <g id="LineCollection_7">
     <path d="M 54.429722 164.818841
 L 54.429722 159.360803
-" clip-path="url(#pd651c67db6)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+" clip-path="url(#p5b91e5eb61)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 84.151429 181.355059
 L 84.151429 176.48217
-" clip-path="url(#pd651c67db6)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+" clip-path="url(#p5b91e5eb61)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
    </g>
    <g id="LineCollection_9">
     <path d="M 113.873135 142.506074
 L 113.873135 137.370395
-" clip-path="url(#pd651c67db6)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+" clip-path="url(#p5b91e5eb61)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
    </g>
    <g id="line2d_20">
     <path d="M 54.429722 162.089822
-" clip-path="url(#pd651c67db6)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+" clip-path="url(#p5b91e5eb61)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
    </g>
    <g id="line2d_21">
     <path d="M 84.151429 178.918615
-" clip-path="url(#pd651c67db6)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+" clip-path="url(#p5b91e5eb61)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
    </g>
    <g id="line2d_22">
     <path d="M 113.873135 139.938234
-" clip-path="url(#pd651c67db6)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+" clip-path="url(#p5b91e5eb61)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_5">
@@ -502,7 +501,7 @@ z
     <g id="ytick_14">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m22e3066cbb" x="152.808571" y="201.161903" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="152.808571" y="201.161903" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_34">
@@ -512,7 +511,7 @@ z
     <g id="ytick_15">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m22e3066cbb" x="152.808571" y="172.818397" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="152.808571" y="172.818397" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_35">
@@ -522,7 +521,7 @@ z
     <g id="ytick_16">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m22e3066cbb" x="152.808571" y="144.47489" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="152.808571" y="144.47489" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_36">
@@ -536,7 +535,7 @@ L 180.746976 229.505409
 L 180.746976 143.322853
 L 156.96961 143.322853
 z
-" clip-path="url(#p8a494e368e)" style="fill: #975134; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+" clip-path="url(#p840d527fd2)" style="fill: #975134; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 186.691317 229.505409
@@ -544,7 +543,7 @@ L 210.468683 229.505409
 L 210.468683 143.194027
 L 186.691317 143.194027
 z
-" clip-path="url(#p8a494e368e)" style="fill: #999999; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+" clip-path="url(#p840d527fd2)" style="fill: #999999; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 216.413024 229.505409
@@ -552,7 +551,7 @@ L 240.19039 229.505409
 L 240.19039 140.720874
 L 216.413024 140.720874
 z
-" clip-path="url(#p8a494e368e)" style="fill: #555555; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+" clip-path="url(#p840d527fd2)" style="fill: #555555; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
     <path d="M 152.808571 215.333656
@@ -579,29 +578,29 @@ L 244.351429 215.333656
    <g id="LineCollection_10">
     <path d="M 168.858293 146.746829
 L 168.858293 139.898877
-" clip-path="url(#p8a494e368e)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+" clip-path="url(#p840d527fd2)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
    </g>
    <g id="LineCollection_11">
     <path d="M 198.58 147.291177
 L 198.58 139.096877
-" clip-path="url(#p8a494e368e)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+" clip-path="url(#p840d527fd2)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
    </g>
    <g id="LineCollection_12">
     <path d="M 228.301707 144.071354
 L 228.301707 137.370395
-" clip-path="url(#p8a494e368e)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+" clip-path="url(#p840d527fd2)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
    </g>
    <g id="line2d_26">
     <path d="M 168.858293 143.322853
-" clip-path="url(#p8a494e368e)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+" clip-path="url(#p840d527fd2)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
    </g>
    <g id="line2d_27">
     <path d="M 198.58 143.194027
-" clip-path="url(#p8a494e368e)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+" clip-path="url(#p840d527fd2)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
    </g>
    <g id="line2d_28">
     <path d="M 228.301707 140.720874
-" clip-path="url(#p8a494e368e)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+" clip-path="url(#p840d527fd2)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_6">
@@ -619,7 +618,7 @@ z
     <g id="ytick_17">
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m22e3066cbb" x="267.237143" y="215.333656" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="267.237143" y="215.333656" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_41">
@@ -629,7 +628,7 @@ z
     <g id="ytick_18">
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m22e3066cbb" x="267.237143" y="197.271729" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="267.237143" y="197.271729" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_42">
@@ -639,7 +638,7 @@ z
     <g id="ytick_19">
      <g id="line2d_31">
       <g>
-       <use xlink:href="#m22e3066cbb" x="267.237143" y="179.209803" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="267.237143" y="179.209803" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_43">
@@ -649,7 +648,7 @@ z
     <g id="ytick_20">
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m22e3066cbb" x="267.237143" y="161.147876" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="267.237143" y="161.147876" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_44">
@@ -659,7 +658,7 @@ z
     <g id="ytick_21">
      <g id="line2d_33">
       <g>
-       <use xlink:href="#m22e3066cbb" x="267.237143" y="143.085949" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m7291acd6cf" x="267.237143" y="143.085949" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_45">
@@ -673,7 +672,7 @@ L 295.175547 233.395583
 L 295.175547 175.245264
 L 271.398182 175.245264
 z
-" clip-path="url(#p1f8a17c51a)" style="fill: #975134; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+" clip-path="url(#p274f8139df)" style="fill: #975134; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
     <path d="M 301.119889 233.395583
@@ -681,7 +680,7 @@ L 324.897254 233.395583
 L 324.897254 157.12062
 L 301.119889 157.12062
 z
-" clip-path="url(#p1f8a17c51a)" style="fill: #999999; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+" clip-path="url(#p274f8139df)" style="fill: #999999; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
    <g id="patch_33">
     <path d="M 330.841596 233.395583
@@ -689,7 +688,7 @@ L 354.618961 233.395583
 L 354.618961 148.078007
 L 330.841596 148.078007
 z
-" clip-path="url(#p1f8a17c51a)" style="fill: #555555; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
+" clip-path="url(#p274f8139df)" style="fill: #555555; stroke: #1f1e1b; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
    <g id="patch_34">
     <path d="M 267.237143 215.333656
@@ -716,46 +715,46 @@ L 358.78 215.333656
    <g id="LineCollection_13">
     <path d="M 283.286865 185.724287
 L 283.286865 164.766241
-" clip-path="url(#p1f8a17c51a)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+" clip-path="url(#p274f8139df)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
    </g>
    <g id="LineCollection_14">
     <path d="M 313.008571 169.427205
 L 313.008571 144.814035
-" clip-path="url(#p1f8a17c51a)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+" clip-path="url(#p274f8139df)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
    </g>
    <g id="LineCollection_15">
     <path d="M 342.730278 158.78562
 L 342.730278 137.370395
-" clip-path="url(#p1f8a17c51a)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
+" clip-path="url(#p274f8139df)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9"/>
    </g>
    <g id="line2d_34">
     <path d="M 283.286865 175.245264
-" clip-path="url(#p1f8a17c51a)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+" clip-path="url(#p274f8139df)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
    </g>
    <g id="line2d_35">
     <path d="M 313.008571 157.12062
-" clip-path="url(#p1f8a17c51a)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+" clip-path="url(#p274f8139df)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
    </g>
    <g id="line2d_36">
     <path d="M 342.730278 148.078007
-" clip-path="url(#p1f8a17c51a)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
+" clip-path="url(#p274f8139df)" style="fill: none; stroke: #1f1e1b; stroke-width: 0.9; stroke-linecap: square"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p4040f5f663">
+  <clipPath id="pcc472b401d">
    <rect x="38.38" y="21.797656" width="91.542857" height="83.42069"/>
   </clipPath>
-  <clipPath id="pb6cef3cb8f">
+  <clipPath id="p0c4277c3ca">
    <rect x="152.808571" y="21.797656" width="91.542857" height="83.42069"/>
   </clipPath>
-  <clipPath id="pd651c67db6">
+  <clipPath id="p5b91e5eb61">
    <rect x="38.38" y="131.912967" width="91.542857" height="83.42069"/>
   </clipPath>
-  <clipPath id="p8a494e368e">
+  <clipPath id="p840d527fd2">
    <rect x="152.808571" y="131.912967" width="91.542857" height="83.42069"/>
   </clipPath>
-  <clipPath id="p1f8a17c51a">
+  <clipPath id="p274f8139df">
    <rect x="267.237143" y="131.912967" width="91.542857" height="83.42069"/>
   </clipPath>
  </defs>

--- a/plots/blog/promoter_cds_specialists.py
+++ b/plots/blog/promoter_cds_specialists.py
@@ -226,6 +226,7 @@ def build_figure(data: pd.DataFrame) -> Figure:
     mpl.rcParams.update(
         {
             "svg.fonttype": "none",
+            "svg.hashsalt": OUTPUT_NAME,
             "axes.spines.top": False,
             "axes.spines.right": False,
             "text.color": INK,
@@ -317,7 +318,10 @@ def build_figure(data: pd.DataFrame) -> Figure:
 def save_figure(figure: Figure) -> None:
     """Save the web SVG and a high-resolution PNG for visual review."""
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    for extension, kwargs in (("svg", {}), ("png", {"dpi": 300})):
+    for extension, kwargs in (
+        ("svg", {"metadata": {"Date": None}}),
+        ("png", {"dpi": 300}),
+    ):
         path = OUTPUT_DIR / f"{OUTPUT_NAME}.{extension}"
         figure.savefig(path, bbox_inches="tight", transparent=True, **kwargs)
         if extension == "svg":

--- a/plots/blog/promoter_cds_specialists.py
+++ b/plots/blog/promoter_cds_specialists.py
@@ -1,0 +1,340 @@
+"""Promoter/CDS specialist comparison for the genomic-LM optimization blog.
+
+The five-panel bar chart follows the CSHL 2026 poster's specialist figure and
+the reworked blog Figure 5 small multiples, but uses the current offline
+Mendelian eval and keeps only region-matched tasks:
+
+* Promoter YOLO: 5' UTR and TSS-proximal variants.
+* CDS YOLO: missense, splicing, and synonymous variants.
+
+Each specialist is compared with Evo 2 40B and GPN-Star (M) under the canonical
+zero-shot protocol for that model family. Error bars are capless +/-1
+chromosome-cluster bootstrap SE.
+
+Run: uv run python -m plots.blog.promoter_cds_specialists
+Out: plots/output/blog/promoter_cds_specialists.{svg,png}
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from matplotlib.patches import Patch
+
+from marin_dna.pipelines.evals.leaderboard import (
+    DEFAULT_PROTOCOL,
+    fetch_method_metrics,
+)
+from marin_dna.pipelines.evals.models import models_for_dataset
+
+DATASET = "mendelian_traits"
+OUTPUT_DIR = Path("plots/output/blog")
+OUTPUT_NAME = "promoter_cds_specialists"
+
+INK = "#1f1e1b"
+AUPRC_BASELINE_PCT = 10.0
+ROLE_ORDER = ("Specialist", "Evo 2 (40B)", "GPN-Star (M)")
+BASELINE_COLORS = {
+    "Evo 2 (40B)": "#999999",
+    "GPN-Star (M)": "#555555",
+}
+REGION_COLORS = {"upstream": "#2f6f63", "cds": "#9c4f2f"}
+
+PANEL_ORDER = (
+    "tss_proximal",
+    "5_prime_UTR_variant",
+    "missense_variant",
+    "splicing",
+    "synonymous_variant",
+)
+PANEL_SPECS = {
+    "5_prime_UTR_variant": {
+        "specialist_id": "exp21-promoters-yolo-step-22000",
+        "region": "upstream",
+    },
+    "tss_proximal": {
+        "specialist_id": "exp21-promoters-yolo-step-22000",
+        "region": "upstream",
+    },
+    "missense_variant": {
+        "specialist_id": "exp27-cds-yolo-step-34000",
+        "region": "cds",
+    },
+    "splicing": {
+        "specialist_id": "exp27-cds-yolo-step-34000",
+        "region": "cds",
+    },
+    "synonymous_variant": {
+        "specialist_id": "exp27-cds-yolo-step-34000",
+        "region": "cds",
+    },
+}
+SUBSET_DISPLAY = {
+    "5_prime_UTR_variant": "5′ UTR",
+    "tss_proximal": "Promoter",
+    "missense_variant": "Missense",
+    "splicing": "Splicing",
+    "synonymous_variant": "Synonymous",
+}
+BASELINE_IDS = {
+    "Evo 2 (40B)": "evo2_40b",
+    "GPN-Star (M)": "GPN-Star-M",
+}
+
+
+def load_plot_data() -> pd.DataFrame:
+    """Load the five region-matched comparisons from current evals_v2 metrics."""
+    required_ids = {
+        *(spec["specialist_id"] for spec in PANEL_SPECS.values()),
+        *BASELINE_IDS.values(),
+    }
+    models = {
+        model.id: model
+        for model in models_for_dataset(DATASET)
+        if model.id in required_ids
+    }
+    assert set(models) == required_ids, (
+        f"missing registered models: {sorted(required_ids - set(models))}"
+    )
+
+    records: list[dict[str, Any]] = []
+    for subset in PANEL_ORDER:
+        spec = PANEL_SPECS[subset]
+        role_to_model_id = {
+            "Specialist": spec["specialist_id"],
+            **BASELINE_IDS,
+        }
+        for role, model_id in role_to_model_id.items():
+            model = models[model_id]
+            metrics = fetch_method_metrics(model, DATASET)
+            row = metrics.filter(metrics["subset"] == subset)
+            assert row.height == 1, (
+                f"expected one {subset!r} row for {model_id!r}, got {row.height}"
+            )
+            values = row.row(0, named=True)
+            value = float(values["value"])
+            se = float(values["se"])
+            n = int(values["n"])
+            n_positives = int(values["n_positives"])
+            assert 0.0 <= value <= 1.0
+            assert 0.0 <= se <= 1.0
+            assert 0 < n_positives <= n
+            records.append(
+                {
+                    "subset": subset,
+                    "consequence": SUBSET_DISPLAY[subset],
+                    "region": spec["region"],
+                    "role": role,
+                    "model_id": model_id,
+                    "protocol": DEFAULT_PROTOCOL[model.family],
+                    "auprc_pct": 100.0 * value,
+                    "se_pct": 100.0 * se,
+                    "n": n,
+                    "n_positives": n_positives,
+                }
+            )
+
+    frame = pd.DataFrame.from_records(records)
+    expected_rows = len(PANEL_ORDER) * len(ROLE_ORDER)
+    assert len(frame) == expected_rows
+    assert not frame.isna().any().any()
+    return frame
+
+
+def _draw_panel(ax: Axes, data: pd.DataFrame, subset: str) -> None:
+    """Draw one consequence panel on its own y-axis."""
+    assert set(data["subset"]) == {subset}
+    assert data["n"].nunique() == 1
+    region = str(data["region"].iloc[0])
+    assert region in REGION_COLORS
+    palette = {
+        "Specialist": REGION_COLORS[region],
+        **BASELINE_COLORS,
+    }
+    sns.barplot(
+        data=data,
+        x="role",
+        y="auprc_pct",
+        hue="role",
+        order=ROLE_ORDER,
+        hue_order=ROLE_ORDER,
+        palette=palette,
+        errorbar=None,
+        edgecolor=INK,
+        linewidth=0.7,
+        saturation=0.9,
+        ax=ax,
+        legend=False,
+        dodge=False,
+    )
+
+    panel_top = 0.0
+    for x, role in enumerate(ROLE_ORDER):
+        row = data.loc[data["role"] == role]
+        assert len(row) == 1
+        value = float(row["auprc_pct"].iloc[0])
+        se = float(row["se_pct"].iloc[0])
+        panel_top = max(panel_top, value + se)
+        ax.errorbar(
+            x,
+            value,
+            yerr=se,
+            color=INK,
+            linewidth=0.9,
+            capsize=0,
+            zorder=5,
+        )
+        ax.text(
+            x,
+            value + se + 0.9,
+            f"{value:.1f}",
+            ha="center",
+            va="bottom",
+            fontsize=8,
+            color=INK,
+        )
+
+    ax.set_axisbelow(True)
+    ax.grid(False)
+    top_padding = max(2.0, 0.07 * (panel_top - AUPRC_BASELINE_PCT))
+    y_max = panel_top + top_padding
+    assert y_max > AUPRC_BASELINE_PCT
+    ax.set_ylim(AUPRC_BASELINE_PCT, y_max)
+    ax.set_xlabel("")
+    ax.tick_params(axis="x", bottom=False, labelbottom=False)
+    ax.tick_params(axis="y", labelsize=8)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.set_title(
+        SUBSET_DISPLAY[subset],
+        fontsize=10,
+        color=REGION_COLORS[region],
+        pad=7,
+    )
+
+
+def build_figure(data: pd.DataFrame) -> Figure:
+    """Build five independently scaled consequence panels in a 2x3 grid."""
+    mpl.rcdefaults()
+    mpl.rcParams.update(
+        {
+            "svg.fonttype": "none",
+            "axes.spines.top": False,
+            "axes.spines.right": False,
+            "text.color": INK,
+            "axes.labelcolor": INK,
+            "axes.edgecolor": INK,
+            "xtick.color": INK,
+            "ytick.color": INK,
+            "axes.titlecolor": INK,
+        }
+    )
+    figure, axes = plt.subplots(2, 3, figsize=(5.0, 3.2), sharex=False, sharey=False)
+    panel_axes = (axes[0, 0], axes[0, 1], axes[1, 0], axes[1, 1], axes[1, 2])
+    for ax, subset in zip(panel_axes, PANEL_ORDER, strict=True):
+        _draw_panel(ax, data.loc[data["subset"] == subset], subset)
+    axes[0, 2].axis("off")
+    axes[0, 0].set_ylabel("AUPRC (%)")
+    axes[1, 0].set_ylabel("AUPRC (%)")
+    for ax in (axes[0, 1], axes[1, 1], axes[1, 2]):
+        ax.set_ylabel("")
+
+    specialist_handles = [
+        Patch(
+            facecolor=REGION_COLORS["upstream"],
+            edgecolor=INK,
+            linewidth=0.7,
+            label="Upstream",
+        ),
+        Patch(
+            facecolor=REGION_COLORS["cds"],
+            edgecolor=INK,
+            linewidth=0.7,
+            label="CDS",
+        ),
+    ]
+    generalist_handles = [
+        Patch(
+            facecolor=BASELINE_COLORS["Evo 2 (40B)"],
+            edgecolor=INK,
+            linewidth=0.7,
+            label="Evo 2 (40B)",
+        ),
+        Patch(
+            facecolor=BASELINE_COLORS["GPN-Star (M)"],
+            edgecolor=INK,
+            linewidth=0.7,
+            label="GPN-Star (M)",
+        ),
+    ]
+    specialist_legend = axes[0, 2].legend(
+        handles=specialist_handles,
+        title="Specialists",
+        loc="upper left",
+        bbox_to_anchor=(0.02, 0.98),
+        ncol=1,
+        frameon=False,
+        fontsize=8,
+        title_fontsize=8,
+        handlelength=1.0,
+        handletextpad=0.4,
+        labelspacing=0.3,
+        borderaxespad=0,
+    )
+    axes[0, 2].add_artist(specialist_legend)
+    axes[0, 2].legend(
+        handles=generalist_handles,
+        title="Generalists",
+        loc="upper left",
+        bbox_to_anchor=(0.02, 0.58),
+        ncol=1,
+        frameon=False,
+        fontsize=8,
+        title_fontsize=8,
+        handlelength=1.0,
+        handletextpad=0.4,
+        labelspacing=0.3,
+        borderaxespad=0,
+    )
+    figure.subplots_adjust(
+        left=0.105,
+        right=0.995,
+        top=0.96,
+        bottom=0.12,
+        wspace=0.25,
+        hspace=0.32,
+    )
+    return figure
+
+
+def save_figure(figure: Figure) -> None:
+    """Save the web SVG and a high-resolution PNG for visual review."""
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    for extension, kwargs in (("svg", {}), ("png", {"dpi": 300})):
+        path = OUTPUT_DIR / f"{OUTPUT_NAME}.{extension}"
+        figure.savefig(path, bbox_inches="tight", transparent=True, **kwargs)
+        if extension == "svg":
+            svg = path.read_text(encoding="utf-8")
+            path.write_text(
+                "\n".join(line.rstrip() for line in svg.splitlines()) + "\n",
+                encoding="utf-8",
+            )
+        print(f"Wrote {path}")
+
+
+def build() -> None:
+    data = load_plot_data()
+    figure = build_figure(data)
+    save_figure(figure)
+    plt.close(figure)
+
+
+if __name__ == "__main__":
+    build()

--- a/tests/test_blog_workspace.py
+++ b/tests/test_blog_workspace.py
@@ -46,7 +46,7 @@ def test_edited_workspace_is_valid_and_baseline_manifest_is_readable() -> None:
     referenced_assets = validate_workspace(config)
     manifest = read_baseline_manifest(config)
 
-    assert len(referenced_assets) == 17
+    assert len(referenced_assets) == 18
     assert len(manifest) == 12
 
 


### PR DESCRIPTION
## Summary

- Add a reproducible five-panel comparison of upstream and CDS specialists with Evo 2 40B and GPN-Star.
- Add restrained prose and a caption that emphasize within-panel comparisons and independent y-axes.
- Make SVG export byte-deterministic and stage the generated blog asset.

This drafts the **Upstream and CDS specialists** section of the genomic LM optimization post. Part of #361.

## Validation

- `uv run python -m plots.blog.promoter_cds_specialists`
- `uv run --no-project python src/marin_dna/blog_workspace.py validate`
- `uv run pytest tests/test_blog_workspace.py` (6 passed)
- `uv run ruff check plots/blog/promoter_cds_specialists.py`
- Two consecutive SVG renders were byte-identical (`ddd9c2f9…`)
- Independent review completed with no remaining findings
