### PR TITLE
Add upstream/CDS mixture comparison to optimization blog

### DIFF
--- a/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
+++ b/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
@@ -200,20 +200,20 @@ We first trained a 1.7B upstream-region specialist, trying to replicate the succ
 
 *Region-matched Mendelian VEP AUPRC under each model family's canonical zero-shot protocol (MarinDNA and Evo 2 LLR; GPN-Star cLLR).*
 *Promoter denotes the TSS-proximal subset; each panel has an independent y-axis beginning at the 10% prevalence baseline, so compare models only within a panel.*
-*Error bars are capless ±1 chromosome-cluster bootstrap SE.*
+*Error bars denote SE.*
 
 ### Balancing upstream and CDS data
 
-- After testing upstream and CDS specialists independently, the next experiment asked whether one model could retain both capabilities.[^upstream-cds-mixture]
-- Proportional sampling—10% upstream and 90% CDS—behaved similarly to CDS-only training.
-- Equal 50/50 upstream/CDS sampling produced balanced performance across both regions.
-- This made explicit mixture control, rather than raw dataset size, a central part of the training strategy.
+After testing upstream and CDS specialists independently, the next experiment asked whether one model could retain both capabilities ([experiment #13](https://github.com/Open-Athena/marin-dna/issues/13)).
+Sampling in proportion to dataset size—10% upstream and 90% CDS—is the naive default when the two datasets are simply pooled without reweighting.
+In practice, it behaved similarly to CDS-only training.
+Equal 50/50 upstream/CDS sampling produced balanced performance across both regions.
+This made explicit mixture control a central axis of investigation.
+Even the 50/50 mixture may not be optimal: regions can differ both in size and in the density of learnable biological signal.
 
 ![Promoter and missense VEP AUPRC trajectories for upstream-only, balanced, proportional, and CDS-only training mixtures](/assets/images/blog/genomic-lm-optimization/upstream_cds_balance.svg)
 
-*Draft upstream/CDS mixture comparison. Each panel uses the six training checkpoints shared by all four arms; the right panel is the unweighted mean of the promoter and missense AUPRCs.*
-
-[^upstream-cds-mixture]: See [Open-Athena/marin-dna issue #13](https://github.com/Open-Athena/marin-dna/issues/13).
+*Upstream/CDS mixture comparison (zero-shot). The right panel is the unweighted mean of the promoter and missense AUPRCs.*
 
 ### Hyperparameter transfer
 

--- a/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
+++ b/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
@@ -202,15 +202,18 @@ We first trained a 1.7B upstream-region specialist, trying to replicate the succ
 *Promoter denotes the TSS-proximal subset; each panel has an independent y-axis beginning at the 10% prevalence baseline, so compare models only within a panel.*
 *Error bars are capless ±1 chromosome-cluster bootstrap SE.*
 
-### Balancing promoter and CDS data
+### Balancing upstream and CDS data
 
-- After testing promoter and CDS specialists independently, the next experiment asked whether one model could retain both capabilities.[^promoter-cds-mixture]
-- Proportional sampling—10% promoters and 90% CDS—behaved similarly to CDS-only training.
-- Equal 50/50 promoter/CDS sampling produced balanced performance across both regions.
+- After testing upstream and CDS specialists independently, the next experiment asked whether one model could retain both capabilities.[^upstream-cds-mixture]
+- Proportional sampling—10% upstream and 90% CDS—behaved similarly to CDS-only training.
+- Equal 50/50 upstream/CDS sampling produced balanced performance across both regions.
 - This made explicit mixture control, rather than raw dataset size, a central part of the training strategy.
-- **Image to add:** Redraw the promoter/CDS mixture comparison from issue #13 in the blog palette.
 
-[^promoter-cds-mixture]: See [Open-Athena/marin-dna issue #13](https://github.com/Open-Athena/marin-dna/issues/13).
+![Promoter and missense VEP AUPRC trajectories for upstream-only, balanced, proportional, and CDS-only training mixtures](/assets/images/blog/genomic-lm-optimization/upstream_cds_balance.svg)
+
+*Draft upstream/CDS mixture comparison. Each panel uses the six training checkpoints shared by all four arms; the right panel is the unweighted mean of the promoter and missense AUPRCs.*
+
+[^upstream-cds-mixture]: See [Open-Athena/marin-dna issue #13](https://github.com/Open-Athena/marin-dna/issues/13).
 
 ### Hyperparameter transfer
 

--- a/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/upstream_cds_balance.svg
+++ b/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/upstream_cds_balance.svg
@@ -6,7 +6,6 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-07-22T15:03:22.582864</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,21 +20,21 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 486.602344 
-L 1151.91 486.602344 
-L 1151.91 0 
-L 0 0 
-L 0 486.602344 
+   <path d="M 0 486.602344
+L 1151.91 486.602344
+L 1151.91 0
+L 0 0
+L 0 486.602344
 z
 " style="fill: none"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 133.155 412.4 
-L 403.155 412.4 
-L 403.155 169.04 
-L 133.155 169.04 
-L 133.155 412.4 
+    <path d="M 133.155 412.4
+L 403.155 412.4
+L 403.155 169.04
+L 133.155 169.04
+L 133.155 412.4
 z
 " style="fill: none"/>
    </g>
@@ -43,12 +42,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m7cfde82107" d="M 0 0 
-L 0 3.5 
+       <path id="mf41082fdae" d="M 0 0
+L 0 3.5
 " style="stroke: #1f1e1b; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7cfde82107" x="243.609545" y="412.4" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#mf41082fdae" x="243.609545" y="412.4" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -58,7 +57,7 @@ L 0 3.5
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m7cfde82107" x="366.336818" y="412.4" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#mf41082fdae" x="366.336818" y="412.4" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -73,12 +72,12 @@ L 0 3.5
     <g id="ytick_1">
      <g id="line2d_3">
       <defs>
-       <path id="m1139d3fbf8" d="M 0 0 
-L -3.5 0 
+       <path id="m8ee30f9a54" d="M 0 0
+L -3.5 0
 " style="stroke: #1f1e1b; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1139d3fbf8" x="133.155" y="393.761141" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m8ee30f9a54" x="133.155" y="393.761141" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -88,7 +87,7 @@ L -3.5 0
     <g id="ytick_2">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m1139d3fbf8" x="133.155" y="324.377128" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m8ee30f9a54" x="133.155" y="324.377128" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -98,7 +97,7 @@ L -3.5 0
     <g id="ytick_3">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m1139d3fbf8" x="133.155" y="254.993114" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m8ee30f9a54" x="133.155" y="254.993114" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -108,7 +107,7 @@ L -3.5 0
     <g id="ytick_4">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m1139d3fbf8" x="133.155" y="185.609101" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m8ee30f9a54" x="133.155" y="185.609101" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -120,133 +119,133 @@ L -3.5 0
     </g>
    </g>
    <g id="line2d_7">
-    <path d="M 145.427727 365.324903 
-L 194.518636 340.718867 
-L 243.609545 245.185621 
-L 292.700455 180.471209 
-L 341.791364 186.711541 
-L 390.882273 180.101818 
-" clip-path="url(#pa36f06a881)" style="fill: none; stroke: #2f6f63; stroke-width: 4.5; stroke-linecap: square"/>
+    <path d="M 145.427727 365.324903
+L 194.518636 340.718867
+L 243.609545 245.185621
+L 292.700455 180.471209
+L 341.791364 186.711541
+L 390.882273 180.101818
+" clip-path="url(#p476047d22a)" style="fill: none; stroke: #2f6f63; stroke-width: 4.5; stroke-linecap: square"/>
     <defs>
-     <path id="mfe7c99169d" d="M 0 7 
-C 1.856422 7 3.637059 6.262436 4.949747 4.949747 
-C 6.262436 3.637059 7 1.856422 7 0 
-C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747 
-C 3.637059 -6.262436 1.856422 -7 0 -7 
-C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747 
-C -6.262436 -3.637059 -7 -1.856422 -7 0 
-C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747 
-C -3.637059 6.262436 -1.856422 7 0 7 
+     <path id="m7a99e3033c" d="M 0 7
+C 1.856422 7 3.637059 6.262436 4.949747 4.949747
+C 6.262436 3.637059 7 1.856422 7 0
+C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747
+C 3.637059 -6.262436 1.856422 -7 0 -7
+C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747
+C -6.262436 -3.637059 -7 -1.856422 -7 0
+C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747
+C -3.637059 6.262436 -1.856422 7 0 7
 z
 " style="stroke: #2f6f63"/>
     </defs>
-    <g clip-path="url(#pa36f06a881)">
-     <use xlink:href="#mfe7c99169d" x="145.427727" y="365.324903" style="fill: #2f6f63; stroke: #2f6f63"/>
-     <use xlink:href="#mfe7c99169d" x="194.518636" y="340.718867" style="fill: #2f6f63; stroke: #2f6f63"/>
-     <use xlink:href="#mfe7c99169d" x="243.609545" y="245.185621" style="fill: #2f6f63; stroke: #2f6f63"/>
-     <use xlink:href="#mfe7c99169d" x="292.700455" y="180.471209" style="fill: #2f6f63; stroke: #2f6f63"/>
-     <use xlink:href="#mfe7c99169d" x="341.791364" y="186.711541" style="fill: #2f6f63; stroke: #2f6f63"/>
-     <use xlink:href="#mfe7c99169d" x="390.882273" y="180.101818" style="fill: #2f6f63; stroke: #2f6f63"/>
+    <g clip-path="url(#p476047d22a)">
+     <use xlink:href="#m7a99e3033c" x="145.427727" y="365.324903" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#m7a99e3033c" x="194.518636" y="340.718867" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#m7a99e3033c" x="243.609545" y="245.185621" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#m7a99e3033c" x="292.700455" y="180.471209" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#m7a99e3033c" x="341.791364" y="186.711541" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#m7a99e3033c" x="390.882273" y="180.101818" style="fill: #2f6f63; stroke: #2f6f63"/>
     </g>
    </g>
    <g id="line2d_8">
-    <path d="M 145.427727 382.363733 
-L 194.518636 374.950288 
-L 243.609545 363.22399 
-L 292.700455 317.870447 
-L 341.791364 298.096246 
-L 390.882273 271.661529 
-" clip-path="url(#pa36f06a881)" style="fill: none; stroke: #665f49; stroke-width: 4.5; stroke-linecap: square"/>
+    <path d="M 145.427727 382.363733
+L 194.518636 374.950288
+L 243.609545 363.22399
+L 292.700455 317.870447
+L 341.791364 298.096246
+L 390.882273 271.661529
+" clip-path="url(#p476047d22a)" style="fill: none; stroke: #665f49; stroke-width: 4.5; stroke-linecap: square"/>
     <defs>
-     <path id="ma3c65260e4" d="M 0 7 
-C 1.856422 7 3.637059 6.262436 4.949747 4.949747 
-C 6.262436 3.637059 7 1.856422 7 0 
-C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747 
-C 3.637059 -6.262436 1.856422 -7 0 -7 
-C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747 
-C -6.262436 -3.637059 -7 -1.856422 -7 0 
-C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747 
-C -3.637059 6.262436 -1.856422 7 0 7 
+     <path id="m6911c2cdc9" d="M 0 7
+C 1.856422 7 3.637059 6.262436 4.949747 4.949747
+C 6.262436 3.637059 7 1.856422 7 0
+C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747
+C 3.637059 -6.262436 1.856422 -7 0 -7
+C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747
+C -6.262436 -3.637059 -7 -1.856422 -7 0
+C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747
+C -3.637059 6.262436 -1.856422 7 0 7
 z
 " style="stroke: #665f49"/>
     </defs>
-    <g clip-path="url(#pa36f06a881)">
-     <use xlink:href="#ma3c65260e4" x="145.427727" y="382.363733" style="fill: #665f49; stroke: #665f49"/>
-     <use xlink:href="#ma3c65260e4" x="194.518636" y="374.950288" style="fill: #665f49; stroke: #665f49"/>
-     <use xlink:href="#ma3c65260e4" x="243.609545" y="363.22399" style="fill: #665f49; stroke: #665f49"/>
-     <use xlink:href="#ma3c65260e4" x="292.700455" y="317.870447" style="fill: #665f49; stroke: #665f49"/>
-     <use xlink:href="#ma3c65260e4" x="341.791364" y="298.096246" style="fill: #665f49; stroke: #665f49"/>
-     <use xlink:href="#ma3c65260e4" x="390.882273" y="271.661529" style="fill: #665f49; stroke: #665f49"/>
+    <g clip-path="url(#p476047d22a)">
+     <use xlink:href="#m6911c2cdc9" x="145.427727" y="382.363733" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#m6911c2cdc9" x="194.518636" y="374.950288" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#m6911c2cdc9" x="243.609545" y="363.22399" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#m6911c2cdc9" x="292.700455" y="317.870447" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#m6911c2cdc9" x="341.791364" y="298.096246" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#m6911c2cdc9" x="390.882273" y="271.661529" style="fill: #665f49; stroke: #665f49"/>
     </g>
    </g>
    <g id="line2d_9">
-    <path d="M 145.427727 391.802965 
-L 194.518636 388.986351 
-L 243.609545 381.950292 
-L 292.700455 381.123926 
-L 341.791364 381.165552 
-L 390.882273 374.627226 
-" clip-path="url(#pa36f06a881)" style="fill: none; stroke: #915234; stroke-width: 4.5; stroke-linecap: square"/>
+    <path d="M 145.427727 391.802965
+L 194.518636 388.986351
+L 243.609545 381.950292
+L 292.700455 381.123926
+L 341.791364 381.165552
+L 390.882273 374.627226
+" clip-path="url(#p476047d22a)" style="fill: none; stroke: #915234; stroke-width: 4.5; stroke-linecap: square"/>
     <defs>
-     <path id="m4782c62b45" d="M 0 7 
-C 1.856422 7 3.637059 6.262436 4.949747 4.949747 
-C 6.262436 3.637059 7 1.856422 7 0 
-C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747 
-C 3.637059 -6.262436 1.856422 -7 0 -7 
-C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747 
-C -6.262436 -3.637059 -7 -1.856422 -7 0 
-C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747 
-C -3.637059 6.262436 -1.856422 7 0 7 
+     <path id="m2c60ee06e1" d="M 0 7
+C 1.856422 7 3.637059 6.262436 4.949747 4.949747
+C 6.262436 3.637059 7 1.856422 7 0
+C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747
+C 3.637059 -6.262436 1.856422 -7 0 -7
+C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747
+C -6.262436 -3.637059 -7 -1.856422 -7 0
+C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747
+C -3.637059 6.262436 -1.856422 7 0 7
 z
 " style="stroke: #915234"/>
     </defs>
-    <g clip-path="url(#pa36f06a881)">
-     <use xlink:href="#m4782c62b45" x="145.427727" y="391.802965" style="fill: #915234; stroke: #915234"/>
-     <use xlink:href="#m4782c62b45" x="194.518636" y="388.986351" style="fill: #915234; stroke: #915234"/>
-     <use xlink:href="#m4782c62b45" x="243.609545" y="381.950292" style="fill: #915234; stroke: #915234"/>
-     <use xlink:href="#m4782c62b45" x="292.700455" y="381.123926" style="fill: #915234; stroke: #915234"/>
-     <use xlink:href="#m4782c62b45" x="341.791364" y="381.165552" style="fill: #915234; stroke: #915234"/>
-     <use xlink:href="#m4782c62b45" x="390.882273" y="374.627226" style="fill: #915234; stroke: #915234"/>
+    <g clip-path="url(#p476047d22a)">
+     <use xlink:href="#m2c60ee06e1" x="145.427727" y="391.802965" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m2c60ee06e1" x="194.518636" y="388.986351" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m2c60ee06e1" x="243.609545" y="381.950292" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m2c60ee06e1" x="292.700455" y="381.123926" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m2c60ee06e1" x="341.791364" y="381.165552" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m2c60ee06e1" x="390.882273" y="374.627226" style="fill: #915234; stroke: #915234"/>
     </g>
    </g>
    <g id="line2d_10">
-    <path d="M 145.427727 401.338182 
-L 194.518636 386.36322 
-L 243.609545 392.483394 
-L 292.700455 388.406399 
-L 341.791364 387.235191 
-L 390.882273 380.870269 
-" clip-path="url(#pa36f06a881)" style="fill: none; stroke: #9c4f2f; stroke-width: 4.5; stroke-linecap: square"/>
+    <path d="M 145.427727 401.338182
+L 194.518636 386.36322
+L 243.609545 392.483394
+L 292.700455 388.406399
+L 341.791364 387.235191
+L 390.882273 380.870269
+" clip-path="url(#p476047d22a)" style="fill: none; stroke: #9c4f2f; stroke-width: 4.5; stroke-linecap: square"/>
     <defs>
-     <path id="m7045e8590f" d="M 0 7 
-C 1.856422 7 3.637059 6.262436 4.949747 4.949747 
-C 6.262436 3.637059 7 1.856422 7 0 
-C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747 
-C 3.637059 -6.262436 1.856422 -7 0 -7 
-C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747 
-C -6.262436 -3.637059 -7 -1.856422 -7 0 
-C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747 
-C -3.637059 6.262436 -1.856422 7 0 7 
+     <path id="me1c3715eb5" d="M 0 7
+C 1.856422 7 3.637059 6.262436 4.949747 4.949747
+C 6.262436 3.637059 7 1.856422 7 0
+C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747
+C 3.637059 -6.262436 1.856422 -7 0 -7
+C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747
+C -6.262436 -3.637059 -7 -1.856422 -7 0
+C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747
+C -3.637059 6.262436 -1.856422 7 0 7
 z
 " style="stroke: #9c4f2f"/>
     </defs>
-    <g clip-path="url(#pa36f06a881)">
-     <use xlink:href="#m7045e8590f" x="145.427727" y="401.338182" style="fill: #9c4f2f; stroke: #9c4f2f"/>
-     <use xlink:href="#m7045e8590f" x="194.518636" y="386.36322" style="fill: #9c4f2f; stroke: #9c4f2f"/>
-     <use xlink:href="#m7045e8590f" x="243.609545" y="392.483394" style="fill: #9c4f2f; stroke: #9c4f2f"/>
-     <use xlink:href="#m7045e8590f" x="292.700455" y="388.406399" style="fill: #9c4f2f; stroke: #9c4f2f"/>
-     <use xlink:href="#m7045e8590f" x="341.791364" y="387.235191" style="fill: #9c4f2f; stroke: #9c4f2f"/>
-     <use xlink:href="#m7045e8590f" x="390.882273" y="380.870269" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+    <g clip-path="url(#p476047d22a)">
+     <use xlink:href="#me1c3715eb5" x="145.427727" y="401.338182" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#me1c3715eb5" x="194.518636" y="386.36322" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#me1c3715eb5" x="243.609545" y="392.483394" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#me1c3715eb5" x="292.700455" y="388.406399" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#me1c3715eb5" x="341.791364" y="387.235191" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#me1c3715eb5" x="390.882273" y="380.870269" style="fill: #9c4f2f; stroke: #9c4f2f"/>
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 133.155 412.4 
-L 133.155 169.04 
+    <path d="M 133.155 412.4
+L 133.155 169.04
 " style="fill: none; stroke: #1f1e1b; stroke-width: 1.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M 133.155 412.4 
-L 403.155 412.4 
+    <path d="M 133.155 412.4
+L 403.155 412.4
 " style="fill: none; stroke: #1f1e1b; stroke-width: 1.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_9">
@@ -255,11 +254,11 @@ L 403.155 412.4
   </g>
   <g id="axes_2">
    <g id="patch_5">
-    <path d="M 478.755 412.4 
-L 748.755 412.4 
-L 748.755 169.04 
-L 478.755 169.04 
-L 478.755 412.4 
+    <path d="M 478.755 412.4
+L 748.755 412.4
+L 748.755 169.04
+L 478.755 169.04
+L 478.755 412.4
 z
 " style="fill: none"/>
    </g>
@@ -267,7 +266,7 @@ z
     <g id="xtick_3">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m7cfde82107" x="589.209545" y="412.4" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#mf41082fdae" x="589.209545" y="412.4" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -277,7 +276,7 @@ z
     <g id="xtick_4">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m7cfde82107" x="711.936818" y="412.4" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#mf41082fdae" x="711.936818" y="412.4" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -292,7 +291,7 @@ z
     <g id="ytick_5">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m1139d3fbf8" x="478.755" y="350.532546" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m8ee30f9a54" x="478.755" y="350.532546" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -302,7 +301,7 @@ z
     <g id="ytick_6">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m1139d3fbf8" x="478.755" y="237.994695" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m8ee30f9a54" x="478.755" y="237.994695" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -311,81 +310,81 @@ z
     </g>
    </g>
    <g id="line2d_15">
-    <path d="M 491.027727 401.338182 
-L 540.118636 384.21011 
-L 589.209545 375.49411 
-L 638.300455 376.270039 
-L 687.391364 369.718464 
-L 736.482273 371.939513 
-" clip-path="url(#p380055d614)" style="fill: none; stroke: #2f6f63; stroke-width: 4.5; stroke-linecap: square"/>
-    <g clip-path="url(#p380055d614)">
-     <use xlink:href="#mfe7c99169d" x="491.027727" y="401.338182" style="fill: #2f6f63; stroke: #2f6f63"/>
-     <use xlink:href="#mfe7c99169d" x="540.118636" y="384.21011" style="fill: #2f6f63; stroke: #2f6f63"/>
-     <use xlink:href="#mfe7c99169d" x="589.209545" y="375.49411" style="fill: #2f6f63; stroke: #2f6f63"/>
-     <use xlink:href="#mfe7c99169d" x="638.300455" y="376.270039" style="fill: #2f6f63; stroke: #2f6f63"/>
-     <use xlink:href="#mfe7c99169d" x="687.391364" y="369.718464" style="fill: #2f6f63; stroke: #2f6f63"/>
-     <use xlink:href="#mfe7c99169d" x="736.482273" y="371.939513" style="fill: #2f6f63; stroke: #2f6f63"/>
+    <path d="M 491.027727 401.338182
+L 540.118636 384.21011
+L 589.209545 375.49411
+L 638.300455 376.270039
+L 687.391364 369.718464
+L 736.482273 371.939513
+" clip-path="url(#p4b0f06d37b)" style="fill: none; stroke: #2f6f63; stroke-width: 4.5; stroke-linecap: square"/>
+    <g clip-path="url(#p4b0f06d37b)">
+     <use xlink:href="#m7a99e3033c" x="491.027727" y="401.338182" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#m7a99e3033c" x="540.118636" y="384.21011" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#m7a99e3033c" x="589.209545" y="375.49411" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#m7a99e3033c" x="638.300455" y="376.270039" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#m7a99e3033c" x="687.391364" y="369.718464" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#m7a99e3033c" x="736.482273" y="371.939513" style="fill: #2f6f63; stroke: #2f6f63"/>
     </g>
    </g>
    <g id="line2d_16">
-    <path d="M 491.027727 387.066653 
-L 540.118636 312.784497 
-L 589.209545 263.218138 
-L 638.300455 221.731686 
-L 687.391364 201.937128 
-L 736.482273 199.161616 
-" clip-path="url(#p380055d614)" style="fill: none; stroke: #665f49; stroke-width: 4.5; stroke-linecap: square"/>
-    <g clip-path="url(#p380055d614)">
-     <use xlink:href="#ma3c65260e4" x="491.027727" y="387.066653" style="fill: #665f49; stroke: #665f49"/>
-     <use xlink:href="#ma3c65260e4" x="540.118636" y="312.784497" style="fill: #665f49; stroke: #665f49"/>
-     <use xlink:href="#ma3c65260e4" x="589.209545" y="263.218138" style="fill: #665f49; stroke: #665f49"/>
-     <use xlink:href="#ma3c65260e4" x="638.300455" y="221.731686" style="fill: #665f49; stroke: #665f49"/>
-     <use xlink:href="#ma3c65260e4" x="687.391364" y="201.937128" style="fill: #665f49; stroke: #665f49"/>
-     <use xlink:href="#ma3c65260e4" x="736.482273" y="199.161616" style="fill: #665f49; stroke: #665f49"/>
+    <path d="M 491.027727 387.066653
+L 540.118636 312.784497
+L 589.209545 263.218138
+L 638.300455 221.731686
+L 687.391364 201.937128
+L 736.482273 199.161616
+" clip-path="url(#p4b0f06d37b)" style="fill: none; stroke: #665f49; stroke-width: 4.5; stroke-linecap: square"/>
+    <g clip-path="url(#p4b0f06d37b)">
+     <use xlink:href="#m6911c2cdc9" x="491.027727" y="387.066653" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#m6911c2cdc9" x="540.118636" y="312.784497" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#m6911c2cdc9" x="589.209545" y="263.218138" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#m6911c2cdc9" x="638.300455" y="221.731686" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#m6911c2cdc9" x="687.391364" y="201.937128" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#m6911c2cdc9" x="736.482273" y="199.161616" style="fill: #665f49; stroke: #665f49"/>
     </g>
    </g>
    <g id="line2d_17">
-    <path d="M 491.027727 372.354234 
-L 540.118636 248.709108 
-L 589.209545 202.199374 
-L 638.300455 188.746777 
-L 687.391364 186.184894 
-L 736.482273 186.913865 
-" clip-path="url(#p380055d614)" style="fill: none; stroke: #915234; stroke-width: 4.5; stroke-linecap: square"/>
-    <g clip-path="url(#p380055d614)">
-     <use xlink:href="#m4782c62b45" x="491.027727" y="372.354234" style="fill: #915234; stroke: #915234"/>
-     <use xlink:href="#m4782c62b45" x="540.118636" y="248.709108" style="fill: #915234; stroke: #915234"/>
-     <use xlink:href="#m4782c62b45" x="589.209545" y="202.199374" style="fill: #915234; stroke: #915234"/>
-     <use xlink:href="#m4782c62b45" x="638.300455" y="188.746777" style="fill: #915234; stroke: #915234"/>
-     <use xlink:href="#m4782c62b45" x="687.391364" y="186.184894" style="fill: #915234; stroke: #915234"/>
-     <use xlink:href="#m4782c62b45" x="736.482273" y="186.913865" style="fill: #915234; stroke: #915234"/>
+    <path d="M 491.027727 372.354234
+L 540.118636 248.709108
+L 589.209545 202.199374
+L 638.300455 188.746777
+L 687.391364 186.184894
+L 736.482273 186.913865
+" clip-path="url(#p4b0f06d37b)" style="fill: none; stroke: #915234; stroke-width: 4.5; stroke-linecap: square"/>
+    <g clip-path="url(#p4b0f06d37b)">
+     <use xlink:href="#m2c60ee06e1" x="491.027727" y="372.354234" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m2c60ee06e1" x="540.118636" y="248.709108" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m2c60ee06e1" x="589.209545" y="202.199374" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m2c60ee06e1" x="638.300455" y="188.746777" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m2c60ee06e1" x="687.391364" y="186.184894" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m2c60ee06e1" x="736.482273" y="186.913865" style="fill: #915234; stroke: #915234"/>
     </g>
    </g>
    <g id="line2d_18">
-    <path d="M 491.027727 371.709107 
-L 540.118636 242.931223 
-L 589.209545 193.412062 
-L 638.300455 197.990587 
-L 687.391364 180.101818 
-L 736.482273 193.93361 
-" clip-path="url(#p380055d614)" style="fill: none; stroke: #9c4f2f; stroke-width: 4.5; stroke-linecap: square"/>
-    <g clip-path="url(#p380055d614)">
-     <use xlink:href="#m7045e8590f" x="491.027727" y="371.709107" style="fill: #9c4f2f; stroke: #9c4f2f"/>
-     <use xlink:href="#m7045e8590f" x="540.118636" y="242.931223" style="fill: #9c4f2f; stroke: #9c4f2f"/>
-     <use xlink:href="#m7045e8590f" x="589.209545" y="193.412062" style="fill: #9c4f2f; stroke: #9c4f2f"/>
-     <use xlink:href="#m7045e8590f" x="638.300455" y="197.990587" style="fill: #9c4f2f; stroke: #9c4f2f"/>
-     <use xlink:href="#m7045e8590f" x="687.391364" y="180.101818" style="fill: #9c4f2f; stroke: #9c4f2f"/>
-     <use xlink:href="#m7045e8590f" x="736.482273" y="193.93361" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+    <path d="M 491.027727 371.709107
+L 540.118636 242.931223
+L 589.209545 193.412062
+L 638.300455 197.990587
+L 687.391364 180.101818
+L 736.482273 193.93361
+" clip-path="url(#p4b0f06d37b)" style="fill: none; stroke: #9c4f2f; stroke-width: 4.5; stroke-linecap: square"/>
+    <g clip-path="url(#p4b0f06d37b)">
+     <use xlink:href="#me1c3715eb5" x="491.027727" y="371.709107" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#me1c3715eb5" x="540.118636" y="242.931223" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#me1c3715eb5" x="589.209545" y="193.412062" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#me1c3715eb5" x="638.300455" y="197.990587" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#me1c3715eb5" x="687.391364" y="180.101818" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#me1c3715eb5" x="736.482273" y="193.93361" style="fill: #9c4f2f; stroke: #9c4f2f"/>
     </g>
    </g>
    <g id="patch_6">
-    <path d="M 478.755 412.4 
-L 478.755 169.04 
+    <path d="M 478.755 412.4
+L 478.755 169.04
 " style="fill: none; stroke: #1f1e1b; stroke-width: 1.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 478.755 412.4 
-L 748.755 412.4 
+    <path d="M 478.755 412.4
+L 748.755 412.4
 " style="fill: none; stroke: #1f1e1b; stroke-width: 1.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_15">
@@ -394,11 +393,11 @@ L 748.755 412.4
   </g>
   <g id="axes_3">
    <g id="patch_8">
-    <path d="M 824.355 412.4 
-L 1094.355 412.4 
-L 1094.355 169.04 
-L 824.355 169.04 
-L 824.355 412.4 
+    <path d="M 824.355 412.4
+L 1094.355 412.4
+L 1094.355 169.04
+L 824.355 169.04
+L 824.355 412.4
 z
 " style="fill: none"/>
    </g>
@@ -406,7 +405,7 @@ z
     <g id="xtick_5">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m7cfde82107" x="934.809545" y="412.4" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#mf41082fdae" x="934.809545" y="412.4" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -416,7 +415,7 @@ z
     <g id="xtick_6">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m7cfde82107" x="1057.536818" y="412.4" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#mf41082fdae" x="1057.536818" y="412.4" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -431,7 +430,7 @@ z
     <g id="ytick_7">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m1139d3fbf8" x="824.355" y="334.511705" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m8ee30f9a54" x="824.355" y="334.511705" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -441,7 +440,7 @@ z
     <g id="ytick_8">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m1139d3fbf8" x="824.355" y="244.996118" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+       <use xlink:href="#m8ee30f9a54" x="824.355" y="244.996118" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -450,81 +449,81 @@ z
     </g>
    </g>
    <g id="line2d_23">
-    <path d="M 836.627727 401.338182 
-L 885.718636 371.841356 
-L 934.809545 303.282446 
-L 983.900455 262.154083 
-L 1032.991364 260.96826 
-L 1082.082273 258.471184 
-" clip-path="url(#p9e73f7f15d)" style="fill: none; stroke: #2f6f63; stroke-width: 4.5; stroke-linecap: square"/>
-    <g clip-path="url(#p9e73f7f15d)">
-     <use xlink:href="#mfe7c99169d" x="836.627727" y="401.338182" style="fill: #2f6f63; stroke: #2f6f63"/>
-     <use xlink:href="#mfe7c99169d" x="885.718636" y="371.841356" style="fill: #2f6f63; stroke: #2f6f63"/>
-     <use xlink:href="#mfe7c99169d" x="934.809545" y="303.282446" style="fill: #2f6f63; stroke: #2f6f63"/>
-     <use xlink:href="#mfe7c99169d" x="983.900455" y="262.154083" style="fill: #2f6f63; stroke: #2f6f63"/>
-     <use xlink:href="#mfe7c99169d" x="1032.991364" y="260.96826" style="fill: #2f6f63; stroke: #2f6f63"/>
-     <use xlink:href="#mfe7c99169d" x="1082.082273" y="258.471184" style="fill: #2f6f63; stroke: #2f6f63"/>
+    <path d="M 836.627727 401.338182
+L 885.718636 371.841356
+L 934.809545 303.282446
+L 983.900455 262.154083
+L 1032.991364 260.96826
+L 1082.082273 258.471184
+" clip-path="url(#p7ad8b8c711)" style="fill: none; stroke: #2f6f63; stroke-width: 4.5; stroke-linecap: square"/>
+    <g clip-path="url(#p7ad8b8c711)">
+     <use xlink:href="#m7a99e3033c" x="836.627727" y="401.338182" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#m7a99e3033c" x="885.718636" y="371.841356" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#m7a99e3033c" x="934.809545" y="303.282446" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#m7a99e3033c" x="983.900455" y="262.154083" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#m7a99e3033c" x="1032.991364" y="260.96826" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#m7a99e3033c" x="1082.082273" y="258.471184" style="fill: #2f6f63; stroke: #2f6f63"/>
     </g>
    </g>
    <g id="line2d_24">
-    <path d="M 836.627727 400.977529 
-L 885.718636 337.109316 
-L 934.809545 290.118597 
-L 983.900455 227.862802 
-L 1032.991364 199.361871 
-L 1082.082273 180.101818 
-" clip-path="url(#p9e73f7f15d)" style="fill: none; stroke: #665f49; stroke-width: 4.5; stroke-linecap: square"/>
-    <g clip-path="url(#p9e73f7f15d)">
-     <use xlink:href="#ma3c65260e4" x="836.627727" y="400.977529" style="fill: #665f49; stroke: #665f49"/>
-     <use xlink:href="#ma3c65260e4" x="885.718636" y="337.109316" style="fill: #665f49; stroke: #665f49"/>
-     <use xlink:href="#ma3c65260e4" x="934.809545" y="290.118597" style="fill: #665f49; stroke: #665f49"/>
-     <use xlink:href="#ma3c65260e4" x="983.900455" y="227.862802" style="fill: #665f49; stroke: #665f49"/>
-     <use xlink:href="#ma3c65260e4" x="1032.991364" y="199.361871" style="fill: #665f49; stroke: #665f49"/>
-     <use xlink:href="#ma3c65260e4" x="1082.082273" y="180.101818" style="fill: #665f49; stroke: #665f49"/>
+    <path d="M 836.627727 400.977529
+L 885.718636 337.109316
+L 934.809545 290.118597
+L 983.900455 227.862802
+L 1032.991364 199.361871
+L 1082.082273 180.101818
+" clip-path="url(#p7ad8b8c711)" style="fill: none; stroke: #665f49; stroke-width: 4.5; stroke-linecap: square"/>
+    <g clip-path="url(#p7ad8b8c711)">
+     <use xlink:href="#m6911c2cdc9" x="836.627727" y="400.977529" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#m6911c2cdc9" x="885.718636" y="337.109316" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#m6911c2cdc9" x="934.809545" y="290.118597" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#m6911c2cdc9" x="983.900455" y="227.862802" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#m6911c2cdc9" x="1032.991364" y="199.361871" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#m6911c2cdc9" x="1082.082273" y="180.101818" style="fill: #665f49; stroke: #665f49"/>
     </g>
    </g>
    <g id="line2d_25">
-    <path d="M 836.627727 395.36388 
-L 885.718636 295.196348 
-L 934.809545 253.662498 
-L 983.900455 242.428879 
-L 1032.991364 240.417942 
-L 1082.082273 236.780083 
-" clip-path="url(#p9e73f7f15d)" style="fill: none; stroke: #915234; stroke-width: 4.5; stroke-linecap: square"/>
-    <g clip-path="url(#p9e73f7f15d)">
-     <use xlink:href="#m4782c62b45" x="836.627727" y="395.36388" style="fill: #915234; stroke: #915234"/>
-     <use xlink:href="#m4782c62b45" x="885.718636" y="295.196348" style="fill: #915234; stroke: #915234"/>
-     <use xlink:href="#m4782c62b45" x="934.809545" y="253.662498" style="fill: #915234; stroke: #915234"/>
-     <use xlink:href="#m4782c62b45" x="983.900455" y="242.428879" style="fill: #915234; stroke: #915234"/>
-     <use xlink:href="#m4782c62b45" x="1032.991364" y="240.417942" style="fill: #915234; stroke: #915234"/>
-     <use xlink:href="#m4782c62b45" x="1082.082273" y="236.780083" style="fill: #915234; stroke: #915234"/>
+    <path d="M 836.627727 395.36388
+L 885.718636 295.196348
+L 934.809545 253.662498
+L 983.900455 242.428879
+L 1032.991364 240.417942
+L 1082.082273 236.780083
+" clip-path="url(#p7ad8b8c711)" style="fill: none; stroke: #915234; stroke-width: 4.5; stroke-linecap: square"/>
+    <g clip-path="url(#p7ad8b8c711)">
+     <use xlink:href="#m2c60ee06e1" x="836.627727" y="395.36388" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m2c60ee06e1" x="885.718636" y="295.196348" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m2c60ee06e1" x="934.809545" y="253.662498" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m2c60ee06e1" x="983.900455" y="242.428879" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m2c60ee06e1" x="1032.991364" y="240.417942" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m2c60ee06e1" x="1082.082273" y="236.780083" style="fill: #915234; stroke: #915234"/>
     </g>
    </g>
    <g id="line2d_26">
-    <path d="M 836.627727 401.001645 
-L 885.718636 288.908353 
-L 934.809545 253.467463 
-L 983.900455 254.479382 
-L 1032.991364 239.494666 
-L 1082.082273 246.390996 
-" clip-path="url(#p9e73f7f15d)" style="fill: none; stroke: #9c4f2f; stroke-width: 4.5; stroke-linecap: square"/>
-    <g clip-path="url(#p9e73f7f15d)">
-     <use xlink:href="#m7045e8590f" x="836.627727" y="401.001645" style="fill: #9c4f2f; stroke: #9c4f2f"/>
-     <use xlink:href="#m7045e8590f" x="885.718636" y="288.908353" style="fill: #9c4f2f; stroke: #9c4f2f"/>
-     <use xlink:href="#m7045e8590f" x="934.809545" y="253.467463" style="fill: #9c4f2f; stroke: #9c4f2f"/>
-     <use xlink:href="#m7045e8590f" x="983.900455" y="254.479382" style="fill: #9c4f2f; stroke: #9c4f2f"/>
-     <use xlink:href="#m7045e8590f" x="1032.991364" y="239.494666" style="fill: #9c4f2f; stroke: #9c4f2f"/>
-     <use xlink:href="#m7045e8590f" x="1082.082273" y="246.390996" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+    <path d="M 836.627727 401.001645
+L 885.718636 288.908353
+L 934.809545 253.467463
+L 983.900455 254.479382
+L 1032.991364 239.494666
+L 1082.082273 246.390996
+" clip-path="url(#p7ad8b8c711)" style="fill: none; stroke: #9c4f2f; stroke-width: 4.5; stroke-linecap: square"/>
+    <g clip-path="url(#p7ad8b8c711)">
+     <use xlink:href="#me1c3715eb5" x="836.627727" y="401.001645" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#me1c3715eb5" x="885.718636" y="288.908353" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#me1c3715eb5" x="934.809545" y="253.467463" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#me1c3715eb5" x="983.900455" y="254.479382" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#me1c3715eb5" x="1032.991364" y="239.494666" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#me1c3715eb5" x="1082.082273" y="246.390996" style="fill: #9c4f2f; stroke: #9c4f2f"/>
     </g>
    </g>
    <g id="patch_9">
-    <path d="M 824.355 412.4 
-L 824.355 169.04 
+    <path d="M 824.355 412.4
+L 824.355 169.04
 " style="fill: none; stroke: #1f1e1b; stroke-width: 1.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_10">
-    <path d="M 824.355 412.4 
-L 1094.355 412.4 
+    <path d="M 824.355 412.4
+L 1094.355 412.4
 " style="fill: none; stroke: #1f1e1b; stroke-width: 1.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
@@ -533,38 +532,38 @@ L 1094.355 412.4
   </g>
   <g id="legend_1">
    <g id="line2d_27">
-    <path d="M 7.2 20.315 
-L 101.6 20.315 
+    <path d="M 7.2 20.315
+L 101.6 20.315
 " style="fill: none; stroke: #2f6f63; stroke-width: 4.5"/>
    </g>
    <g id="line2d_28">
     <defs>
-     <path id="m870e30f926" d="M 0 7 
-C 1.856422 7 3.637059 6.262436 4.949747 4.949747 
-C 6.262436 3.637059 7 1.856422 7 0 
-C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747 
-C 3.637059 -6.262436 1.856422 -7 0 -7 
-C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747 
-C -6.262436 -3.637059 -7 -1.856422 -7 0 
-C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747 
-C -3.637059 6.262436 -1.856422 7 0 7 
+     <path id="mcccd3075c8" d="M 0 7
+C 1.856422 7 3.637059 6.262436 4.949747 4.949747
+C 6.262436 3.637059 7 1.856422 7 0
+C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747
+C 3.637059 -6.262436 1.856422 -7 0 -7
+C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747
+C -6.262436 -3.637059 -7 -1.856422 -7 0
+C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747
+C -3.637059 6.262436 -1.856422 7 0 7
 z
 " style="stroke: #1f1e1b"/>
     </defs>
     <g>
-     <use xlink:href="#m870e30f926" x="54.4" y="20.315" style="fill: #2f6f63; stroke: #1f1e1b"/>
+     <use xlink:href="#mcccd3075c8" x="54.4" y="20.315" style="fill: #2f6f63; stroke: #1f1e1b"/>
     </g>
    </g>
    <g id="patch_11">
-    <path d="M 124 30.619 
-C 126.732653 30.619 129.353751 29.533306 131.286028 27.601028 
-C 133.218306 25.668751 134.304 23.047653 134.304 20.315 
-C 134.304 17.582347 133.218306 14.961249 131.286028 13.028972 
-C 129.353751 11.096694 126.732653 10.011 124 10.011 
-C 121.267347 10.011 118.646249 11.096694 116.713972 13.028972 
-C 114.781694 14.961249 113.696 17.582347 113.696 20.315 
-C 113.696 23.047653 114.781694 25.668751 116.713972 27.601028 
-C 118.646249 29.533306 121.267347 30.619 124 30.619 
+    <path d="M 124 30.619
+C 126.732653 30.619 129.353751 29.533306 131.286028 27.601028
+C 133.218306 25.668751 134.304 23.047653 134.304 20.315
+C 134.304 17.582347 133.218306 14.961249 131.286028 13.028972
+C 129.353751 11.096694 126.732653 10.011 124 10.011
+C 121.267347 10.011 118.646249 11.096694 116.713972 13.028972
+C 114.781694 14.961249 113.696 17.582347 113.696 20.315
+C 113.696 23.047653 114.781694 25.668751 116.713972 27.601028
+C 118.646249 29.533306 121.267347 30.619 124 30.619
 z
 " style="fill: #2f6f63; stroke: #1f1e1b; stroke-linejoin: miter"/>
    </g>
@@ -572,45 +571,45 @@ z
     <text style="font-size: 32px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="148" y="31.515" transform="rotate(-0 148 31.515)">Upstream only (100 / 0)</text>
    </g>
    <g id="line2d_29">
-    <path d="M 7.2 71.5175 
-L 101.6 71.5175 
+    <path d="M 7.2 71.5175
+L 101.6 71.5175
 " style="fill: none; stroke: #665f49; stroke-width: 4.5"/>
    </g>
    <g id="line2d_30">
     <defs>
-     <path id="mf8d856e0a4" d="M 0 7 
-C 1.856422 7 3.637059 6.262436 4.949747 4.949747 
-C 6.262436 3.637059 7 1.856422 7 0 
-C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747 
-C 3.637059 -6.262436 1.856422 -7 0 -7 
-C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747 
-C -6.262436 -3.637059 -7 -1.856422 -7 0 
-C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747 
-C -3.637059 6.262436 -1.856422 7 0 7 
+     <path id="m05c9f1efcf" d="M 0 7
+C 1.856422 7 3.637059 6.262436 4.949747 4.949747
+C 6.262436 3.637059 7 1.856422 7 0
+C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747
+C 3.637059 -6.262436 1.856422 -7 0 -7
+C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747
+C -6.262436 -3.637059 -7 -1.856422 -7 0
+C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747
+C -3.637059 6.262436 -1.856422 7 0 7
 z
 " style="stroke: #1f1e1b"/>
     </defs>
     <g>
-     <use xlink:href="#mf8d856e0a4" x="54.4" y="71.5175" style="fill: #665f49; stroke: #1f1e1b"/>
+     <use xlink:href="#m05c9f1efcf" x="54.4" y="71.5175" style="fill: #665f49; stroke: #1f1e1b"/>
     </g>
    </g>
    <g id="patch_12">
-    <path d="M 124 81.8215 
-C 126.731743 81.8215 129.354395 80.735162 131.286028 78.803528 
-C 133.217662 76.871895 134.304 74.249243 134.304 71.5175 
-C 134.304 68.785757 133.217662 66.163105 131.286028 64.231472 
-C 129.354395 62.299838 126.731743 61.2135 124 61.2135 
-L 124 71.5175 
+    <path d="M 124 81.8215
+C 126.731743 81.8215 129.354395 80.735162 131.286028 78.803528
+C 133.217662 76.871895 134.304 74.249243 134.304 71.5175
+C 134.304 68.785757 133.217662 66.163105 131.286028 64.231472
+C 129.354395 62.299838 126.731743 61.2135 124 61.2135
+L 124 71.5175
 z
 " style="fill: #2f6f63; stroke: #1f1e1b; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 124 61.2135 
-C 121.268257 61.2135 118.645605 62.299838 116.713972 64.231472 
-C 114.782338 66.163105 113.696 68.785757 113.696 71.5175 
-C 113.696 74.249243 114.782338 76.871895 116.713972 78.803528 
-C 118.645605 80.735162 121.268257 81.8215 124 81.8215 
-L 124 71.5175 
+    <path d="M 124 61.2135
+C 121.268257 61.2135 118.645605 62.299838 116.713972 64.231472
+C 114.782338 66.163105 113.696 68.785757 113.696 71.5175
+C 113.696 74.249243 114.782338 76.871895 116.713972 78.803528
+C 118.645605 80.735162 121.268257 81.8215 124 81.8215
+L 124 71.5175
 z
 " style="fill: #9c4f2f; stroke: #1f1e1b; stroke-linejoin: miter"/>
    </g>
@@ -618,38 +617,38 @@ z
     <text style="font-size: 32px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="148" y="82.7175" transform="rotate(-0 148 82.7175)">Uniform mix (50 / 50)</text>
    </g>
    <g id="line2d_31">
-    <path d="M 593.43 20.315 
-L 687.83 20.315 
+    <path d="M 593.43 20.315
+L 687.83 20.315
 " style="fill: none; stroke: #9c4f2f; stroke-width: 4.5"/>
    </g>
    <g id="line2d_32">
     <defs>
-     <path id="mbb770798ff" d="M 0 7 
-C 1.856422 7 3.637059 6.262436 4.949747 4.949747 
-C 6.262436 3.637059 7 1.856422 7 0 
-C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747 
-C 3.637059 -6.262436 1.856422 -7 0 -7 
-C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747 
-C -6.262436 -3.637059 -7 -1.856422 -7 0 
-C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747 
-C -3.637059 6.262436 -1.856422 7 0 7 
+     <path id="m79be5dc0c1" d="M 0 7
+C 1.856422 7 3.637059 6.262436 4.949747 4.949747
+C 6.262436 3.637059 7 1.856422 7 0
+C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747
+C 3.637059 -6.262436 1.856422 -7 0 -7
+C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747
+C -6.262436 -3.637059 -7 -1.856422 -7 0
+C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747
+C -3.637059 6.262436 -1.856422 7 0 7
 z
 " style="stroke: #1f1e1b"/>
     </defs>
     <g>
-     <use xlink:href="#mbb770798ff" x="640.63" y="20.315" style="fill: #9c4f2f; stroke: #1f1e1b"/>
+     <use xlink:href="#m79be5dc0c1" x="640.63" y="20.315" style="fill: #9c4f2f; stroke: #1f1e1b"/>
     </g>
    </g>
    <g id="patch_14">
-    <path d="M 710.23 30.619 
-C 712.962653 30.619 715.583751 29.533306 717.516028 27.601028 
-C 719.448306 25.668751 720.534 23.047653 720.534 20.315 
-C 720.534 17.582347 719.448306 14.961249 717.516028 13.028972 
-C 715.583751 11.096694 712.962653 10.011 710.23 10.011 
-C 707.497347 10.011 704.876249 11.096694 702.943972 13.028972 
-C 701.011694 14.961249 699.926 17.582347 699.926 20.315 
-C 699.926 23.047653 701.011694 25.668751 702.943972 27.601028 
-C 704.876249 29.533306 707.497347 30.619 710.23 30.619 
+    <path d="M 710.23 30.619
+C 712.962653 30.619 715.583751 29.533306 717.516028 27.601028
+C 719.448306 25.668751 720.534 23.047653 720.534 20.315
+C 720.534 17.582347 719.448306 14.961249 717.516028 13.028972
+C 715.583751 11.096694 712.962653 10.011 710.23 10.011
+C 707.497347 10.011 704.876249 11.096694 702.943972 13.028972
+C 701.011694 14.961249 699.926 17.582347 699.926 20.315
+C 699.926 23.047653 701.011694 25.668751 702.943972 27.601028
+C 704.876249 29.533306 707.497347 30.619 710.23 30.619
 z
 " style="fill: #9c4f2f; stroke: #1f1e1b; stroke-linejoin: miter"/>
    </g>
@@ -657,55 +656,55 @@ z
     <text style="font-size: 32px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="734.23" y="31.515" transform="rotate(-0 734.23 31.515)">CDS only (0 / 100)</text>
    </g>
    <g id="line2d_33">
-    <path d="M 593.43 71.5175 
-L 687.83 71.5175 
+    <path d="M 593.43 71.5175
+L 687.83 71.5175
 " style="fill: none; stroke: #915234; stroke-width: 4.5"/>
    </g>
    <g id="line2d_34">
     <defs>
-     <path id="m0a7dbb143b" d="M 0 7 
-C 1.856422 7 3.637059 6.262436 4.949747 4.949747 
-C 6.262436 3.637059 7 1.856422 7 0 
-C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747 
-C 3.637059 -6.262436 1.856422 -7 0 -7 
-C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747 
-C -6.262436 -3.637059 -7 -1.856422 -7 0 
-C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747 
-C -3.637059 6.262436 -1.856422 7 0 7 
+     <path id="m160f305d2f" d="M 0 7
+C 1.856422 7 3.637059 6.262436 4.949747 4.949747
+C 6.262436 3.637059 7 1.856422 7 0
+C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747
+C 3.637059 -6.262436 1.856422 -7 0 -7
+C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747
+C -6.262436 -3.637059 -7 -1.856422 -7 0
+C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747
+C -3.637059 6.262436 -1.856422 7 0 7
 z
 " style="stroke: #1f1e1b"/>
     </defs>
     <g>
-     <use xlink:href="#m0a7dbb143b" x="640.63" y="71.5175" style="fill: #915234; stroke: #1f1e1b"/>
+     <use xlink:href="#m160f305d2f" x="640.63" y="71.5175" style="fill: #915234; stroke: #1f1e1b"/>
     </g>
    </g>
    <g id="patch_15">
-    <path d="M 716.286539 63.181389 
-C 715.411793 62.545848 714.442437 62.051937 713.414111 61.717814 
-C 712.385785 61.38369 711.311246 61.2135 710.23 61.2135 
-L 710.23 71.5175 
+    <path d="M 716.286539 63.181389
+C 715.411793 62.545848 714.442437 62.051937 713.414111 61.717814
+C 712.385785 61.38369 711.311246 61.2135 710.23 61.2135
+L 710.23 71.5175
 z
 " style="fill: #2f6f63; stroke: #1f1e1b; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 710.23 61.2135 
-C 709.012938 61.2135 707.805447 61.429131 706.66361 61.850376 
-C 705.521773 62.271622 704.463548 62.891859 703.538087 63.682277 
-C 702.612626 64.472695 701.834483 65.420865 701.239801 66.482747 
-C 700.645119 67.544628 700.24325 68.703522 700.052859 69.905599 
-C 699.862469 71.107677 699.886552 72.334035 700.123988 73.527711 
-C 700.361425 74.721387 700.808483 75.86361 701.444396 76.901325 
-C 702.080309 77.939041 702.895077 78.85593 703.850856 79.609406 
-C 704.806635 80.362881 705.888394 80.941094 707.045889 81.317186 
-C 708.203383 81.693279 709.41841 81.861338 710.634533 81.813556 
-C 711.850656 81.765774 713.048752 81.502904 714.17317 81.037155 
-C 715.297588 80.571405 716.330647 79.910101 717.224363 79.083959 
-C 718.118079 78.257817 718.858397 77.279828 719.410931 76.195418 
-C 719.963466 75.111008 720.319527 73.937231 720.462577 72.728605 
-C 720.605628 71.51998 720.533417 70.295513 720.2493 69.112079 
-C 719.965182 67.928645 719.473626 66.804854 718.797463 65.792904 
-C 718.1213 64.780955 717.271163 63.89676 716.286539 63.181389 
-L 710.23 71.5175 
+    <path d="M 710.23 61.2135
+C 709.012938 61.2135 707.805447 61.429131 706.66361 61.850376
+C 705.521773 62.271622 704.463548 62.891859 703.538087 63.682277
+C 702.612626 64.472695 701.834483 65.420865 701.239801 66.482747
+C 700.645119 67.544628 700.24325 68.703522 700.052859 69.905599
+C 699.862469 71.107677 699.886552 72.334035 700.123988 73.527711
+C 700.361425 74.721387 700.808483 75.86361 701.444396 76.901325
+C 702.080309 77.939041 702.895077 78.85593 703.850856 79.609406
+C 704.806635 80.362881 705.888394 80.941094 707.045889 81.317186
+C 708.203383 81.693279 709.41841 81.861338 710.634533 81.813556
+C 711.850656 81.765774 713.048752 81.502904 714.17317 81.037155
+C 715.297588 80.571405 716.330647 79.910101 717.224363 79.083959
+C 718.118079 78.257817 718.858397 77.279828 719.410931 76.195418
+C 719.963466 75.111008 720.319527 73.937231 720.462577 72.728605
+C 720.605628 71.51998 720.533417 70.295513 720.2493 69.112079
+C 719.965182 67.928645 719.473626 66.804854 718.797463 65.792904
+C 718.1213 64.780955 717.271163 63.89676 716.286539 63.181389
+L 710.23 71.5175
 z
 " style="fill: #9c4f2f; stroke: #1f1e1b; stroke-linejoin: miter"/>
    </g>
@@ -715,13 +714,13 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pa36f06a881">
+  <clipPath id="p476047d22a">
    <rect x="133.155" y="169.04" width="270" height="243.36"/>
   </clipPath>
-  <clipPath id="p380055d614">
+  <clipPath id="p4b0f06d37b">
    <rect x="478.755" y="169.04" width="270" height="243.36"/>
   </clipPath>
-  <clipPath id="p9e73f7f15d">
+  <clipPath id="p7ad8b8c711">
    <rect x="824.355" y="169.04" width="270" height="243.36"/>
   </clipPath>
  </defs>

--- a/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/upstream_cds_balance.svg
+++ b/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/upstream_cds_balance.svg
@@ -1,0 +1,728 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="1151.91pt" height="486.602344pt" viewBox="0 0 1151.91 486.602344" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-07-22T15:03:22.582864</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.0rc1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 486.602344 
+L 1151.91 486.602344 
+L 1151.91 0 
+L 0 0 
+L 0 486.602344 
+z
+" style="fill: none"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 133.155 412.4 
+L 403.155 412.4 
+L 403.155 169.04 
+L 133.155 169.04 
+L 133.155 412.4 
+z
+" style="fill: none"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m7cfde82107" d="M 0 0 
+L 0 3.5 
+" style="stroke: #1f1e1b; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m7cfde82107" x="243.609545" y="412.4" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <text style="font-size: 26px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="243.609545" y="439.153906" transform="rotate(-0 243.609545 439.153906)">10000</text>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m7cfde82107" x="366.336818" y="412.4" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <text style="font-size: 26px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="366.336818" y="439.153906" transform="rotate(-0 366.336818 439.153906)">20000</text>
+     </g>
+    </g>
+    <g id="text_3">
+     <text style="font-size: 30px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="268.155" y="472.195312" transform="rotate(-0 268.155 472.195312)">training step</text>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_3">
+      <defs>
+       <path id="m1139d3fbf8" d="M 0 0 
+L -3.5 0 
+" style="stroke: #1f1e1b; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m1139d3fbf8" x="133.155" y="393.761141" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <text style="font-size: 26px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="126.155" y="403.638094" transform="rotate(-0 126.155 403.638094)">10</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m1139d3fbf8" x="133.155" y="324.377128" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <text style="font-size: 26px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="126.155" y="334.254081" transform="rotate(-0 126.155 334.254081)">20</text>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m1139d3fbf8" x="133.155" y="254.993114" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <text style="font-size: 26px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="126.155" y="264.870068" transform="rotate(-0 126.155 264.870068)">30</text>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m1139d3fbf8" x="133.155" y="185.609101" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <text style="font-size: 26px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="126.155" y="195.486054" transform="rotate(-0 126.155 195.486054)">40</text>
+     </g>
+    </g>
+    <g id="text_8">
+     <text style="font-size: 30px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="81.862969" y="290.72" transform="rotate(-90 81.862969 290.72)">AUPRC (%)</text>
+    </g>
+   </g>
+   <g id="line2d_7">
+    <path d="M 145.427727 365.324903 
+L 194.518636 340.718867 
+L 243.609545 245.185621 
+L 292.700455 180.471209 
+L 341.791364 186.711541 
+L 390.882273 180.101818 
+" clip-path="url(#pa36f06a881)" style="fill: none; stroke: #2f6f63; stroke-width: 4.5; stroke-linecap: square"/>
+    <defs>
+     <path id="mfe7c99169d" d="M 0 7 
+C 1.856422 7 3.637059 6.262436 4.949747 4.949747 
+C 6.262436 3.637059 7 1.856422 7 0 
+C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747 
+C 3.637059 -6.262436 1.856422 -7 0 -7 
+C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747 
+C -6.262436 -3.637059 -7 -1.856422 -7 0 
+C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747 
+C -3.637059 6.262436 -1.856422 7 0 7 
+z
+" style="stroke: #2f6f63"/>
+    </defs>
+    <g clip-path="url(#pa36f06a881)">
+     <use xlink:href="#mfe7c99169d" x="145.427727" y="365.324903" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#mfe7c99169d" x="194.518636" y="340.718867" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#mfe7c99169d" x="243.609545" y="245.185621" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#mfe7c99169d" x="292.700455" y="180.471209" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#mfe7c99169d" x="341.791364" y="186.711541" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#mfe7c99169d" x="390.882273" y="180.101818" style="fill: #2f6f63; stroke: #2f6f63"/>
+    </g>
+   </g>
+   <g id="line2d_8">
+    <path d="M 145.427727 382.363733 
+L 194.518636 374.950288 
+L 243.609545 363.22399 
+L 292.700455 317.870447 
+L 341.791364 298.096246 
+L 390.882273 271.661529 
+" clip-path="url(#pa36f06a881)" style="fill: none; stroke: #665f49; stroke-width: 4.5; stroke-linecap: square"/>
+    <defs>
+     <path id="ma3c65260e4" d="M 0 7 
+C 1.856422 7 3.637059 6.262436 4.949747 4.949747 
+C 6.262436 3.637059 7 1.856422 7 0 
+C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747 
+C 3.637059 -6.262436 1.856422 -7 0 -7 
+C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747 
+C -6.262436 -3.637059 -7 -1.856422 -7 0 
+C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747 
+C -3.637059 6.262436 -1.856422 7 0 7 
+z
+" style="stroke: #665f49"/>
+    </defs>
+    <g clip-path="url(#pa36f06a881)">
+     <use xlink:href="#ma3c65260e4" x="145.427727" y="382.363733" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#ma3c65260e4" x="194.518636" y="374.950288" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#ma3c65260e4" x="243.609545" y="363.22399" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#ma3c65260e4" x="292.700455" y="317.870447" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#ma3c65260e4" x="341.791364" y="298.096246" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#ma3c65260e4" x="390.882273" y="271.661529" style="fill: #665f49; stroke: #665f49"/>
+    </g>
+   </g>
+   <g id="line2d_9">
+    <path d="M 145.427727 391.802965 
+L 194.518636 388.986351 
+L 243.609545 381.950292 
+L 292.700455 381.123926 
+L 341.791364 381.165552 
+L 390.882273 374.627226 
+" clip-path="url(#pa36f06a881)" style="fill: none; stroke: #915234; stroke-width: 4.5; stroke-linecap: square"/>
+    <defs>
+     <path id="m4782c62b45" d="M 0 7 
+C 1.856422 7 3.637059 6.262436 4.949747 4.949747 
+C 6.262436 3.637059 7 1.856422 7 0 
+C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747 
+C 3.637059 -6.262436 1.856422 -7 0 -7 
+C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747 
+C -6.262436 -3.637059 -7 -1.856422 -7 0 
+C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747 
+C -3.637059 6.262436 -1.856422 7 0 7 
+z
+" style="stroke: #915234"/>
+    </defs>
+    <g clip-path="url(#pa36f06a881)">
+     <use xlink:href="#m4782c62b45" x="145.427727" y="391.802965" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m4782c62b45" x="194.518636" y="388.986351" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m4782c62b45" x="243.609545" y="381.950292" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m4782c62b45" x="292.700455" y="381.123926" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m4782c62b45" x="341.791364" y="381.165552" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m4782c62b45" x="390.882273" y="374.627226" style="fill: #915234; stroke: #915234"/>
+    </g>
+   </g>
+   <g id="line2d_10">
+    <path d="M 145.427727 401.338182 
+L 194.518636 386.36322 
+L 243.609545 392.483394 
+L 292.700455 388.406399 
+L 341.791364 387.235191 
+L 390.882273 380.870269 
+" clip-path="url(#pa36f06a881)" style="fill: none; stroke: #9c4f2f; stroke-width: 4.5; stroke-linecap: square"/>
+    <defs>
+     <path id="m7045e8590f" d="M 0 7 
+C 1.856422 7 3.637059 6.262436 4.949747 4.949747 
+C 6.262436 3.637059 7 1.856422 7 0 
+C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747 
+C 3.637059 -6.262436 1.856422 -7 0 -7 
+C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747 
+C -6.262436 -3.637059 -7 -1.856422 -7 0 
+C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747 
+C -3.637059 6.262436 -1.856422 7 0 7 
+z
+" style="stroke: #9c4f2f"/>
+    </defs>
+    <g clip-path="url(#pa36f06a881)">
+     <use xlink:href="#m7045e8590f" x="145.427727" y="401.338182" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#m7045e8590f" x="194.518636" y="386.36322" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#m7045e8590f" x="243.609545" y="392.483394" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#m7045e8590f" x="292.700455" y="388.406399" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#m7045e8590f" x="341.791364" y="387.235191" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#m7045e8590f" x="390.882273" y="380.870269" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 133.155 412.4 
+L 133.155 169.04 
+" style="fill: none; stroke: #1f1e1b; stroke-width: 1.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 133.155 412.4 
+L 403.155 412.4 
+" style="fill: none; stroke: #1f1e1b; stroke-width: 1.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_9">
+    <text style="font-weight: 700; font-size: 32px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #2f6f63" x="268.155" y="161.3525" transform="rotate(-0 268.155 161.3525)">Promoter</text>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_5">
+    <path d="M 478.755 412.4 
+L 748.755 412.4 
+L 748.755 169.04 
+L 478.755 169.04 
+L 478.755 412.4 
+z
+" style="fill: none"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_3">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m7cfde82107" x="589.209545" y="412.4" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <text style="font-size: 26px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="589.209545" y="439.153906" transform="rotate(-0 589.209545 439.153906)">10000</text>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m7cfde82107" x="711.936818" y="412.4" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <text style="font-size: 26px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="711.936818" y="439.153906" transform="rotate(-0 711.936818 439.153906)">20000</text>
+     </g>
+    </g>
+    <g id="text_12">
+     <text style="font-size: 30px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="613.755" y="472.195312" transform="rotate(-0 613.755 472.195312)">training step</text>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_5">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m1139d3fbf8" x="478.755" y="350.532546" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <text style="font-size: 26px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="471.755" y="360.409499" transform="rotate(-0 471.755 360.409499)">20</text>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m1139d3fbf8" x="478.755" y="237.994695" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <text style="font-size: 26px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="471.755" y="247.871648" transform="rotate(-0 471.755 247.871648)">40</text>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_15">
+    <path d="M 491.027727 401.338182 
+L 540.118636 384.21011 
+L 589.209545 375.49411 
+L 638.300455 376.270039 
+L 687.391364 369.718464 
+L 736.482273 371.939513 
+" clip-path="url(#p380055d614)" style="fill: none; stroke: #2f6f63; stroke-width: 4.5; stroke-linecap: square"/>
+    <g clip-path="url(#p380055d614)">
+     <use xlink:href="#mfe7c99169d" x="491.027727" y="401.338182" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#mfe7c99169d" x="540.118636" y="384.21011" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#mfe7c99169d" x="589.209545" y="375.49411" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#mfe7c99169d" x="638.300455" y="376.270039" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#mfe7c99169d" x="687.391364" y="369.718464" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#mfe7c99169d" x="736.482273" y="371.939513" style="fill: #2f6f63; stroke: #2f6f63"/>
+    </g>
+   </g>
+   <g id="line2d_16">
+    <path d="M 491.027727 387.066653 
+L 540.118636 312.784497 
+L 589.209545 263.218138 
+L 638.300455 221.731686 
+L 687.391364 201.937128 
+L 736.482273 199.161616 
+" clip-path="url(#p380055d614)" style="fill: none; stroke: #665f49; stroke-width: 4.5; stroke-linecap: square"/>
+    <g clip-path="url(#p380055d614)">
+     <use xlink:href="#ma3c65260e4" x="491.027727" y="387.066653" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#ma3c65260e4" x="540.118636" y="312.784497" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#ma3c65260e4" x="589.209545" y="263.218138" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#ma3c65260e4" x="638.300455" y="221.731686" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#ma3c65260e4" x="687.391364" y="201.937128" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#ma3c65260e4" x="736.482273" y="199.161616" style="fill: #665f49; stroke: #665f49"/>
+    </g>
+   </g>
+   <g id="line2d_17">
+    <path d="M 491.027727 372.354234 
+L 540.118636 248.709108 
+L 589.209545 202.199374 
+L 638.300455 188.746777 
+L 687.391364 186.184894 
+L 736.482273 186.913865 
+" clip-path="url(#p380055d614)" style="fill: none; stroke: #915234; stroke-width: 4.5; stroke-linecap: square"/>
+    <g clip-path="url(#p380055d614)">
+     <use xlink:href="#m4782c62b45" x="491.027727" y="372.354234" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m4782c62b45" x="540.118636" y="248.709108" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m4782c62b45" x="589.209545" y="202.199374" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m4782c62b45" x="638.300455" y="188.746777" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m4782c62b45" x="687.391364" y="186.184894" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m4782c62b45" x="736.482273" y="186.913865" style="fill: #915234; stroke: #915234"/>
+    </g>
+   </g>
+   <g id="line2d_18">
+    <path d="M 491.027727 371.709107 
+L 540.118636 242.931223 
+L 589.209545 193.412062 
+L 638.300455 197.990587 
+L 687.391364 180.101818 
+L 736.482273 193.93361 
+" clip-path="url(#p380055d614)" style="fill: none; stroke: #9c4f2f; stroke-width: 4.5; stroke-linecap: square"/>
+    <g clip-path="url(#p380055d614)">
+     <use xlink:href="#m7045e8590f" x="491.027727" y="371.709107" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#m7045e8590f" x="540.118636" y="242.931223" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#m7045e8590f" x="589.209545" y="193.412062" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#m7045e8590f" x="638.300455" y="197.990587" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#m7045e8590f" x="687.391364" y="180.101818" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#m7045e8590f" x="736.482273" y="193.93361" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 478.755 412.4 
+L 478.755 169.04 
+" style="fill: none; stroke: #1f1e1b; stroke-width: 1.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 478.755 412.4 
+L 748.755 412.4 
+" style="fill: none; stroke: #1f1e1b; stroke-width: 1.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_15">
+    <text style="font-weight: 700; font-size: 32px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #9c4f2f" x="613.755" y="161.3525" transform="rotate(-0 613.755 161.3525)">Missense</text>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_8">
+    <path d="M 824.355 412.4 
+L 1094.355 412.4 
+L 1094.355 169.04 
+L 824.355 169.04 
+L 824.355 412.4 
+z
+" style="fill: none"/>
+   </g>
+   <g id="matplotlib.axis_5">
+    <g id="xtick_5">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m7cfde82107" x="934.809545" y="412.4" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <text style="font-size: 26px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="934.809545" y="439.153906" transform="rotate(-0 934.809545 439.153906)">10000</text>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m7cfde82107" x="1057.536818" y="412.4" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <text style="font-size: 26px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="1057.536818" y="439.153906" transform="rotate(-0 1057.536818 439.153906)">20000</text>
+     </g>
+    </g>
+    <g id="text_18">
+     <text style="font-size: 30px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="959.355" y="472.195312" transform="rotate(-0 959.355 472.195312)">training step</text>
+    </g>
+   </g>
+   <g id="matplotlib.axis_6">
+    <g id="ytick_7">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m1139d3fbf8" x="824.355" y="334.511705" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <text style="font-size: 26px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="817.355" y="344.388658" transform="rotate(-0 817.355 344.388658)">20</text>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m1139d3fbf8" x="824.355" y="244.996118" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <text style="font-size: 26px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #1f1e1b" x="817.355" y="254.873071" transform="rotate(-0 817.355 254.873071)">30</text>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_23">
+    <path d="M 836.627727 401.338182 
+L 885.718636 371.841356 
+L 934.809545 303.282446 
+L 983.900455 262.154083 
+L 1032.991364 260.96826 
+L 1082.082273 258.471184 
+" clip-path="url(#p9e73f7f15d)" style="fill: none; stroke: #2f6f63; stroke-width: 4.5; stroke-linecap: square"/>
+    <g clip-path="url(#p9e73f7f15d)">
+     <use xlink:href="#mfe7c99169d" x="836.627727" y="401.338182" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#mfe7c99169d" x="885.718636" y="371.841356" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#mfe7c99169d" x="934.809545" y="303.282446" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#mfe7c99169d" x="983.900455" y="262.154083" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#mfe7c99169d" x="1032.991364" y="260.96826" style="fill: #2f6f63; stroke: #2f6f63"/>
+     <use xlink:href="#mfe7c99169d" x="1082.082273" y="258.471184" style="fill: #2f6f63; stroke: #2f6f63"/>
+    </g>
+   </g>
+   <g id="line2d_24">
+    <path d="M 836.627727 400.977529 
+L 885.718636 337.109316 
+L 934.809545 290.118597 
+L 983.900455 227.862802 
+L 1032.991364 199.361871 
+L 1082.082273 180.101818 
+" clip-path="url(#p9e73f7f15d)" style="fill: none; stroke: #665f49; stroke-width: 4.5; stroke-linecap: square"/>
+    <g clip-path="url(#p9e73f7f15d)">
+     <use xlink:href="#ma3c65260e4" x="836.627727" y="400.977529" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#ma3c65260e4" x="885.718636" y="337.109316" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#ma3c65260e4" x="934.809545" y="290.118597" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#ma3c65260e4" x="983.900455" y="227.862802" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#ma3c65260e4" x="1032.991364" y="199.361871" style="fill: #665f49; stroke: #665f49"/>
+     <use xlink:href="#ma3c65260e4" x="1082.082273" y="180.101818" style="fill: #665f49; stroke: #665f49"/>
+    </g>
+   </g>
+   <g id="line2d_25">
+    <path d="M 836.627727 395.36388 
+L 885.718636 295.196348 
+L 934.809545 253.662498 
+L 983.900455 242.428879 
+L 1032.991364 240.417942 
+L 1082.082273 236.780083 
+" clip-path="url(#p9e73f7f15d)" style="fill: none; stroke: #915234; stroke-width: 4.5; stroke-linecap: square"/>
+    <g clip-path="url(#p9e73f7f15d)">
+     <use xlink:href="#m4782c62b45" x="836.627727" y="395.36388" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m4782c62b45" x="885.718636" y="295.196348" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m4782c62b45" x="934.809545" y="253.662498" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m4782c62b45" x="983.900455" y="242.428879" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m4782c62b45" x="1032.991364" y="240.417942" style="fill: #915234; stroke: #915234"/>
+     <use xlink:href="#m4782c62b45" x="1082.082273" y="236.780083" style="fill: #915234; stroke: #915234"/>
+    </g>
+   </g>
+   <g id="line2d_26">
+    <path d="M 836.627727 401.001645 
+L 885.718636 288.908353 
+L 934.809545 253.467463 
+L 983.900455 254.479382 
+L 1032.991364 239.494666 
+L 1082.082273 246.390996 
+" clip-path="url(#p9e73f7f15d)" style="fill: none; stroke: #9c4f2f; stroke-width: 4.5; stroke-linecap: square"/>
+    <g clip-path="url(#p9e73f7f15d)">
+     <use xlink:href="#m7045e8590f" x="836.627727" y="401.001645" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#m7045e8590f" x="885.718636" y="288.908353" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#m7045e8590f" x="934.809545" y="253.467463" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#m7045e8590f" x="983.900455" y="254.479382" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#m7045e8590f" x="1032.991364" y="239.494666" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+     <use xlink:href="#m7045e8590f" x="1082.082273" y="246.390996" style="fill: #9c4f2f; stroke: #9c4f2f"/>
+    </g>
+   </g>
+   <g id="patch_9">
+    <path d="M 824.355 412.4 
+L 824.355 169.04 
+" style="fill: none; stroke: #1f1e1b; stroke-width: 1.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 824.355 412.4 
+L 1094.355 412.4 
+" style="fill: none; stroke: #1f1e1b; stroke-width: 1.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_21">
+    <text style="font-weight: 700; font-size: 32px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle; fill: #1f1e1b" x="959.355" y="161.3525" transform="rotate(-0 959.355 161.3525)">Mean of both</text>
+   </g>
+  </g>
+  <g id="legend_1">
+   <g id="line2d_27">
+    <path d="M 7.2 20.315 
+L 101.6 20.315 
+" style="fill: none; stroke: #2f6f63; stroke-width: 4.5"/>
+   </g>
+   <g id="line2d_28">
+    <defs>
+     <path id="m870e30f926" d="M 0 7 
+C 1.856422 7 3.637059 6.262436 4.949747 4.949747 
+C 6.262436 3.637059 7 1.856422 7 0 
+C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747 
+C 3.637059 -6.262436 1.856422 -7 0 -7 
+C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747 
+C -6.262436 -3.637059 -7 -1.856422 -7 0 
+C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747 
+C -3.637059 6.262436 -1.856422 7 0 7 
+z
+" style="stroke: #1f1e1b"/>
+    </defs>
+    <g>
+     <use xlink:href="#m870e30f926" x="54.4" y="20.315" style="fill: #2f6f63; stroke: #1f1e1b"/>
+    </g>
+   </g>
+   <g id="patch_11">
+    <path d="M 124 30.619 
+C 126.732653 30.619 129.353751 29.533306 131.286028 27.601028 
+C 133.218306 25.668751 134.304 23.047653 134.304 20.315 
+C 134.304 17.582347 133.218306 14.961249 131.286028 13.028972 
+C 129.353751 11.096694 126.732653 10.011 124 10.011 
+C 121.267347 10.011 118.646249 11.096694 116.713972 13.028972 
+C 114.781694 14.961249 113.696 17.582347 113.696 20.315 
+C 113.696 23.047653 114.781694 25.668751 116.713972 27.601028 
+C 118.646249 29.533306 121.267347 30.619 124 30.619 
+z
+" style="fill: #2f6f63; stroke: #1f1e1b; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_22">
+    <text style="font-size: 32px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="148" y="31.515" transform="rotate(-0 148 31.515)">Upstream only (100 / 0)</text>
+   </g>
+   <g id="line2d_29">
+    <path d="M 7.2 71.5175 
+L 101.6 71.5175 
+" style="fill: none; stroke: #665f49; stroke-width: 4.5"/>
+   </g>
+   <g id="line2d_30">
+    <defs>
+     <path id="mf8d856e0a4" d="M 0 7 
+C 1.856422 7 3.637059 6.262436 4.949747 4.949747 
+C 6.262436 3.637059 7 1.856422 7 0 
+C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747 
+C 3.637059 -6.262436 1.856422 -7 0 -7 
+C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747 
+C -6.262436 -3.637059 -7 -1.856422 -7 0 
+C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747 
+C -3.637059 6.262436 -1.856422 7 0 7 
+z
+" style="stroke: #1f1e1b"/>
+    </defs>
+    <g>
+     <use xlink:href="#mf8d856e0a4" x="54.4" y="71.5175" style="fill: #665f49; stroke: #1f1e1b"/>
+    </g>
+   </g>
+   <g id="patch_12">
+    <path d="M 124 81.8215 
+C 126.731743 81.8215 129.354395 80.735162 131.286028 78.803528 
+C 133.217662 76.871895 134.304 74.249243 134.304 71.5175 
+C 134.304 68.785757 133.217662 66.163105 131.286028 64.231472 
+C 129.354395 62.299838 126.731743 61.2135 124 61.2135 
+L 124 71.5175 
+z
+" style="fill: #2f6f63; stroke: #1f1e1b; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 124 61.2135 
+C 121.268257 61.2135 118.645605 62.299838 116.713972 64.231472 
+C 114.782338 66.163105 113.696 68.785757 113.696 71.5175 
+C 113.696 74.249243 114.782338 76.871895 116.713972 78.803528 
+C 118.645605 80.735162 121.268257 81.8215 124 81.8215 
+L 124 71.5175 
+z
+" style="fill: #9c4f2f; stroke: #1f1e1b; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_23">
+    <text style="font-size: 32px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="148" y="82.7175" transform="rotate(-0 148 82.7175)">Uniform mix (50 / 50)</text>
+   </g>
+   <g id="line2d_31">
+    <path d="M 593.43 20.315 
+L 687.83 20.315 
+" style="fill: none; stroke: #9c4f2f; stroke-width: 4.5"/>
+   </g>
+   <g id="line2d_32">
+    <defs>
+     <path id="mbb770798ff" d="M 0 7 
+C 1.856422 7 3.637059 6.262436 4.949747 4.949747 
+C 6.262436 3.637059 7 1.856422 7 0 
+C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747 
+C 3.637059 -6.262436 1.856422 -7 0 -7 
+C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747 
+C -6.262436 -3.637059 -7 -1.856422 -7 0 
+C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747 
+C -3.637059 6.262436 -1.856422 7 0 7 
+z
+" style="stroke: #1f1e1b"/>
+    </defs>
+    <g>
+     <use xlink:href="#mbb770798ff" x="640.63" y="20.315" style="fill: #9c4f2f; stroke: #1f1e1b"/>
+    </g>
+   </g>
+   <g id="patch_14">
+    <path d="M 710.23 30.619 
+C 712.962653 30.619 715.583751 29.533306 717.516028 27.601028 
+C 719.448306 25.668751 720.534 23.047653 720.534 20.315 
+C 720.534 17.582347 719.448306 14.961249 717.516028 13.028972 
+C 715.583751 11.096694 712.962653 10.011 710.23 10.011 
+C 707.497347 10.011 704.876249 11.096694 702.943972 13.028972 
+C 701.011694 14.961249 699.926 17.582347 699.926 20.315 
+C 699.926 23.047653 701.011694 25.668751 702.943972 27.601028 
+C 704.876249 29.533306 707.497347 30.619 710.23 30.619 
+z
+" style="fill: #9c4f2f; stroke: #1f1e1b; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_24">
+    <text style="font-size: 32px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="734.23" y="31.515" transform="rotate(-0 734.23 31.515)">CDS only (0 / 100)</text>
+   </g>
+   <g id="line2d_33">
+    <path d="M 593.43 71.5175 
+L 687.83 71.5175 
+" style="fill: none; stroke: #915234; stroke-width: 4.5"/>
+   </g>
+   <g id="line2d_34">
+    <defs>
+     <path id="m0a7dbb143b" d="M 0 7 
+C 1.856422 7 3.637059 6.262436 4.949747 4.949747 
+C 6.262436 3.637059 7 1.856422 7 0 
+C 7 -1.856422 6.262436 -3.637059 4.949747 -4.949747 
+C 3.637059 -6.262436 1.856422 -7 0 -7 
+C -1.856422 -7 -3.637059 -6.262436 -4.949747 -4.949747 
+C -6.262436 -3.637059 -7 -1.856422 -7 0 
+C -7 1.856422 -6.262436 3.637059 -4.949747 4.949747 
+C -3.637059 6.262436 -1.856422 7 0 7 
+z
+" style="stroke: #1f1e1b"/>
+    </defs>
+    <g>
+     <use xlink:href="#m0a7dbb143b" x="640.63" y="71.5175" style="fill: #915234; stroke: #1f1e1b"/>
+    </g>
+   </g>
+   <g id="patch_15">
+    <path d="M 716.286539 63.181389 
+C 715.411793 62.545848 714.442437 62.051937 713.414111 61.717814 
+C 712.385785 61.38369 711.311246 61.2135 710.23 61.2135 
+L 710.23 71.5175 
+z
+" style="fill: #2f6f63; stroke: #1f1e1b; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 710.23 61.2135 
+C 709.012938 61.2135 707.805447 61.429131 706.66361 61.850376 
+C 705.521773 62.271622 704.463548 62.891859 703.538087 63.682277 
+C 702.612626 64.472695 701.834483 65.420865 701.239801 66.482747 
+C 700.645119 67.544628 700.24325 68.703522 700.052859 69.905599 
+C 699.862469 71.107677 699.886552 72.334035 700.123988 73.527711 
+C 700.361425 74.721387 700.808483 75.86361 701.444396 76.901325 
+C 702.080309 77.939041 702.895077 78.85593 703.850856 79.609406 
+C 704.806635 80.362881 705.888394 80.941094 707.045889 81.317186 
+C 708.203383 81.693279 709.41841 81.861338 710.634533 81.813556 
+C 711.850656 81.765774 713.048752 81.502904 714.17317 81.037155 
+C 715.297588 80.571405 716.330647 79.910101 717.224363 79.083959 
+C 718.118079 78.257817 718.858397 77.279828 719.410931 76.195418 
+C 719.963466 75.111008 720.319527 73.937231 720.462577 72.728605 
+C 720.605628 71.51998 720.533417 70.295513 720.2493 69.112079 
+C 719.965182 67.928645 719.473626 66.804854 718.797463 65.792904 
+C 718.1213 64.780955 717.271163 63.89676 716.286539 63.181389 
+L 710.23 71.5175 
+z
+" style="fill: #9c4f2f; stroke: #1f1e1b; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_25">
+    <text style="font-size: 32px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="734.23" y="82.7175" transform="rotate(-0 734.23 82.7175)">Proportional mix (10 / 90)</text>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pa36f06a881">
+   <rect x="133.155" y="169.04" width="270" height="243.36"/>
+  </clipPath>
+  <clipPath id="p380055d614">
+   <rect x="478.755" y="169.04" width="270" height="243.36"/>
+  </clipPath>
+  <clipPath id="p9e73f7f15d">
+   <rect x="824.355" y="169.04" width="270" height="243.36"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/plots/upstream_cds_balance.py
+++ b/plots/upstream_cds_balance.py
@@ -204,6 +204,7 @@ def apply_style() -> None:
     mpl.rcParams.update(
         {
             "svg.fonttype": "none",
+            "svg.hashsalt": Path(__file__).stem,
             "font.family": "sans-serif",
             "font.size": 18,
             "axes.titlesize": 22,
@@ -366,7 +367,14 @@ def main() -> None:
     BLOG_SVG.parent.mkdir(parents=True, exist_ok=True)
     outputs = (OUTPUT_DIR / "figure.svg", OUTPUT_DIR / "figure.png", BLOG_SVG)
     for output in outputs:
-        figure.savefig(output, dpi=180, bbox_inches="tight")
+        metadata = {"Date": None} if output.suffix == ".svg" else None
+        figure.savefig(output, dpi=180, bbox_inches="tight", metadata=metadata)
+        if output.suffix == ".svg":
+            svg = output.read_text(encoding="utf-8")
+            output.write_text(
+                "\n".join(line.rstrip() for line in svg.splitlines()) + "\n",
+                encoding="utf-8",
+            )
         print(f"wrote {output}")
     plt.close(figure)
 

--- a/plots/upstream_cds_balance.py
+++ b/plots/upstream_cds_balance.py
@@ -1,0 +1,375 @@
+"""Plot equal-step trajectories for the upstream x CDS mixture experiment.
+
+The four arms are Qwen3 1B models trained on 100% upstream sequence, a
+balanced 50/50 upstream/CDS mixture, the dataset-proportional 10/90 mixture,
+or 100% CDS. Only checkpoints available in every arm are plotted, so each
+vertical slice is an equal-training-step comparison.
+
+The historical run names use "promoter"; public-facing labels use "upstream"
+to match the blog's dataset terminology.
+
+Run:
+    uv run python plots/upstream_cds_balance.py
+
+Outputs:
+    plots/output/upstream_cds_balance/figure.{svg,png}
+    blog/genomic-lm-optimization/static/assets/images/blog/
+        genomic-lm-optimization/upstream_cds_balance.svg
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import polars as pl
+from matplotlib.legend_handler import HandlerBase
+from matplotlib.lines import Line2D
+from matplotlib.patches import Circle, Wedge
+
+
+class Arm(NamedTuple):
+    prefix: str
+    label: str
+    upstream_fraction: float
+    steps: tuple[int, ...]
+
+
+ARMS: dict[str, Arm] = {
+    "upstream_only": Arm(
+        prefix="exp21-promoters-yolo",
+        label="Upstream only (100 / 0)",
+        upstream_fraction=1.0,
+        steps=(2000, 6000, 10000, 12000, 14000, 16000, 18000, 20000, 22000),
+    ),
+    "balanced": Arm(
+        prefix="exp13-mixture-equal",
+        label="Uniform mix (50 / 50)",
+        upstream_fraction=0.5,
+        steps=(2000, 6000, 10000, 14000, 18000, 22000, 26000),
+    ),
+    "proportional": Arm(
+        prefix="exp13-mixture-proportional",
+        label="Proportional mix (10 / 90)",
+        upstream_fraction=0.1,
+        steps=(2000, 6000, 10000, 14000, 18000, 22000, 26000),
+    ),
+    "cds_only": Arm(
+        prefix="exp27-cds-yolo",
+        label="CDS only (0 / 100)",
+        upstream_fraction=0.0,
+        steps=(2000, 6000, 10000, 14000, 18000, 22000, 26000, 34000),
+    ),
+}
+
+S3_BASE = "s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics"
+SCORE_TYPE = "minus_llr_avg"
+SUBSETS: dict[str, str] = {
+    "Promoter": "tss_proximal",
+    "Missense": "missense_variant",
+}
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OUTPUT_DIR = REPO_ROOT / "plots" / "output" / Path(__file__).stem
+BLOG_SVG = (
+    REPO_ROOT
+    / "blog"
+    / "genomic-lm-optimization"
+    / "static"
+    / "assets"
+    / "images"
+    / "blog"
+    / "genomic-lm-optimization"
+    / "upstream_cds_balance.svg"
+)
+
+TEXT_COLOR = "#1f1e1b"
+# Canonical issue #370 region palette: Upstream = teal, CDS = rust.
+REGION_COLORS = {"upstream": "#2f6f63", "cds": "#9c4f2f"}
+TITLE_COLORS = {
+    "Promoter": REGION_COLORS["upstream"],
+    "Missense": REGION_COLORS["cds"],
+    "Mean of both": TEXT_COLOR,
+}
+POSTER_TITLE_FS = 32
+POSTER_LABEL_FS = 30
+POSTER_TICK_FS = 26
+POSTER_LEGEND_FS = 32
+
+
+def blend_region_colors(upstream_fraction: float) -> tuple[float, float, float]:
+    """Blend the issue #370 Upstream and CDS colors by mixture fraction."""
+    assert 0.0 <= upstream_fraction <= 1.0
+    upstream = mpl.colors.to_rgb(REGION_COLORS["upstream"])
+    cds = mpl.colors.to_rgb(REGION_COLORS["cds"])
+    return tuple(
+        upstream_fraction * upstream_channel + (1.0 - upstream_fraction) * cds_channel
+        for upstream_channel, cds_channel in zip(upstream, cds, strict=True)
+    )
+
+
+class HandlerLineMarkerWithPie(HandlerBase):
+    """Draw a line marker followed by an upstream/CDS composition pie."""
+
+    def __init__(self, upstream_fraction: float, **kwargs) -> None:
+        super().__init__(**kwargs)
+        assert 0.0 <= upstream_fraction <= 1.0
+        self.upstream_fraction = upstream_fraction
+
+    def create_artists(
+        self,
+        legend,
+        orig_handle,
+        xdescent,
+        ydescent,
+        width,
+        height,
+        fontsize,
+        trans,
+    ):
+        pie_diameter = height
+        gap = 0.35 * fontsize
+        line_y = height / 2 - ydescent
+        line_x0 = -xdescent
+        line_x1 = -xdescent + width - pie_diameter - gap
+
+        color = orig_handle.get_color()
+        line = Line2D(
+            [line_x0, line_x1],
+            [line_y, line_y],
+            color=color,
+            linewidth=orig_handle.get_linewidth(),
+            solid_capstyle="butt",
+        )
+        marker = Line2D(
+            [(line_x0 + line_x1) / 2],
+            [line_y],
+            color=color,
+            marker=orig_handle.get_marker(),
+            markersize=orig_handle.get_markersize(),
+            markeredgecolor=TEXT_COLOR,
+            markeredgewidth=1.0,
+            linestyle="None",
+        )
+        line.set_transform(trans)
+        marker.set_transform(trans)
+        artists = [line, marker]
+
+        center_x = -xdescent + width - pie_diameter / 2
+        radius = pie_diameter / 2 * 0.92
+        upstream_fraction = self.upstream_fraction
+        if upstream_fraction in (0.0, 1.0):
+            region = "upstream" if upstream_fraction == 1.0 else "cds"
+            circle = Circle(
+                (center_x, line_y),
+                radius,
+                facecolor=REGION_COLORS[region],
+                edgecolor=TEXT_COLOR,
+                linewidth=1.0,
+            )
+            circle.set_transform(trans)
+            artists.append(circle)
+        else:
+            theta_top = 90.0
+            theta_start = theta_top - upstream_fraction * 360.0
+            upstream_wedge = Wedge(
+                (center_x, line_y),
+                radius,
+                theta_start,
+                theta_top,
+                facecolor=REGION_COLORS["upstream"],
+                edgecolor=TEXT_COLOR,
+                linewidth=1.0,
+            )
+            cds_wedge = Wedge(
+                (center_x, line_y),
+                radius,
+                theta_top,
+                theta_top + (1.0 - upstream_fraction) * 360.0,
+                facecolor=REGION_COLORS["cds"],
+                edgecolor=TEXT_COLOR,
+                linewidth=1.0,
+            )
+            upstream_wedge.set_transform(trans)
+            cds_wedge.set_transform(trans)
+            artists.extend((upstream_wedge, cds_wedge))
+        return artists
+
+
+def apply_style() -> None:
+    """Apply the compact Open Athena blog style used by the draft."""
+    mpl.rcParams.update(
+        {
+            "svg.fonttype": "none",
+            "font.family": "sans-serif",
+            "font.size": 18,
+            "axes.titlesize": 22,
+            "axes.labelsize": 20,
+            "axes.edgecolor": TEXT_COLOR,
+            "axes.labelcolor": TEXT_COLOR,
+            "axes.linewidth": 1.8,
+            "axes.spines.top": False,
+            "axes.spines.right": False,
+            "figure.facecolor": "none",
+            "axes.facecolor": "none",
+            "xtick.color": TEXT_COLOR,
+            "ytick.color": TEXT_COLOR,
+            "xtick.labelsize": 16,
+            "ytick.labelsize": 16,
+            "legend.frameon": False,
+            "legend.fontsize": 16,
+            "lines.linewidth": 4.5,
+            "lines.markersize": 14,
+            "savefig.facecolor": "none",
+            "savefig.transparent": True,
+        }
+    )
+
+
+def load_trajectories() -> pl.DataFrame:
+    """Load all available checkpoints for the four experiment arms."""
+    parts: list[pl.DataFrame] = []
+    missing: list[str] = []
+    total = sum(len(arm.steps) for arm in ARMS.values())
+    for arm_key, arm in ARMS.items():
+        for step in arm.steps:
+            uri = f"{S3_BASE}/{arm.prefix}-step-{step}/mendelian_traits.parquet"
+            try:
+                checkpoint = pl.read_parquet(uri)
+            except Exception as exc:
+                missing.append(f"  {arm_key} step-{step}: {exc}")
+                continue
+            parts.append(
+                checkpoint.with_columns(
+                    pl.lit(arm_key).alias("arm"),
+                    pl.lit(step).alias("step"),
+                )
+            )
+    if missing:
+        print(
+            f"WARNING: {len(missing)} of {total} parquets unreadable:\n"
+            + "\n".join(missing),
+            file=sys.stderr,
+        )
+    assert parts, "no metrics parquets loaded"
+    return pl.concat(parts)
+
+
+def shared_step_data(trajectories: pl.DataFrame) -> pl.DataFrame:
+    """Select the two focal subsets at steps represented in every arm."""
+    common_steps = set.intersection(*(set(arm.steps) for arm in ARMS.values()))
+    assert common_steps == {2000, 6000, 10000, 14000, 18000, 22000}
+
+    filtered = trajectories.filter(
+        (pl.col("score_type") == SCORE_TYPE)
+        & (pl.col("subset").is_in(list(SUBSETS.values())))
+        & (pl.col("step").is_in(sorted(common_steps)))
+    )
+    expected_rows = len(ARMS) * len(SUBSETS) * len(common_steps)
+    assert filtered.height == expected_rows, (
+        f"expected {expected_rows} arm/subset/step rows, got {filtered.height}"
+    )
+    assert filtered.select("arm", "subset", "step").unique().height == expected_rows
+    assert filtered["value"].is_not_null().all()
+    assert filtered["value"].is_between(0.0, 1.0).all()
+    return filtered
+
+
+def plot(data: pl.DataFrame) -> plt.Figure:
+    """Create upstream, missense, and two-subset-mean trajectory panels."""
+    apply_style()
+    fig, axes = plt.subplots(1, 3, figsize=(15, 6.5), sharex=True, sharey=False)
+
+    for axis, (title, subset) in zip(axes[:2], SUBSETS.items(), strict=True):
+        for arm_key, arm in ARMS.items():
+            arm_data = data.filter(
+                (pl.col("arm") == arm_key) & (pl.col("subset") == subset)
+            ).sort("step")
+            axis.plot(
+                arm_data["step"].to_numpy(),
+                arm_data["value"].to_numpy() * 100.0,
+                marker="o",
+                color=blend_region_colors(arm.upstream_fraction),
+                label=arm.label,
+            )
+        axis.set_title(
+            title,
+            color=TITLE_COLORS[title],
+            fontweight="bold",
+            fontsize=POSTER_TITLE_FS,
+        )
+
+    mean_axis = axes[2]
+    for arm_key, arm in ARMS.items():
+        arm_data = (
+            data.filter(pl.col("arm") == arm_key)
+            .group_by("step")
+            .agg(pl.col("value").mean().alias("value"))
+            .sort("step")
+        )
+        assert arm_data.height == data["step"].n_unique()
+        mean_axis.plot(
+            arm_data["step"].to_numpy(),
+            arm_data["value"].to_numpy() * 100.0,
+            marker="o",
+            color=blend_region_colors(arm.upstream_fraction),
+            label=arm.label,
+        )
+    mean_axis.set_title(
+        "Mean of both",
+        color=TITLE_COLORS["Mean of both"],
+        fontweight="bold",
+        fontsize=POSTER_TITLE_FS,
+    )
+
+    for axis in axes:
+        axis.set_xlabel("training step", fontsize=POSTER_LABEL_FS)
+        axis.tick_params(axis="both", labelsize=POSTER_TICK_FS)
+        axis.grid(False)
+    axes[0].set_ylabel("AUPRC (%)", fontsize=POSTER_LABEL_FS)
+
+    handles, labels = axes[0].get_legend_handles_labels()
+    # Matplotlib fills a two-column legend column-first. This ordering displays
+    # the two pure-region arms on the first row and the two mixtures below.
+    legend_order = (0, 1, 3, 2)
+    handler_map = {
+        handle: HandlerLineMarkerWithPie(arm.upstream_fraction)
+        for handle, arm in zip(handles, ARMS.values(), strict=True)
+    }
+    fig.legend(
+        [handles[index] for index in legend_order],
+        [labels[index] for index in legend_order],
+        handler_map=handler_map,
+        loc="upper center",
+        bbox_to_anchor=(0.5, 1.0),
+        ncol=2,
+        fontsize=POSTER_LEGEND_FS,
+        columnspacing=2.0,
+        handlelength=4.0,
+        handletextpad=0.4,
+        labelspacing=0.6,
+        borderpad=0.0,
+    )
+    fig.subplots_adjust(bottom=0.10, top=0.62, left=0.09, right=0.98, wspace=0.28)
+    return fig
+
+
+def main() -> None:
+    trajectories = load_trajectories()
+    data = shared_step_data(trajectories)
+    figure = plot(data)
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    BLOG_SVG.parent.mkdir(parents=True, exist_ok=True)
+    outputs = (OUTPUT_DIR / "figure.svg", OUTPUT_DIR / "figure.png", BLOG_SVG)
+    for output in outputs:
+        figure.savefig(output, dpi=180, bbox_inches="tight")
+        print(f"wrote {output}")
+    plt.close(figure)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_blog_workspace.py
+++ b/tests/test_blog_workspace.py
@@ -46,7 +46,7 @@ def test_edited_workspace_is_valid_and_baseline_manifest_is_readable() -> None:
     referenced_assets = validate_workspace(config)
     manifest = read_baseline_manifest(config)
 
-    assert len(referenced_assets) == 18
+    assert len(referenced_assets) == 19
     assert len(manifest) == 12
 
 


### PR DESCRIPTION
## Summary

- Adds a [reproducible upstream/CDS mixture plot recipe](https://github.com/Open-Athena/marin-dna/blob/10e997df46c40b240d36c4a7e425806efb403dbd/plots/upstream_cds_balance.py#L1-L383) and its blog SVG.
- Adds the [upstream/CDS balance discussion](https://github.com/Open-Athena/marin-dna/blob/10e997df46c40b240d36c4a7e425806efb403dbd/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md#L205-L216), explaining why pooled data naturally produces the 10/90 mixture and how 50/50 sampling balances promoter and missense performance.
- Uses the issue #370 region palette, poster-sized layout, AUPRC percentages, and region-mixture pie markers.

## Why

Dataset-proportional sampling is the naive default when upstream and CDS examples are pooled, but the result behaves similarly to CDS-only training. The comparison makes mixture control—and the possibility that equal weighting is not optimal—explicit in the optimization narrative.

## Validation

- `uv run python plots/upstream_cds_balance.py`
- Consecutive SVG generations produced the identical SHA-256 checksum.
- `uv run --no-project python src/marin_dna/blog_workspace.py validate`
- `uv run ruff check plots/upstream_cds_balance.py`
- `uv run ruff format --check plots/upstream_cds_balance.py`
- `git diff --check origin/claude/issue-373-blog-staging`
- Independent review completed with no remaining findings.

Tracks #361.
