### PR TITLE
Refresh genomic LM leaderboard figures and narrative

### DIFF
--- a/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
+++ b/blog/genomic-lm-optimization/content/blog/genomic-lm-optimization.md
@@ -377,13 +377,25 @@ m5.1's strong endpoint raises the possibility that exposure order matters: learn
 
 ### Leaderboard scores
 
-The result of the previous mixture experiments is the m5.1 model used for the headline comparison. The [Mendelian VEP leaderboard](#fig-mendelian-leaderboard) is a snapshot of the benchmark we host at [openathena.ai/marin-dna/leaderboards/mendelian](https://openathena.ai/marin-dna/leaderboards/mendelian), where we are continuing to add new experimental runs and baselines. In this snapshot, m5.1 is again just a 1B GPT-style model, but it comes out slightly ahead of Evo 2 40B on average across all variant classes.
+The result of the previous mixture experiments is m5.1, a 1B GPT-style model evaluated alongside other models on our [live Mendelian VEP leaderboard](https://openathena.ai/marin-dna/leaderboards/mendelian), where we continue to add experimental runs and baselines. In the zero-shot snapshot shown here, m5.1 comes out slightly ahead of Evo 2 40B. Its advantage is considerably larger under frozen-embedding linear probing.
 
-<!-- Plot recipe: plots/blog/genomic_lm_optimization/src/figures/figure11_leaderboard_heatmap.py -->
+Most notably, m5.1 closes Evo 2's main gap on distal enhancers, outperforming Evo 2 40B there under both readouts. The improvement is not uniform, however: Evo 2 40B remains ahead on splicing under both readouts, as well as on promoters and synonymous variants in the zero-shot evaluation and missense variants under linear probing.
+
+On the broader zero-shot leaderboard, m5.1 remains slightly behind AlphaGenome and substantially behind GPN-Star. These are different model families: AlphaGenome learns from functional-genomics supervision, while GPN-Star uses whole-genome alignments. Further improvements to the alignment-free recipe may narrow the gap to GPN-Star, but it is not clear that they will eliminate it. Some of the remaining difference may reflect information that an alignment-free model cannot recover from unaligned sequence alone.
+
+<!-- Plot recipe: plots/blog/figure11_leaderboard_heatmap.py -->
 <figure id="fig-mendelian-leaderboard">
-<img src="/assets/images/blog/genomic-lm-optimization/figure11_leaderboard_heatmap.svg" alt="Mendelian VEP benchmark AUPRC (%) heatmap across models" />
-<figcaption><strong>Figure 18:</strong> Mendelian VEP benchmark — AUPRC (%) across models, with the Macro Avg column highlighted. This leaderboard is computed with a newer version of the TraitGym Mendelian eval, so its scores are not directly comparable to those in the earlier <a href="#fig-mixture-lineage-trajectories">mixture-lineage trajectories</a>; this is why m5.1's end-of-training score in the latter does not match its current leaderboard score here.</figcaption>
+<img src="/assets/images/blog/genomic-lm-optimization/figure11_leaderboard_heatmap__mendelian_llr.svg" alt="Mendelian VEP benchmark zero-shot AUPRC (%) heatmap across six headline models" />
+<figcaption><strong>Figure 18:</strong> Mendelian VEP benchmark — zero-shot AUPRC (%) across six headline models using each model family's canonical scoring protocol, with the Macro Avg column highlighted.</figcaption>
 </figure>
+
+<details>
+<summary>Show the frozen-embedding linear-probe leaderboard</summary>
+<figure id="fig-mendelian-leaderboard-probe">
+<img src="/assets/images/blog/genomic-lm-optimization/figure11_leaderboard_heatmap__mendelian_probe.svg" alt="Mendelian VEP benchmark frozen-embedding linear-probe AUPRC (%) heatmap across four overlapping models" />
+<figcaption><strong>Figure 19:</strong> Frozen-embedding linear-probe AUPRC (%) for the four models that also appear in the zero-shot leaderboard and have compatible probe metrics. The two heatmaps are sorted and color-normalized independently, and their subset metrics use different aggregation: Figure 18 pools variants within each subset before computing AUPRC, whereas Figure 19 computes a sample-size-weighted mean of per-chromosome AUPRCs; both Macro Avg columns are unweighted means across subsets. Compare model names and within-panel values rather than row positions, colors, or absolute values across panels. GPN-Star and AlphaGenome are absent because no compatible probe result is available here, not because of their performance.</figcaption>
+</figure>
+</details>
 
 ## Conclusion
 

--- a/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/figure11_leaderboard_heatmap__mendelian_llr.svg
+++ b/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/figure11_leaderboard_heatmap__mendelian_llr.svg
@@ -1,0 +1,542 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="519.655172pt" height="225.264187pt" viewBox="0 0 519.655172 225.264187" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.0rc1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 225.264187
+L 519.655172 225.264187
+L 519.655172 0
+L 0 0
+L 0 225.264187
+z
+" style="fill: none"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 114.718906 177.796287
+L 467.223978 177.796287
+L 467.223978 24.418516
+L 114.718906 24.418516
+L 114.718906 177.796287
+z
+" style="fill: none"/>
+   </g>
+   <g clip-path="url(#p3e6922e3d7)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAeoAAADVCAYAAACYNrP2AAAFDUlEQVR4nO3XPa8YYhjHYac9+kqXNpqIl7ZhaGxlIBERS2P3AViET2BgMVhZGcUkMbDYGgaDt4oOlKRxxNRIK7SOhKOnPoHxyf3LyXV9gv+zPL/cG5fee/H2HXvU5YvfT09Y4uPPrkxPWOaNt16ZnrDE0fsem56wxIG7T05PWOa791+dnrDEQ+dfnp6wzKdvvz49YYl90wMAgP8n1AAQJtQAECbUABAm1AAQJtQAECbUABAm1AAQJtQAECbUABAm1AAQJtQAECbUABAm1AAQJtQAECbUABAm1AAQJtQAECbUABAm1AAQJtQAECbUABAm1AAQJtQAECbUABAm1AAQJtQAECbUABAm1AAQJtQAECbUABAm1AAQJtQAECbUABC2uXvr3+kNyzxw6vj0hCUOfbk1PWGZnz6/MD1hiTOPb0xPWGLf6SenJyxz9PjJ6QlL7O5sT09Y5vCRA9MTlnBRA0CYUANAmFADQJhQA0CYUANAmFADQJhQA0CYUANAmFADQJhQA0CYUANAmFADQJhQA0CYUANAmFADQJhQA0CYUANAmFADQJhQA0CYUANAmFADQJhQA0CYUANAmFADQJhQA0CYUANAmFADQJhQA0CYUANAmFADQJhQA0CYUANAmFADQJhQA0CYUANA2Obff96Y3rDMwbuOTU9Y4sSxw9MTljl05ND0hCWuXbk0PWGJX3+8OD1hmb36N544uz09YZmDh++cnrCEixoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwjZv7exMb1jmj+s3picsce6Re6cnLHPz9+3pCUucOn12esISW998NT1hmZ1/bk1PWOLqpQvTE5a559Tp6QlLuKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBsc3f39vSGZZ546c3pCUt88NoL0xOWuf/MyekJS3z07ofTE5Z49rlnpicsc/mLb6cnLLHz183pCctsbV2dnrCEixoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwjbeef7c7ekRq/zwy2/TE5bY2NiYnrDM+acenp6wxPVr29MTlvjk65+nJyzz9KMPTk9Y4sCB/dMTltm/uTdvz735KgDYI4QaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAML+A80MVe/5lnj+AAAAAElFTkSuQmCC" id="imaged8d9df1c12" transform="scale(1 -1) translate(0 -153.36)" x="114.48" y="-24.384187" width="352.8" height="153.36"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1"/>
+     <g id="text_1">
+      <text style="font-weight: 700; font-size: 9px; font-family: 'DejaVu Sans', sans-serif; fill: #1f1e1b" transform="translate(87.258657 213.754715) rotate(-30)">Macro Avg</text>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2"/>
+     <g id="text_2">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; fill: #1f1e1b" transform="translate(136.786122 207.773839) rotate(-30)">Missense</text>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3"/>
+     <g id="text_3">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; fill: #1f1e1b" transform="translate(180.990372 204.865714) rotate(-30)">Splicing</text>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4"/>
+     <g id="text_4">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; fill: #1f1e1b" transform="translate(225.26404 201.916902) rotate(-30)">5' UTR</text>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5"/>
+     <g id="text_5">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; fill: #1f1e1b" transform="translate(254.108789 207.87659) rotate(-30)">Promoter</text>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6"/>
+     <g id="text_6">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; fill: #1f1e1b" transform="translate(303.25385 202.115886) rotate(-30)">ncRNA</text>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7"/>
+     <g id="text_7">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; fill: #1f1e1b" transform="translate(342.765731 201.916902) rotate(-30)">3' UTR</text>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8"/>
+     <g id="text_8">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; fill: #1f1e1b" transform="translate(385.167566 200.050011) rotate(-30)">Distal</text>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9"/>
+     <g id="text_9">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; fill: #1f1e1b" transform="translate(396.375437 216.191746) rotate(-30)">Synonymous</text>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_10">
+      <path d="M 114.718906 177.796287
+L 114.718906 24.418516
+" clip-path="url(#p3e6922e3d7)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11"/>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_12">
+      <path d="M 153.886136 177.796287
+L 153.886136 24.418516
+" clip-path="url(#p3e6922e3d7)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13"/>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_14">
+      <path d="M 193.053367 177.796287
+L 193.053367 24.418516
+" clip-path="url(#p3e6922e3d7)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_15"/>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_16">
+      <path d="M 232.220597 177.796287
+L 232.220597 24.418516
+" clip-path="url(#p3e6922e3d7)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_17"/>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_18">
+      <path d="M 271.387827 177.796287
+L 271.387827 24.418516
+" clip-path="url(#p3e6922e3d7)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_19"/>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_20">
+      <path d="M 310.555057 177.796287
+L 310.555057 24.418516
+" clip-path="url(#p3e6922e3d7)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_21"/>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_22">
+      <path d="M 349.722288 177.796287
+L 349.722288 24.418516
+" clip-path="url(#p3e6922e3d7)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_23"/>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_24">
+      <path d="M 388.889518 177.796287
+L 388.889518 24.418516
+" clip-path="url(#p3e6922e3d7)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_25"/>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_26">
+      <path d="M 428.056748 177.796287
+L 428.056748 24.418516
+" clip-path="url(#p3e6922e3d7)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_27"/>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_28">
+      <path d="M 467.223978 177.796287
+L 467.223978 24.418516
+" clip-path="url(#p3e6922e3d7)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_29"/>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_30"/>
+     <g id="text_10">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; text-anchor: end; fill: #1f1e1b" x="111.218906" y="40.618942" transform="rotate(-0 111.218906 40.618942)">GPN-Star (M)</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_31"/>
+     <g id="text_11">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; text-anchor: end; fill: #1f1e1b" x="111.218906" y="66.182255" transform="rotate(-0 111.218906 66.182255)">AlphaGenome</text>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_32"/>
+     <g id="text_12">
+      <text style="font-weight: 700; font-size: 9px; font-family: 'DejaVu Sans', sans-serif; text-anchor: end; fill: #1f1e1b" x="111.218906" y="91.745217" transform="rotate(-0 111.218906 91.745217)">MarinDNA (1B/m5.1)</text>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_33"/>
+     <g id="text_13">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; text-anchor: end; fill: #1f1e1b" x="111.218906" y="117.307828" transform="rotate(-0 111.218906 117.307828)">Evo 2 (40B)</text>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_34"/>
+     <g id="text_14">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; text-anchor: end; fill: #1f1e1b" x="111.218906" y="142.870789" transform="rotate(-0 111.218906 142.870789)">Evo 2 (7B)</text>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_35"/>
+     <g id="text_15">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; text-anchor: end; fill: #1f1e1b" x="111.218906" y="168.434103" transform="rotate(-0 111.218906 168.434103)">Evo 2 (1B base)</text>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_36">
+      <path d="M 114.718906 24.418516
+L 467.223978 24.418516
+" clip-path="url(#p3e6922e3d7)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_37"/>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_38">
+      <path d="M 114.718906 49.981478
+L 467.223978 49.981478
+" clip-path="url(#p3e6922e3d7)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_39"/>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_40">
+      <path d="M 114.718906 75.544439
+L 467.223978 75.544439
+" clip-path="url(#p3e6922e3d7)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_41"/>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_42">
+      <path d="M 114.718906 101.107401
+L 467.223978 101.107401
+" clip-path="url(#p3e6922e3d7)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_43"/>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_44">
+      <path d="M 114.718906 126.670363
+L 467.223978 126.670363
+" clip-path="url(#p3e6922e3d7)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_45"/>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_46">
+      <path d="M 114.718906 152.233325
+L 467.223978 152.233325
+" clip-path="url(#p3e6922e3d7)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_47"/>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_48">
+      <path d="M 114.718906 177.796287
+L 467.223978 177.796287
+" clip-path="url(#p3e6922e3d7)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_49"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <text style="font-weight: 700; font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="134.302521" y="39.278122" transform="rotate(-0 134.302521 39.278122)">53.8</text>
+   </g>
+   <g id="text_17">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="173.469752" y="39.278122" transform="rotate(-0 173.469752 39.278122)">63.1</text>
+   </g>
+   <g id="text_18">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="212.636982" y="39.278122" transform="rotate(-0 212.636982 39.278122)">62.6</text>
+   </g>
+   <g id="text_19">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="251.804212" y="39.278122" transform="rotate(-0 251.804212 39.278122)">43.6</text>
+   </g>
+   <g id="text_20">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="290.971442" y="39.278122" transform="rotate(-0 290.971442 39.278122)">49.6</text>
+   </g>
+   <g id="text_21">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="330.138672" y="39.278122" transform="rotate(-0 330.138672 39.278122)">65.7</text>
+   </g>
+   <g id="text_22">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="369.305903" y="39.278122" transform="rotate(-0 369.305903 39.278122)">50.1</text>
+   </g>
+   <g id="text_23">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="408.473133" y="39.278122" transform="rotate(-0 408.473133 39.278122)">48.4</text>
+   </g>
+   <g id="text_24">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="447.640363" y="39.278122" transform="rotate(-0 447.640363 39.278122)">47.2</text>
+   </g>
+   <g id="text_25">
+    <text style="font-weight: 700; font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="134.302521" y="64.841083" transform="rotate(-0 134.302521 64.841083)">40.1</text>
+   </g>
+   <g id="text_26">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="173.469752" y="64.841083" transform="rotate(-0 173.469752 64.841083)">11.7</text>
+   </g>
+   <g id="text_27">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="212.636982" y="64.841083" transform="rotate(-0 212.636982 64.841083)">52.3</text>
+   </g>
+   <g id="text_28">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="251.804212" y="64.841083" transform="rotate(-0 251.804212 64.841083)">37.7</text>
+   </g>
+   <g id="text_29">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="290.971442" y="64.841083" transform="rotate(-0 290.971442 64.841083)">56.4</text>
+   </g>
+   <g id="text_30">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="330.138672" y="64.841083" transform="rotate(-0 330.138672 64.841083)">31.2</text>
+   </g>
+   <g id="text_31">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="369.305903" y="64.841083" transform="rotate(-0 369.305903 64.841083)">47.6</text>
+   </g>
+   <g id="text_32">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="408.473133" y="64.841083" transform="rotate(-0 408.473133 64.841083)">37.0</text>
+   </g>
+   <g id="text_33">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="447.640363" y="64.841083" transform="rotate(-0 447.640363 64.841083)">46.7</text>
+   </g>
+   <g id="text_34">
+    <text style="font-weight: 700; font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="134.302521" y="90.404045" transform="rotate(-0 134.302521 90.404045)">39.5</text>
+   </g>
+   <g id="text_35">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="173.469752" y="90.404045" transform="rotate(-0 173.469752 90.404045)">43.8</text>
+   </g>
+   <g id="text_36">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="212.636982" y="90.404045" transform="rotate(-0 212.636982 90.404045)">47.9</text>
+   </g>
+   <g id="text_37">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="251.804212" y="90.404045" transform="rotate(-0 251.804212 90.404045)">42.6</text>
+   </g>
+   <g id="text_38">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="290.971442" y="90.404045" transform="rotate(-0 290.971442 90.404045)">28.0</text>
+   </g>
+   <g id="text_39">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="330.138672" y="90.404045" transform="rotate(-0 330.138672 90.404045)">42.8</text>
+   </g>
+   <g id="text_40">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="369.305903" y="90.404045" transform="rotate(-0 369.305903 90.404045)">44.6</text>
+   </g>
+   <g id="text_41">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="408.473133" y="90.404045" transform="rotate(-0 408.473133 90.404045)">33.9</text>
+   </g>
+   <g id="text_42">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="447.640363" y="90.404045" transform="rotate(-0 447.640363 90.404045)">32.3</text>
+   </g>
+   <g id="text_43">
+    <text style="font-weight: 700; font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="134.302521" y="115.967007" transform="rotate(-0 134.302521 115.967007)">38.2</text>
+   </g>
+   <g id="text_44">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="173.469752" y="115.967007" transform="rotate(-0 173.469752 115.967007)">35.6</text>
+   </g>
+   <g id="text_45">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="212.636982" y="115.967007" transform="rotate(-0 212.636982 115.967007)">60.9</text>
+   </g>
+   <g id="text_46">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="251.804212" y="115.967007" transform="rotate(-0 251.804212 115.967007)">37.9</text>
+   </g>
+   <g id="text_47">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="290.971442" y="115.967007" transform="rotate(-0 290.971442 115.967007)">34.9</text>
+   </g>
+   <g id="text_48">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="330.138672" y="115.967007" transform="rotate(-0 330.138672 115.967007)">35.7</text>
+   </g>
+   <g id="text_49">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="369.305903" y="115.967007" transform="rotate(-0 369.305903 115.967007)">39.1</text>
+   </g>
+   <g id="text_50">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="408.473133" y="115.967007" transform="rotate(-0 408.473133 115.967007)">19.5</text>
+   </g>
+   <g id="text_51">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="447.640363" y="115.967007" transform="rotate(-0 447.640363 115.967007)">42.2</text>
+   </g>
+   <g id="text_52">
+    <text style="font-weight: 700; font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="134.302521" y="141.529969" transform="rotate(-0 134.302521 141.529969)">34.5</text>
+   </g>
+   <g id="text_53">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="173.469752" y="141.529969" transform="rotate(-0 173.469752 141.529969)">39.2</text>
+   </g>
+   <g id="text_54">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="212.636982" y="141.529969" transform="rotate(-0 212.636982 141.529969)">65.4</text>
+   </g>
+   <g id="text_55">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="251.804212" y="141.529969" transform="rotate(-0 251.804212 141.529969)">40.7</text>
+   </g>
+   <g id="text_56">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="290.971442" y="141.529969" transform="rotate(-0 290.971442 141.529969)">23.6</text>
+   </g>
+   <g id="text_57">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="330.138672" y="141.529969" transform="rotate(-0 330.138672 141.529969)">13.3</text>
+   </g>
+   <g id="text_58">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="369.305903" y="141.529969" transform="rotate(-0 369.305903 141.529969)">32.1</text>
+   </g>
+   <g id="text_59">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="408.473133" y="141.529969" transform="rotate(-0 408.473133 141.529969)">17.4</text>
+   </g>
+   <g id="text_60">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="447.640363" y="141.529969" transform="rotate(-0 447.640363 141.529969)">44.6</text>
+   </g>
+   <g id="text_61">
+    <text style="font-weight: 700; font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="134.302521" y="167.092931" transform="rotate(-0 134.302521 167.092931)">33.4</text>
+   </g>
+   <g id="text_62">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="173.469752" y="167.092931" transform="rotate(-0 173.469752 167.092931)">49.1</text>
+   </g>
+   <g id="text_63">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="212.636982" y="167.092931" transform="rotate(-0 212.636982 167.092931)">67.5</text>
+   </g>
+   <g id="text_64">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="251.804212" y="167.092931" transform="rotate(-0 251.804212 167.092931)">23.9</text>
+   </g>
+   <g id="text_65">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="290.971442" y="167.092931" transform="rotate(-0 290.971442 167.092931)">14.9</text>
+   </g>
+   <g id="text_66">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="330.138672" y="167.092931" transform="rotate(-0 330.138672 167.092931)">10.7</text>
+   </g>
+   <g id="text_67">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="369.305903" y="167.092931" transform="rotate(-0 369.305903 167.092931)">37.7</text>
+   </g>
+   <g id="text_68">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="408.473133" y="167.092931" transform="rotate(-0 408.473133 167.092931)">15.8</text>
+   </g>
+   <g id="text_69">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="447.640363" y="167.092931" transform="rotate(-0 447.640363 167.092931)">47.7</text>
+   </g>
+   <g id="text_70">
+    <text style="font-size: 9.5px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #1f1e1b" x="290.971442" y="14.418516" transform="rotate(-0 290.971442 14.418516)">Mendelian VEP benchmark — AUPRC (%) · zero-shot LLR</text>
+   </g>
+   <g id="patch_3">
+    <path d="M 114.718906 24.418516
+L 153.886136 24.418516
+L 153.886136 177.796287
+L 114.718906 177.796287
+L 114.718906 24.418516
+z
+" clip-path="url(#p3e6922e3d7)" style="fill: none; stroke: #000000; stroke-width: 2; stroke-linejoin: miter"/>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_4">
+    <path d="M 474.606283 177.796287
+L 482.275172 177.796287
+L 482.275172 24.418516
+L 474.606283 24.418516
+L 474.606283 177.796287
+z
+" style="fill: none"/>
+   </g>
+   <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAAsAAADVCAYAAACBmAp5AAABLklEQVR4nOWXsQ3DQAwD5cD7D+gZUqa1lBV0xQF04log+CSfLx+f9zW1/M6a9WydM/d+GCFXIRot0YDIFg1TDTA8iDOiQQ6YElFGA9lNTGmksxZRpAayu4GDDNnLc0ZEQ9Tw+pndFC3PRRwUaYhqZLwpLM8RETXtJjTIM0E4v9aTpUr3RAch5/Ws2fxeb5g6W3lm21fG2x1yrVLyzPbnkN6IoJGSZ/S0iSvxehbSeGLJhOQZzGLpAPK0xRk6SJA1nUUHWT8DZOagR0PLc3tdp10reEALWQs/20WbRFR8rX4+ogDZdFAsGUvnFAf3wDSiwEH4pxmRZ+agZ0rIAUMiipDBz4S7yUQ4aJoChlHzp5iyB6YHzFhO2LUSN0YyrKnhRTSkRf8gohZyiBoZLfoFf5TMAHijIPwAAAAASUVORK5CYII=" id="image931ced4fa7" transform="scale(1 -1) translate(0 -153.36)" x="474.48" y="-23.76" width="7.92" height="153.36"/>
+   <g id="matplotlib.axis_3"/>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_14">
+     <g id="line2d_50">
+      <defs>
+       <path id="me0c3d264bd" d="M 0 0
+L 3.5 0
+" style="stroke: #1f1e1b; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#me0c3d264bd" x="482.275172" y="152.760062" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_71">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: start; fill: #1f1e1b" x="489.275172" y="155.799124" transform="rotate(-0 489.275172 155.799124)">20</text>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#me0c3d264bd" x="482.275172" y="125.752646" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_72">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: start; fill: #1f1e1b" x="489.275172" y="128.791709" transform="rotate(-0 489.275172 128.791709)">30</text>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#me0c3d264bd" x="482.275172" y="98.745231" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_73">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: start; fill: #1f1e1b" x="489.275172" y="101.784293" transform="rotate(-0 489.275172 101.784293)">40</text>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#me0c3d264bd" x="482.275172" y="71.737815" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_74">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: start; fill: #1f1e1b" x="489.275172" y="74.776878" transform="rotate(-0 489.275172 74.776878)">50</text>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#me0c3d264bd" x="482.275172" y="44.7304" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_75">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: start; fill: #1f1e1b" x="489.275172" y="47.769462" transform="rotate(-0 489.275172 47.769462)">60</text>
+     </g>
+    </g>
+    <g id="text_76">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #1f1e1b" x="510.293063" y="101.107401" transform="rotate(-90 510.293063 101.107401)">AUPRC (%)</text>
+    </g>
+   </g>
+   <g id="LineCollection_1"/>
+   <g id="patch_5">
+    <path d="M 474.606283 177.796287
+L 478.440728 177.796287
+L 482.275172 177.796287
+L 482.275172 24.418516
+L 478.440728 24.418516
+L 474.606283 24.418516
+L 474.606283 177.796287
+z
+" style="fill: none; stroke: #1f1e1b; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p3e6922e3d7">
+   <rect x="114.718906" y="24.418516" width="352.505072" height="153.377771"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/figure11_leaderboard_heatmap__mendelian_probe.svg
+++ b/blog/genomic-lm-optimization/static/assets/images/blog/genomic-lm-optimization/figure11_leaderboard_heatmap__mendelian_probe.svg
@@ -1,0 +1,470 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="519.655172pt" height="225.264187pt" viewBox="0 0 519.655172 225.264187" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.0rc1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 225.264187
+L 519.655172 225.264187
+L 519.655172 0
+L 0 0
+L 0 225.264187
+z
+" style="fill: none"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 114.718906 177.796287
+L 467.223978 177.796287
+L 467.223978 24.418516
+L 114.718906 24.418516
+L 114.718906 177.796287
+z
+" style="fill: none"/>
+   </g>
+   <g clip-path="url(#pebdd369ecb)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAeoAAADVCAYAAACYNrP2AAAEdElEQVR4nO3Xy4oIYBjHYYfJRFhMNiIlOwuX4MbkbmzcgD3Z2MlhoSbUFHLKMcaYGVdg+fX+mp7nCv71ffXrPb597/bhsSPq2YOH0xOWePR4Z3rCMrfu3JuesMT+7vfpCUscHuxPT1jm28v70xOWOHX+4vSEZd49PZpvdmJ6AADwf0INAGFCDQBhQg0AYUINAGFCDQBhQg0AYUINAGFCDQBhQg0AYUINAGFCDQBhQg0AYUINAGFCDQBhQg0AYUINAGFCDQBhQg0AYUINAGFCDQBhQg0AYUINAGFCDQBhQg0AYUINAGFCDQBhQg0AYUINAGFCDQBhQg0AYUINAGFCDQBhQg0AYUINAGFCDQBhQg0AYUINAGFCDQBhQg0AYUINAGFCDQBhQg0AYUINAGFCDQBhQg0AYUINAGFCDQBhQg0AYUINAGFCDQBhQg0AYRtf37ye3rDMi+330xOW+PFrb3rCMs/v3pqesMSFa9enJyxx7tKN6QnL7H7/Mj1hic2tq9MT1jk8nF6whIsaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMKEGgDChBoAwoQaAMI2Dv7uTW9Y5vSpjekJS3z9uTs9YZmj+h9Pb12ZnrDEwf6f6QnL/P72eXrCEpufX01PWGb/79H8jy5qAAgTagAIE2oACBNqAAgTagAIE2oACBNqAAgTagAIE2oACBNqAAgTagAIE2oACBNqAAgTagAIE2oACBNqAAgTagAIE2oACBNqAAgTagAIE2oACBNqAAgTagAIE2oACBNqAAgTagAIE2oACBNqAAgTagAIE2oACBNqAAgTagAIE2oACBNqAAgTagAIE2oACBNqAAgTagAIE2oACBNqAAgTagAIE2oACBNqAAgTagAIE2oACBNqAAgTagAIE2oACBNqAAgTagAIE2oACBNqAAgTagAI29h5+XZ6wzLnz25OT1ji5o3L0xOW2Xn9aXrCEme2Hk1PWOLHx3fTE5Z5tf1hesISJ08+mZ6wzO7vvekJS7ioASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASBMqAEgTKgBIEyoASDsH8jYSke3wBOPAAAAAElFTkSuQmCC" id="image62366327da" transform="scale(1 -1) translate(0 -153.36)" x="114.48" y="-24.384187" width="352.8" height="153.36"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1"/>
+     <g id="text_1">
+      <text style="font-weight: 700; font-size: 9px; font-family: 'DejaVu Sans', sans-serif; fill: #1f1e1b" transform="translate(87.258657 213.754715) rotate(-30)">Macro Avg</text>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2"/>
+     <g id="text_2">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; fill: #1f1e1b" transform="translate(136.786122 207.773839) rotate(-30)">Missense</text>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3"/>
+     <g id="text_3">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; fill: #1f1e1b" transform="translate(180.990372 204.865714) rotate(-30)">Splicing</text>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4"/>
+     <g id="text_4">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; fill: #1f1e1b" transform="translate(225.26404 201.916902) rotate(-30)">5' UTR</text>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5"/>
+     <g id="text_5">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; fill: #1f1e1b" transform="translate(254.108789 207.87659) rotate(-30)">Promoter</text>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6"/>
+     <g id="text_6">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; fill: #1f1e1b" transform="translate(303.25385 202.115886) rotate(-30)">ncRNA</text>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7"/>
+     <g id="text_7">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; fill: #1f1e1b" transform="translate(342.765731 201.916902) rotate(-30)">3' UTR</text>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8"/>
+     <g id="text_8">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; fill: #1f1e1b" transform="translate(385.167566 200.050011) rotate(-30)">Distal</text>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9"/>
+     <g id="text_9">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; fill: #1f1e1b" transform="translate(396.375437 216.191746) rotate(-30)">Synonymous</text>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_10">
+      <path d="M 114.718906 177.796287
+L 114.718906 24.418516
+" clip-path="url(#pebdd369ecb)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11"/>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_12">
+      <path d="M 153.886136 177.796287
+L 153.886136 24.418516
+" clip-path="url(#pebdd369ecb)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13"/>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_14">
+      <path d="M 193.053367 177.796287
+L 193.053367 24.418516
+" clip-path="url(#pebdd369ecb)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_15"/>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_16">
+      <path d="M 232.220597 177.796287
+L 232.220597 24.418516
+" clip-path="url(#pebdd369ecb)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_17"/>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_18">
+      <path d="M 271.387827 177.796287
+L 271.387827 24.418516
+" clip-path="url(#pebdd369ecb)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_19"/>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_20">
+      <path d="M 310.555057 177.796287
+L 310.555057 24.418516
+" clip-path="url(#pebdd369ecb)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_21"/>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_22">
+      <path d="M 349.722288 177.796287
+L 349.722288 24.418516
+" clip-path="url(#pebdd369ecb)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_23"/>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_24">
+      <path d="M 388.889518 177.796287
+L 388.889518 24.418516
+" clip-path="url(#pebdd369ecb)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_25"/>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_26">
+      <path d="M 428.056748 177.796287
+L 428.056748 24.418516
+" clip-path="url(#pebdd369ecb)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_27"/>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_28">
+      <path d="M 467.223978 177.796287
+L 467.223978 24.418516
+" clip-path="url(#pebdd369ecb)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_29"/>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_30"/>
+     <g id="text_10">
+      <text style="font-weight: 700; font-size: 9px; font-family: 'DejaVu Sans', sans-serif; text-anchor: end; fill: #1f1e1b" x="111.218906" y="47.010034" transform="rotate(-0 111.218906 47.010034)">MarinDNA (1B/m5.1)</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_31"/>
+     <g id="text_11">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; text-anchor: end; fill: #1f1e1b" x="111.218906" y="85.354125" transform="rotate(-0 111.218906 85.354125)">Evo 2 (7B)</text>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_32"/>
+     <g id="text_12">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; text-anchor: end; fill: #1f1e1b" x="111.218906" y="123.698568" transform="rotate(-0 111.218906 123.698568)">Evo 2 (40B)</text>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_33"/>
+     <g id="text_13">
+      <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; text-anchor: end; fill: #1f1e1b" x="111.218906" y="162.043362" transform="rotate(-0 111.218906 162.043362)">Evo 2 (1B base)</text>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_34">
+      <path d="M 114.718906 24.418516
+L 467.223978 24.418516
+" clip-path="url(#pebdd369ecb)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_35"/>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_36">
+      <path d="M 114.718906 62.762958
+L 467.223978 62.762958
+" clip-path="url(#pebdd369ecb)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_37"/>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_38">
+      <path d="M 114.718906 101.107401
+L 467.223978 101.107401
+" clip-path="url(#pebdd369ecb)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_39"/>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_40">
+      <path d="M 114.718906 139.451844
+L 467.223978 139.451844
+" clip-path="url(#pebdd369ecb)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_41"/>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_42">
+      <path d="M 114.718906 177.796287
+L 467.223978 177.796287
+" clip-path="url(#pebdd369ecb)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_43"/>
+    </g>
+   </g>
+   <g id="text_14">
+    <text style="font-weight: 700; font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="134.302521" y="45.668862" transform="rotate(-0 134.302521 45.668862)">48.9</text>
+   </g>
+   <g id="text_15">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="173.469752" y="45.668862" transform="rotate(-0 173.469752 45.668862)">53.8</text>
+   </g>
+   <g id="text_16">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="212.636982" y="45.668862" transform="rotate(-0 212.636982 45.668862)">55.1</text>
+   </g>
+   <g id="text_17">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="251.804212" y="45.668862" transform="rotate(-0 251.804212 45.668862)">50.3</text>
+   </g>
+   <g id="text_18">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="290.971442" y="45.668862" transform="rotate(-0 290.971442 45.668862)">34.2</text>
+   </g>
+   <g id="text_19">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="330.138672" y="45.668862" transform="rotate(-0 330.138672 45.668862)">40.8</text>
+   </g>
+   <g id="text_20">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="369.305903" y="45.668862" transform="rotate(-0 369.305903 45.668862)">52.2</text>
+   </g>
+   <g id="text_21">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="408.473133" y="45.668862" transform="rotate(-0 408.473133 45.668862)">51.2</text>
+   </g>
+   <g id="text_22">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="447.640363" y="45.668862" transform="rotate(-0 447.640363 45.668862)">53.9</text>
+   </g>
+   <g id="text_23">
+    <text style="font-weight: 700; font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="134.302521" y="84.013305" transform="rotate(-0 134.302521 84.013305)">38.0</text>
+   </g>
+   <g id="text_24">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="173.469752" y="84.013305" transform="rotate(-0 173.469752 84.013305)">57.5</text>
+   </g>
+   <g id="text_25">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="212.636982" y="84.013305" transform="rotate(-0 212.636982 84.013305)">70.4</text>
+   </g>
+   <g id="text_26">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="251.804212" y="84.013305" transform="rotate(-0 251.804212 84.013305)">40.2</text>
+   </g>
+   <g id="text_27">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="290.971442" y="84.013305" transform="rotate(-0 290.971442 84.013305)">21.5</text>
+   </g>
+   <g id="text_28">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="330.138672" y="84.013305" transform="rotate(-0 330.138672 84.013305)">19.6</text>
+   </g>
+   <g id="text_29">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="369.305903" y="84.013305" transform="rotate(-0 369.305903 84.013305)">33.6</text>
+   </g>
+   <g id="text_30">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="408.473133" y="84.013305" transform="rotate(-0 408.473133 84.013305)">24.8</text>
+   </g>
+   <g id="text_31">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="447.640363" y="84.013305" transform="rotate(-0 447.640363 84.013305)">36.3</text>
+   </g>
+   <g id="text_32">
+    <text style="font-weight: 700; font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="134.302521" y="122.357748" transform="rotate(-0 134.302521 122.357748)">36.7</text>
+   </g>
+   <g id="text_33">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="173.469752" y="122.357748" transform="rotate(-0 173.469752 122.357748)">59.7</text>
+   </g>
+   <g id="text_34">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="212.636982" y="122.357748" transform="rotate(-0 212.636982 122.357748)">66.4</text>
+   </g>
+   <g id="text_35">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="251.804212" y="122.357748" transform="rotate(-0 251.804212 122.357748)">38.7</text>
+   </g>
+   <g id="text_36">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="290.971442" y="122.357748" transform="rotate(-0 290.971442 122.357748)">27.7</text>
+   </g>
+   <g id="text_37">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="330.138672" y="122.357748" transform="rotate(-0 330.138672 122.357748)">18.5</text>
+   </g>
+   <g id="text_38">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="369.305903" y="122.357748" transform="rotate(-0 369.305903 122.357748)">28.8</text>
+   </g>
+   <g id="text_39">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="408.473133" y="122.357748" transform="rotate(-0 408.473133 122.357748)">18.7</text>
+   </g>
+   <g id="text_40">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="447.640363" y="122.357748" transform="rotate(-0 447.640363 122.357748)">35.1</text>
+   </g>
+   <g id="text_41">
+    <text style="font-weight: 700; font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="134.302521" y="160.702191" transform="rotate(-0 134.302521 160.702191)">28.5</text>
+   </g>
+   <g id="text_42">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="173.469752" y="160.702191" transform="rotate(-0 173.469752 160.702191)">48.2</text>
+   </g>
+   <g id="text_43">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #ffffff" x="212.636982" y="160.702191" transform="rotate(-0 212.636982 160.702191)">63.8</text>
+   </g>
+   <g id="text_44">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="251.804212" y="160.702191" transform="rotate(-0 251.804212 160.702191)">10.1</text>
+   </g>
+   <g id="text_45">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="290.971442" y="160.702191" transform="rotate(-0 290.971442 160.702191)">12.7</text>
+   </g>
+   <g id="text_46">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="330.138672" y="160.702191" transform="rotate(-0 330.138672 160.702191)">13.0</text>
+   </g>
+   <g id="text_47">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="369.305903" y="160.702191" transform="rotate(-0 369.305903 160.702191)">24.9</text>
+   </g>
+   <g id="text_48">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="408.473133" y="160.702191" transform="rotate(-0 408.473133 160.702191)">20.2</text>
+   </g>
+   <g id="text_49">
+    <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle" x="447.640363" y="160.702191" transform="rotate(-0 447.640363 160.702191)">34.7</text>
+   </g>
+   <g id="text_50">
+    <text style="font-size: 9.5px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #1f1e1b" x="290.971442" y="14.418516" transform="rotate(-0 290.971442 14.418516)">Mendelian VEP benchmark — AUPRC (%) · frozen-embedding linear probe</text>
+   </g>
+   <g id="patch_3">
+    <path d="M 114.718906 24.418516
+L 153.886136 24.418516
+L 153.886136 177.796287
+L 114.718906 177.796287
+L 114.718906 24.418516
+z
+" clip-path="url(#pebdd369ecb)" style="fill: none; stroke: #000000; stroke-width: 2; stroke-linejoin: miter"/>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_4">
+    <path d="M 474.606283 177.796287
+L 482.275172 177.796287
+L 482.275172 24.418516
+L 474.606283 24.418516
+L 474.606283 177.796287
+z
+" style="fill: none"/>
+   </g>
+   <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAAsAAADVCAYAAACBmAp5AAABLklEQVR4nOWXsQ3DQAwD5cD7D+gZUqa1lBV0xQF04log+CSfLx+f9zW1/M6a9WydM/d+GCFXIRot0YDIFg1TDTA8iDOiQQ6YElFGA9lNTGmksxZRpAayu4GDDNnLc0ZEQ9Tw+pndFC3PRRwUaYhqZLwpLM8RETXtJjTIM0E4v9aTpUr3RAch5/Ws2fxeb5g6W3lm21fG2x1yrVLyzPbnkN6IoJGSZ/S0iSvxehbSeGLJhOQZzGLpAPK0xRk6SJA1nUUHWT8DZOagR0PLc3tdp10reEALWQs/20WbRFR8rX4+ogDZdFAsGUvnFAf3wDSiwEH4pxmRZ+agZ0rIAUMiipDBz4S7yUQ4aJoChlHzp5iyB6YHzFhO2LUSN0YyrKnhRTSkRf8gohZyiBoZLfoFf5TMAHijIPwAAAAASUVORK5CYII=" id="image55debc95f4" transform="scale(1 -1) translate(0 -153.36)" x="474.48" y="-23.76" width="7.92" height="153.36"/>
+   <g id="matplotlib.axis_3"/>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_10">
+     <g id="line2d_44">
+      <defs>
+       <path id="m3be59ce9ac" d="M 0 0
+L 3.5 0
+" style="stroke: #1f1e1b; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m3be59ce9ac" x="482.275172" y="152.662865" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_51">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: start; fill: #1f1e1b" x="489.275172" y="155.701927" transform="rotate(-0 489.275172 155.701927)">20</text>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#m3be59ce9ac" x="482.275172" y="127.227771" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_52">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: start; fill: #1f1e1b" x="489.275172" y="130.266834" transform="rotate(-0 489.275172 130.266834)">30</text>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m3be59ce9ac" x="482.275172" y="101.792678" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_53">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: start; fill: #1f1e1b" x="489.275172" y="104.831741" transform="rotate(-0 489.275172 104.831741)">40</text>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#m3be59ce9ac" x="482.275172" y="76.357585" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_54">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: start; fill: #1f1e1b" x="489.275172" y="79.396647" transform="rotate(-0 489.275172 79.396647)">50</text>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m3be59ce9ac" x="482.275172" y="50.922492" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_55">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: start; fill: #1f1e1b" x="489.275172" y="53.961554" transform="rotate(-0 489.275172 53.961554)">60</text>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#m3be59ce9ac" x="482.275172" y="25.487398" style="fill: #1f1e1b; stroke: #1f1e1b; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_56">
+      <text style="font-size: 8px; font-family: 'DejaVu Sans', sans-serif; text-anchor: start; fill: #1f1e1b" x="489.275172" y="28.526461" transform="rotate(-0 489.275172 28.526461)">70</text>
+     </g>
+    </g>
+    <g id="text_57">
+     <text style="font-size: 9px; font-family: 'DejaVu Sans', sans-serif; text-anchor: middle; fill: #1f1e1b" x="510.293063" y="101.107401" transform="rotate(-90 510.293063 101.107401)">AUPRC (%)</text>
+    </g>
+   </g>
+   <g id="LineCollection_1"/>
+   <g id="patch_5">
+    <path d="M 474.606283 177.796287
+L 478.440728 177.796287
+L 482.275172 177.796287
+L 482.275172 24.418516
+L 478.440728 24.418516
+L 474.606283 24.418516
+L 474.606283 177.796287
+z
+" style="fill: none; stroke: #1f1e1b; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pebdd369ecb">
+   <rect x="114.718906" y="24.418516" width="352.505072" height="153.377771"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/plots/blog/README.md
+++ b/plots/blog/README.md
@@ -1,0 +1,37 @@
+# Current blog figure recipes
+
+This directory contains the current `evals_v2`-backed plotting recipes for the
+[Genomic Language Model Optimization](../../blog/genomic-lm-optimization/)
+article. The imported historical plotting bundle remains under
+[`genomic_lm_optimization/`](genomic_lm_optimization/).
+
+## Mendelian leaderboard heatmaps
+
+Figure 18 (zero-shot) and the collapsed Figure 19 (linear probe) follow the
+canonical scope in [issue #370](https://github.com/Open-Athena/marin-dna/issues/370):
+
+- zero-shot: the six headline models, each using its canonical protocol;
+- probe: the four probe-capable models that overlap the zero-shot panel.
+
+Run from the repository root:
+
+```bash
+uv run python -m plots.blog.figure11_leaderboard_heatmap
+```
+
+The recipe reads current `evals_v2` Mendelian metrics, fails if the expected
+model sets are incomplete, and writes SVG, PNG, and PDF files to
+`plots/output/blog/`. To copy the generated SVGs into the article after review:
+
+```bash
+uv run --project plots/blog/genomic_lm_optimization \
+  python plots/blog/genomic_lm_optimization/src/sync_blog_assets.py \
+  figure11_leaderboard_heatmap__mendelian_llr \
+  figure11_leaderboard_heatmap__mendelian_probe
+```
+
+The shared heatmap renderer was ported from the commit-pinned Figure 11 code in
+[`73dbfa7`](https://github.com/Open-Athena/marin-dna/tree/73dbfa7/plots/blog).
+The article assets reproduce the collaborator-review figures pinned in issue
+#370, with the original blog's reader-facing label `MarinDNA (1B/m5.1)` restored
+in place of the internal run identifier `exp135-1B-m5.1`.

--- a/plots/blog/__init__.py
+++ b/plots/blog/__init__.py
@@ -1,0 +1,1 @@
+"""Reproducible plotting recipes for the Genomic LM Optimization blog."""

--- a/plots/blog/_leaderboard.py
+++ b/plots/blog/_leaderboard.py
@@ -1,0 +1,161 @@
+"""Shared table builder and renderer for Mendelian leaderboard heatmaps."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import polars as pl
+from matplotlib.cm import ScalarMappable
+from matplotlib.colors import Normalize
+from matplotlib.patches import Rectangle
+
+from marin_dna.pipelines.evals.metrics import MACRO_AVG_SUBSET
+from plots.blog.genomic_lm_optimization.src.utils import figure_theme as _figure_theme  # noqa: F401
+from plots.blog.genomic_lm_optimization.src.utils.figure_style import (
+    HEATMAP_CMAP,
+    figsize,
+)
+
+OUTPUT_DIR = Path(__file__).resolve().parents[1] / "output" / "blog"
+
+SUBSET_DISPLAY: dict[str, str] = {
+    "missense_variant": "Missense",
+    "splicing": "Splicing",
+    "5_prime_UTR_variant": "5' UTR",
+    "tss_proximal": "Promoter",
+    "non_coding_transcript_exon_variant": "ncRNA",
+    "3_prime_UTR_variant": "3' UTR",
+    "distal": "Distal",
+    "synonymous_variant": "Synonymous",
+}
+SUBSET_ORDER = list(SUBSET_DISPLAY)
+
+
+def _luminance(rgba: tuple[float, ...] | np.ndarray) -> float:
+    r, g, b = rgba[:3]
+    return float(0.2126 * r + 0.7152 * g + 0.0722 * b)
+
+
+def table_from_normalized(rows: pl.DataFrame) -> pd.DataFrame:
+    """Convert normalized leaderboard rows to an AUPRC-percent heatmap table."""
+    keep = [MACRO_AVG_SUBSET, *SUBSET_ORDER]
+    selected = (
+        rows.filter(pl.col("subset").is_in(keep))
+        .with_columns(value=pl.col("value") * 100.0)
+        .select(["method_display", "family", "subset", "value"])
+    )
+    duplicates = (
+        selected.group_by(["method_display", "family", "subset"])
+        .len()
+        .filter(pl.col("len") != 1)
+    )
+    assert duplicates.height == 0, f"duplicate leaderboard cells:\n{duplicates}"
+    pdf = selected.to_pandas()
+    return pdf.pivot(
+        index=["method_display", "family"], columns="subset", values="value"
+    ).reindex(columns=keep)
+
+
+def _save_figure(fig: plt.Figure, name: str) -> None:
+    """Write deterministic SVG plus local-review PNG and PDF artifacts."""
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    paths: list[Path] = []
+    with mpl.rc_context({"svg.hashsalt": name}):
+        for extension, options in (
+            ("png", {"dpi": 300}),
+            ("pdf", {"metadata": {"CreationDate": None, "ModDate": None}}),
+            ("svg", {"metadata": {"Date": None}}),
+        ):
+            path = OUTPUT_DIR / f"{name}.{extension}"
+            fig.savefig(path, bbox_inches="tight", transparent=True, **options)
+            if extension == "svg":
+                lines = path.read_text().splitlines()
+                path.write_text("\n".join(line.rstrip() for line in lines) + "\n")
+            paths.append(path)
+    print("Wrote " + ", ".join(str(path) for path in paths))
+
+
+def render_heatmap(
+    table: pd.DataFrame,
+    *,
+    title: str,
+    output_name: str,
+) -> None:
+    """Render one independently sorted and color-normalized leaderboard."""
+    table = table.sort_values(MACRO_AVG_SUBSET, ascending=False)
+    display_names = [index[0] for index in table.index]
+    families = [index[1] for index in table.index]
+    column_labels = ["Macro Avg", *SUBSET_DISPLAY.values()]
+    matrix = table[[MACRO_AVG_SUBSET, *SUBSET_ORDER]].to_numpy(dtype=float)
+    n_rows, n_columns = matrix.shape
+
+    finite = matrix[np.isfinite(matrix)]
+    assert finite.size > 0, "leaderboard has no finite values"
+    norm = Normalize(float(finite.min()), float(finite.max()))
+
+    fig, ax = plt.subplots(figsize=figsize(10.0, max(4.4, 0.30 * n_rows)))
+    ax.imshow(matrix, cmap=HEATMAP_CMAP, norm=norm, aspect="auto")
+
+    ax.set_xticks(np.arange(-0.5, n_columns), minor=True)
+    ax.set_yticks(np.arange(-0.5, n_rows), minor=True)
+    ax.grid(which="minor", color="white", linewidth=1.5)
+    ax.tick_params(which="both", length=0)
+
+    for row_index in range(n_rows):
+        for column_index in range(n_columns):
+            value = matrix[row_index, column_index]
+            if not np.isfinite(value):
+                continue
+            text_color = (
+                "white" if _luminance(HEATMAP_CMAP(norm(value))) < 0.5 else "black"
+            )
+            ax.text(
+                column_index,
+                row_index,
+                f"{value:.1f}",
+                ha="center",
+                va="center",
+                fontsize=8,
+                color=text_color,
+                fontweight="bold" if column_index == 0 else "normal",
+            )
+
+    ax.add_patch(
+        Rectangle(
+            (-0.5, -0.5),
+            1,
+            n_rows,
+            fill=False,
+            edgecolor="black",
+            linewidth=2.0,
+            zorder=5,
+        )
+    )
+    ax.set_xticks(range(n_columns))
+    ax.set_xticklabels(column_labels, rotation=30, ha="right", fontsize=9)
+    ax.get_xticklabels()[0].set_fontweight("bold")
+    ax.set_yticks(range(n_rows))
+    ax.set_yticklabels(display_names, fontsize=9)
+    for tick, family in zip(ax.get_yticklabels(), families, strict=True):
+        if family == "marin_dna":
+            tick.set_fontweight("bold")
+    for spine in ax.spines.values():
+        spine.set_visible(False)
+
+    colorbar = fig.colorbar(
+        ScalarMappable(norm=norm, cmap=HEATMAP_CMAP),
+        ax=ax,
+        fraction=0.025,
+        pad=0.02,
+    )
+    colorbar.set_label("AUPRC (%)", fontsize=9)
+    colorbar.ax.tick_params(labelsize=8)
+
+    ax.set_title(title, fontsize=9.5, pad=10)
+    fig.tight_layout()
+    _save_figure(fig, output_name)
+    plt.close(fig)

--- a/plots/blog/figure11_leaderboard_heatmap.py
+++ b/plots/blog/figure11_leaderboard_heatmap.py
@@ -1,0 +1,109 @@
+"""Figure 11: current Mendelian zero-shot and linear-probe leaderboards.
+
+The zero-shot panel contains the six headline models from the original Figure
+11 selection. The probe panel is deliberately restricted to the four models
+that overlap that zero-shot set, matching the canonical review in issue #370.
+
+Run:
+    uv run python -m plots.blog.figure11_leaderboard_heatmap
+
+Outputs:
+    plots/output/blog/figure11_leaderboard_heatmap__mendelian_{llr,probe}.{svg,png,pdf}
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import polars as pl
+
+from marin_dna.pipelines.evals.leaderboard import (
+    DEFAULT_PROTOCOL,
+    normalized_rows,
+    probe_normalized_rows,
+)
+from plots.blog._leaderboard import render_heatmap, table_from_normalized
+
+ZERO_SHOT_DISPLAYS: frozenset[str] = frozenset(
+    {
+        "GPN-Star (M)",
+        "AlphaGenome",
+        "exp135-1B-m5.1",
+        "Evo 2 (40B)",
+        "Evo 2 (7B)",
+        "Evo 2 (1B base)",
+    }
+)
+PROBE_DISPLAYS: frozenset[str] = frozenset(
+    {
+        "exp135-1B-m5.1",
+        "Evo 2 (40B)",
+        "Evo 2 (7B)",
+        "Evo 2 (1B base)",
+    }
+)
+DISPLAY_OVERRIDES: dict[str, str] = {
+    "exp135-1B-m5.1": "MarinDNA (1B/m5.1)",
+}
+
+
+def _table_for_displays(
+    rows: pl.DataFrame,
+    expected_displays: frozenset[str],
+) -> pd.DataFrame:
+    """Select and require the exact editorial model set for one panel."""
+    table = table_from_normalized(rows)
+    mask = table.index.get_level_values("method_display").isin(expected_displays)
+    table = table[mask]
+    actual_displays = frozenset(table.index.get_level_values("method_display"))
+    assert actual_displays == expected_displays, (
+        "leaderboard model set mismatch: "
+        f"missing={sorted(expected_displays - actual_displays)}, "
+        f"unexpected={sorted(actual_displays - expected_displays)}"
+    )
+    table.index = pd.MultiIndex.from_tuples(
+        [
+            (DISPLAY_OVERRIDES.get(display, display), family)
+            for display, family in table.index
+        ],
+        names=table.index.names,
+    )
+    return table
+
+
+def build_mendelian_llr() -> None:
+    """Render the six canonical-protocol zero-shot headline rows."""
+    rows = (
+        normalized_rows("mendelian_traits")
+        .with_columns(
+            pl.col("family")
+            .replace_strict(DEFAULT_PROTOCOL, default=None)
+            .alias("_default")
+        )
+        .filter(pl.col("protocol") == pl.col("_default"))
+    )
+    render_heatmap(
+        _table_for_displays(rows, ZERO_SHOT_DISPLAYS),
+        title="Mendelian VEP benchmark — AUPRC (%) · zero-shot LLR",
+        output_name="figure11_leaderboard_heatmap__mendelian_llr",
+    )
+
+
+def build_mendelian_probe() -> None:
+    """Render only the four probe rows that overlap the zero-shot panel."""
+    render_heatmap(
+        _table_for_displays(
+            probe_normalized_rows("mendelian_traits"),
+            PROBE_DISPLAYS,
+        ),
+        title="Mendelian VEP benchmark — AUPRC (%) · frozen-embedding linear probe",
+        output_name="figure11_leaderboard_heatmap__mendelian_probe",
+    )
+
+
+def build() -> None:
+    build_mendelian_llr()
+    build_mendelian_probe()
+
+
+if __name__ == "__main__":
+    build()

--- a/plots/blog/genomic_lm_optimization/README.md
+++ b/plots/blog/genomic_lm_optimization/README.md
@@ -6,13 +6,19 @@ The imported project comes from [`eric-czech/marin-dna-post-202606`](https://git
 
 ## Reproduce
 
-Run from the MarinDNA repository root using the repository root project. Figures 12–14 import MarinDNA evaluation code and require its Parquet dependencies, so the complete current build does not use this directory’s historical nested lock. The committed CSV snapshots back the transfer, loss-scaling, mixture, and leaderboard figures; Figures 12–14 additionally read the paired endpoint predictions used to recompute both readouts with the same chromosome-weighted AUPRC implementation:
+Run from the MarinDNA repository root using the repository root project. Figures 12–14 import MarinDNA evaluation code and require its Parquet dependencies, so the complete historical build does not use this directory’s nested lock. The committed CSV snapshots back the transfer, loss-scaling, mixture, and historical leaderboard figures; Figures 12–14 additionally read the paired endpoint predictions used to recompute both readouts with the same chromosome-weighted AUPRC implementation:
 
 ```bash
 uv run --frozen python plots/blog/genomic_lm_optimization/src/figures/__main__.py
 ```
 
-Outputs are written to `plots/output/blog/genomic_lm_optimization/` as SVG, PNG, and PDF. Figure 11 also writes its Kaplan-fit report there, and SVG trailing whitespace is normalized.
+Generate the current live-evals leaderboard panels separately:
+
+```bash
+uv run python -m plots.blog.figure11_leaderboard_heatmap
+```
+
+Historical-bundle outputs are written to `plots/output/blog/genomic_lm_optimization/`; the current leaderboard panels are written to `plots/output/blog/`. Both locations contain SVG, PNG, and PDF artifacts. Figure 11 also writes its Kaplan-fit report to the historical output directory, and SVG trailing whitespace is normalized.
 
 After inspecting generated SVGs and PNGs, copy only approved assets into the blog with the explicit sync command:
 
@@ -49,7 +55,8 @@ uv run --project plots/blog/genomic_lm_optimization python plots/blog/genomic_lm
 | 15 | `continued_training_data_exposures.svg` | Authored SVG; no plot recipe | Figure 10 mixture-lineage definitions and token accounting |
 | 16 | `figure16_offline_lineage_llr_prototype.svg` | `src/figures/figure16_offline_lineage_prototype.py` | Existing `evals_v2` Mendelian metric Parquets on S3; mixture results CSV for lineage token accounting |
 | 17 | `figure16_offline_lineage_probe_prototype.svg` (collapsed) | `src/figures/figure16_offline_lineage_prototype.py` | Existing `evals_v2` probe-metric Parquets on S3; mixture results CSV for lineage token accounting |
-| 18 | `figure11_leaderboard_heatmap.svg` | `src/figures/figure11_leaderboard_heatmap.py` | `model_leaderboard.csv` |
+| 18 | `figure11_leaderboard_heatmap__mendelian_llr.svg` | `../figure11_leaderboard_heatmap.py` | Current `evals_v2` Mendelian zero-shot metrics |
+| 19 | `figure11_leaderboard_heatmap__mendelian_probe.svg` (collapsed) | `../figure11_leaderboard_heatmap.py` | Current `evals_v2` Mendelian probe metrics |
 
 The upstream-reweighting analysis remains reproducible in this source bundle but is not currently included in the article.
 Its displayed endpoints confound mixture proportion with continuation budget: the 40% and 50% upstream arms received about 8.3k steps, while the other five arms received about 2.5k, and no exact checkpoint step is retained across all seven runs.

--- a/plots/blog/genomic_lm_optimization/src/sync_blog_assets.py
+++ b/plots/blog/genomic_lm_optimization/src/sync_blog_assets.py
@@ -19,10 +19,19 @@ ASSET_NAMES = (
     "figure16_offline_lineage_llr_prototype",
     "figure16_offline_lineage_probe_prototype",
     "figure11_leaderboard_heatmap",
+    "figure11_leaderboard_heatmap__mendelian_llr",
+    "figure11_leaderboard_heatmap__mendelian_probe",
+)
+CURRENT_LEADERBOARD_NAMES = frozenset(
+    {
+        "figure11_leaderboard_heatmap__mendelian_llr",
+        "figure11_leaderboard_heatmap__mendelian_probe",
+    }
 )
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = PACKAGE_ROOT.parents[2]
 OUTPUT_DIR = REPO_ROOT / "plots" / "output" / "blog" / "genomic_lm_optimization"
+CURRENT_LEADERBOARD_OUTPUT_DIR = REPO_ROOT / "plots" / "output" / "blog"
 BLOG_ASSET_DIR = (
     REPO_ROOT
     / "blog"
@@ -42,7 +51,12 @@ def main() -> None:
 
     BLOG_ASSET_DIR.mkdir(parents=True, exist_ok=True)
     for name in args.names:
-        source = OUTPUT_DIR / f"{name}.svg"
+        source_dir = (
+            CURRENT_LEADERBOARD_OUTPUT_DIR
+            if name in CURRENT_LEADERBOARD_NAMES
+            else OUTPUT_DIR
+        )
+        source = source_dir / f"{name}.svg"
         destination = BLOG_ASSET_DIR / f"{name}.svg"
         if not source.is_file():
             raise FileNotFoundError(f"generate {source} before syncing it")

--- a/tests/test_blog_workspace.py
+++ b/tests/test_blog_workspace.py
@@ -51,7 +51,7 @@ def test_edited_workspace_is_valid_and_baseline_manifest_is_readable() -> None:
     referenced_assets = validate_workspace(config)
     manifest = read_baseline_manifest(config)
 
-    assert len(referenced_assets) == 18
+    assert len(referenced_assets) == 19
     assert len(manifest) == 12
 
 


### PR DESCRIPTION
## Summary

- refresh the genomic LM optimization blog's Mendelian zero-shot leaderboard from current `evals_v2` metrics
- add the overlapping frozen-embedding linear-probe leaderboard as a collapsed Figure 19
- add a reproducible plotting recipe, asset-sync support, and documentation
- revise the leaderboard narrative to highlight the live dashboard, distal-enhancer gains, remaining Evo 2 strengths, and the comparison with AlphaGenome and GPN-Star

## Why

This carries the updated figures reviewed in #370 into the editing branch for #361 while keeping the linear-probe view available without making it the primary panel.

## Validation

- `uv run pytest tests/test_blog_workspace.py tests/pipelines/evals/test_leaderboard.py` (31 passed)
- `uv run ruff check plots/blog/__init__.py plots/blog/_leaderboard.py plots/blog/figure11_leaderboard_heatmap.py plots/blog/genomic_lm_optimization/src/sync_blog_assets.py tests/test_blog_workspace.py`
- `uv run ruff format --check plots/blog/__init__.py plots/blog/_leaderboard.py plots/blog/figure11_leaderboard_heatmap.py plots/blog/genomic_lm_optimization/src/sync_blog_assets.py tests/test_blog_workspace.py`
- `uv run --no-project python src/marin_dna/blog_workspace.py validate` (19 referenced assets)
- `git diff --check`