### PR TITLE
Add tested m5.1 SAE activation hooks

### DIFF
--- a/scripts/issue288/five_way_data.py
+++ b/scripts/issue288/five_way_data.py
@@ -1,0 +1,395 @@
+"""Pinned five-way m5.1 data adapter for the issue #288 SAE experiment.
+
+The m5.1 continuation used five equally weighted sequence sources, but three
+store DNA in ``seq`` while two use ``sequence`` and richer projection
+metadata.  SAELens expects a pretokenized ``input_ids`` column.  This module
+bridges those boundaries without adding SAE dependencies to MarinDNA core.
+
+The source repositories were globally shuffled before sharding, so this
+adapter deliberately does not apply a small-buffer streaming shuffle.  It
+round-robins the five pinned streams, giving exact source balance for every
+complete group of five windows and deterministic replay.
+
+Run a live two-window-per-source audit from the repository root::
+
+    uv run python scripts/issue288/five_way_data.py --windows-per-source 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from functools import partial
+from typing import Any
+
+from datasets import IterableDataset, interleave_datasets, load_dataset
+from transformers import AutoTokenizer, PreTrainedTokenizerBase
+
+WINDOW_BP = 255
+CONTEXT_TOKENS = 256
+N_SOURCES = 5
+DNA_IUPAC = frozenset("ACGTNRYSWKMBDHVacgtnryswkmbdhv")
+GENOMES_V5_COLUMNS = ("id", "seq")
+ZOONOMIA_V1_COLUMNS = (
+    "query_name",
+    "species",
+    "t_chrom",
+    "t_start",
+    "t_end",
+    "t_strand",
+    "t_src_size",
+    "sequence",
+    "augmentation",
+)
+
+TOKENIZER_ID = "marin-dna/tokenizer-char-bos"
+TOKENIZER_REVISION = "a73e9d9ee636f722b4c378703c9e2997857809b2"
+
+
+@dataclass(frozen=True)
+class SourceSpec:
+    """One commit-pinned component of m5.1's equal training mixture."""
+
+    name: str
+    dataset_id: str
+    revision: str
+    text_key: str
+    schema: str
+
+
+SOURCES: tuple[SourceSpec, ...] = (
+    SourceSpec(
+        name="cds",
+        dataset_id=("marin-dna/genomes-v5-genome_set-animals-intervals-v5_255_128"),
+        revision="ffe3e78c99868077c65ad6568e1445d80e480794",
+        text_key="seq",
+        schema="genomes_v5",
+    ),
+    SourceSpec(
+        name="upstream",
+        dataset_id=("marin-dna/genomes-v5-genome_set-animals-intervals-v1_255_128"),
+        revision="d93209847b02a0c9be5c03591a0a5e56ee09c35d",
+        text_key="seq",
+        schema="genomes_v5",
+    ),
+    SourceSpec(
+        name="downstream",
+        dataset_id=("marin-dna/genomes-v5-genome_set-animals-intervals-v15_255_128"),
+        revision="b009afaab756937d75b8da3b1271ad8f0cec0b4d",
+        text_key="seq",
+        schema="genomes_v5",
+    ),
+    SourceSpec(
+        name="ncrna_exon",
+        dataset_id="marin-dna/zoonomia-v1-v3_ncrna_exon",
+        revision="3e48d9ae7c604b99ccfc8bd07e391b960c1ea21a",
+        text_key="sequence",
+        schema="zoonomia_v1",
+    ),
+    SourceSpec(
+        name="ccre_non_promoter",
+        dataset_id="marin-dna/zoonomia-v1-v3_ccre_non_promoter",
+        revision="862485aa18eed53a53e693ba4c2eb45e0afc5087",
+        text_key="sequence",
+        schema="zoonomia_v1",
+    ),
+)
+
+
+@dataclass(frozen=True)
+class BalancedBudget:
+    """Smallest exactly five-way-balanced window budget above a target."""
+
+    requested_activations: int
+    windows_per_source: int
+    total_windows: int
+    actual_activations: int
+
+
+def balanced_budget(requested_activations: int) -> BalancedBudget:
+    """Round an activation target up to whole windows and equal source counts."""
+
+    assert requested_activations > 0
+    windows_per_source = math.ceil(requested_activations / (WINDOW_BP * N_SOURCES))
+    total_windows = windows_per_source * N_SOURCES
+    actual_activations = total_windows * WINDOW_BP
+    assert actual_activations >= requested_activations
+    assert total_windows % N_SOURCES == 0
+    return BalancedBudget(
+        requested_activations=requested_activations,
+        windows_per_source=windows_per_source,
+        total_windows=total_windows,
+        actual_activations=actual_activations,
+    )
+
+
+def _opposite_strand(strand: str) -> str:
+    assert strand in {"+", "-"}
+    return "-" if strand == "+" else "+"
+
+
+def _parse_genomes_v5_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    record_id = row["id"]
+    assert isinstance(record_id, str)
+    coordinate_id, augmentation = record_id.rsplit("_", maxsplit=1)
+    chrom, interval = coordinate_id.rsplit(":", maxsplit=1)
+    start_text, end_text = interval.split("-", maxsplit=1)
+    start = int(start_text)
+    end = int(end_text)
+    assert augmentation in {"+", "-"}
+    return {
+        "record_id": record_id,
+        "species": "",
+        "chrom": chrom,
+        "start": start,
+        "end": end,
+        "source_strand": "",
+        "augmentation": augmentation,
+        "sequence_strand": augmentation,
+        "source_size": -1,
+    }
+
+
+def _parse_zoonomia_v1_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    source_strand = row["t_strand"]
+    augmentation = row["augmentation"]
+    assert source_strand in {"+", "-"}
+    assert augmentation in {"+", "-"}
+    sequence_strand = (
+        source_strand if augmentation == "+" else _opposite_strand(source_strand)
+    )
+    start = int(row["t_start"])
+    end = int(row["t_end"])
+    source_size = int(row["t_src_size"])
+    query_name = row["query_name"]
+    species = row["species"]
+    chrom = row["t_chrom"]
+    assert all(isinstance(value, str) for value in (query_name, species, chrom))
+    record_id = (
+        f"{query_name}:{species}:{chrom}:{start}-{end}_{source_strand}:{augmentation}"
+    )
+    return {
+        "record_id": record_id,
+        "species": species,
+        "chrom": chrom,
+        "start": start,
+        "end": end,
+        "source_strand": source_strand,
+        "augmentation": augmentation,
+        "sequence_strand": sequence_strand,
+        "source_size": source_size,
+    }
+
+
+def reference_position(example: Mapping[str, Any], nucleotide_offset: int) -> int:
+    """Map a 0-based input nucleotide offset back to a reference coordinate."""
+
+    assert 0 <= nucleotide_offset < WINDOW_BP
+    start = int(example["start"])
+    end = int(example["end"])
+    assert end - start == WINDOW_BP
+    sequence_strand = example["sequence_strand"]
+    assert sequence_strand in {"+", "-"}
+    if sequence_strand == "+":
+        position = start + nucleotide_offset
+    else:
+        position = end - 1 - nucleotide_offset
+    assert start <= position < end
+    return position
+
+
+def normalize_and_tokenize_row(
+    row: Mapping[str, Any],
+    *,
+    source: SourceSpec,
+    tokenizer: PreTrainedTokenizerBase,
+) -> dict[str, Any]:
+    """Normalize one source row and enforce the m5.1 token/coordinate contract."""
+
+    assert source.text_key in row, (source.name, source.text_key, sorted(row))
+    sequence = row[source.text_key]
+    assert isinstance(sequence, str)
+    assert len(sequence) == WINDOW_BP, (source.name, len(sequence))
+    unexpected = set(sequence) - DNA_IUPAC
+    assert not unexpected, (source.name, sorted(unexpected))
+
+    if source.schema == "genomes_v5":
+        metadata = _parse_genomes_v5_row(row)
+    elif source.schema == "zoonomia_v1":
+        metadata = _parse_zoonomia_v1_row(row)
+    else:
+        raise AssertionError(f"unsupported schema {source.schema!r}")
+
+    start = int(metadata["start"])
+    end = int(metadata["end"])
+    source_size = int(metadata["source_size"])
+    assert start >= 0
+    assert end - start == WINDOW_BP
+    if source_size >= 0:
+        assert end <= source_size
+
+    encoded = tokenizer(
+        sequence,
+        add_special_tokens=True,
+        padding=False,
+        truncation=False,
+        return_attention_mask=False,
+        return_token_type_ids=False,
+    )
+    input_ids = encoded["input_ids"]
+    assert isinstance(input_ids, list)
+    assert len(input_ids) == CONTEXT_TOKENS, (source.name, len(input_ids))
+    bos_token_id = tokenizer.bos_token_id
+    pad_token_id = tokenizer.pad_token_id
+    assert bos_token_id is not None
+    assert input_ids[0] == bos_token_id
+    assert bos_token_id not in input_ids[1:]
+    if pad_token_id is not None:
+        assert pad_token_id not in input_ids
+
+    unk_token_id = tokenizer.unk_token_id
+    unknown_tokens = (
+        0 if unk_token_id is None else sum(token == unk_token_id for token in input_ids)
+    )
+    normalized = {
+        "input_ids": input_ids,
+        "source": source.name,
+        "sequence": sequence,
+        "unknown_tokens": unknown_tokens,
+        "lowercase_bases": sum(base.islower() for base in sequence),
+        **metadata,
+    }
+    assert reference_position(normalized, 0) in {start, end - 1}
+    assert reference_position(normalized, WINDOW_BP - 1) in {start, end - 1}
+    return normalized
+
+
+def tokenize_source(
+    dataset: IterableDataset,
+    source: SourceSpec,
+    tokenizer: PreTrainedTokenizerBase,
+) -> IterableDataset:
+    """Convert one raw stream to the common pretokenized/provenance schema."""
+
+    columns = dataset.column_names
+    if columns is None:
+        if source.schema == "genomes_v5":
+            columns = list(GENOMES_V5_COLUMNS)
+        elif source.schema == "zoonomia_v1":
+            columns = list(ZOONOMIA_V1_COLUMNS)
+        else:
+            raise AssertionError(f"unsupported schema {source.schema!r}")
+    assert source.text_key in columns, (source.name, source.text_key, columns)
+    return dataset.map(
+        partial(normalize_and_tokenize_row, source=source, tokenizer=tokenizer),
+        remove_columns=list(columns),
+    )
+
+
+def interleave_five_sources(datasets: Sequence[IterableDataset]) -> IterableDataset:
+    """Round-robin five normalized streams with exact deterministic balance."""
+
+    assert len(datasets) == N_SOURCES
+    return interleave_datasets(list(datasets), stopping_strategy="first_exhausted")
+
+
+def build_five_way_dataset(
+    tokenizer: PreTrainedTokenizerBase,
+    sources: Sequence[SourceSpec] = SOURCES,
+) -> IterableDataset:
+    """Load, pin, normalize, tokenize, and round-robin the m5.1 sources."""
+
+    assert len(sources) == N_SOURCES
+    assert len({source.name for source in sources}) == N_SOURCES
+    streams = []
+    for source in sources:
+        raw = load_dataset(
+            source.dataset_id,
+            split="train",
+            streaming=True,
+            revision=source.revision,
+        )
+        assert isinstance(raw, IterableDataset)
+        streams.append(tokenize_source(raw, source, tokenizer))
+    return interleave_five_sources(streams)
+
+
+def audit_live_dataset(windows_per_source: int) -> dict[str, Any]:
+    """Read a small balanced prefix and summarize its enforced invariants."""
+
+    assert windows_per_source > 0
+    tokenizer = AutoTokenizer.from_pretrained(
+        TOKENIZER_ID,
+        revision=TOKENIZER_REVISION,
+    )
+    assert tokenizer.bos_token_id == 2
+    assert tokenizer.pad_token_id == 0
+    assert tokenizer.unk_token_id == 1
+
+    dataset = build_five_way_dataset(tokenizer)
+    expected_order = [source.name for source in SOURCES]
+    source_counts: Counter[str] = Counter()
+    unknown_tokens: Counter[str] = Counter()
+    lowercase_bases: Counter[str] = Counter()
+    first_records: dict[str, str] = {}
+    total_windows = windows_per_source * N_SOURCES
+    for index, row in enumerate(dataset.take(total_windows)):
+        source = row["source"]
+        assert source == expected_order[index % N_SOURCES]
+        assert len(row["input_ids"]) == CONTEXT_TOKENS
+        source_counts[source] += 1
+        unknown_tokens[source] += int(row["unknown_tokens"])
+        lowercase_bases[source] += int(row["lowercase_bases"])
+        first_records.setdefault(source, row["record_id"])
+
+    assert source_counts == Counter(
+        {source.name: windows_per_source for source in SOURCES}
+    )
+    budget_1m = balanced_budget(1_000_000)
+    budget_5m = balanced_budget(5_000_000)
+    return {
+        "tokenizer": {
+            "dataset_id": TOKENIZER_ID,
+            "revision": TOKENIZER_REVISION,
+            "bos_token_id": tokenizer.bos_token_id,
+            "pad_token_id": tokenizer.pad_token_id,
+            "unk_token_id": tokenizer.unk_token_id,
+        },
+        "sources": [asdict(source) for source in SOURCES],
+        "audit": {
+            "source_counts": dict(source_counts),
+            "total_windows": total_windows,
+            "nucleotide_activations": total_windows * WINDOW_BP,
+            "unknown_tokens": dict(unknown_tokens),
+            "lowercase_bases": dict(lowercase_bases),
+            "first_records": first_records,
+        },
+        "balanced_budgets": {
+            "1m": asdict(budget_1m),
+            "5m": asdict(budget_5m),
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--windows-per-source",
+        type=int,
+        default=2,
+        help="number of live rows to audit from each of the five streams",
+    )
+    args = parser.parse_args()
+    print(
+        json.dumps(
+            audit_live_dataset(args.windows_per_source), indent=2, sort_keys=True
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue288/live_saelens_data_smoke.py
+++ b/scripts/issue288/live_saelens_data_smoke.py
@@ -1,0 +1,101 @@
+"""Exercise the real five-way m5.1 stream through pinned SAELens.
+
+This uses the tiny random Qwen3 model from ``saelens_compatibility.py``;
+there is no m5.1 checkpoint download and no accelerator launch.  Run from the
+repository root with the same commit-pinned SAELens dependency::
+
+    uv run --with \
+      'sae-lens @ git+https://github.com/decoderesearch/SAELens@8be14080485952f729ed58d674bcddf9778e0aa4' \
+      python scripts/issue288/live_saelens_data_smoke.py
+"""
+
+from __future__ import annotations
+
+import json
+
+import torch
+from sae_lens.load_model import HookedProxyLM
+from sae_lens.training.activations_store import ActivationsStore
+from transformers import AutoTokenizer
+
+from five_way_data import (
+    CONTEXT_TOKENS,
+    SOURCES,
+    TOKENIZER_ID,
+    TOKENIZER_REVISION,
+    WINDOW_BP,
+    build_five_way_dataset,
+)
+from saelens_compatibility import (
+    HIDDEN_SIZE,
+    HOOK_NAME,
+    make_model,
+)
+
+BATCH_WINDOWS = len(SOURCES)
+
+
+@torch.no_grad()
+def run_live_smoke() -> dict[str, object]:
+    tokenizer = AutoTokenizer.from_pretrained(
+        TOKENIZER_ID,
+        revision=TOKENIZER_REVISION,
+    )
+    bos_token_id = tokenizer.bos_token_id
+    assert bos_token_id is not None
+
+    dataset = build_five_way_dataset(tokenizer)
+    preview = list(dataset.take(BATCH_WINDOWS))
+    expected_order = [source.name for source in SOURCES]
+    assert [row["source"] for row in preview] == expected_order
+    assert all(len(row["input_ids"]) == CONTEXT_TOKENS for row in preview)
+
+    model = HookedProxyLM(
+        make_model(),
+        tokenizer,
+        hook_names=[HOOK_NAME],
+    )
+    store = ActivationsStore(
+        model=model,
+        dataset=dataset,
+        streaming=True,
+        hook_name=HOOK_NAME,
+        hook_head_index=None,
+        context_size=CONTEXT_TOKENS,
+        d_in=HIDDEN_SIZE,
+        n_batches_in_buffer=1,
+        total_training_tokens=BATCH_WINDOWS * WINDOW_BP,
+        store_batch_size_prompts=BATCH_WINDOWS,
+        train_batch_size_tokens=BATCH_WINDOWS * WINDOW_BP,
+        prepend_bos=True,
+        normalize_activations="none",
+        device=torch.device("cpu"),
+        dtype="float32",
+        cached_activations_path=None,
+        model_kwargs=None,
+        autocast_lm=False,
+        dataset_trust_remote_code=False,
+        seqpos_slice=(None,),
+        exclude_special_tokens=torch.tensor([bos_token_id], dtype=torch.long),
+        disable_concat_sequences=True,
+        sequence_separator_token="bos",
+        activations_mixing_fraction=0.0,
+        use_chat_formatting=False,
+    )
+    activations = store.get_filtered_llm_batch()
+    expected_shape = (BATCH_WINDOWS * WINDOW_BP, HIDDEN_SIZE)
+    assert tuple(activations.shape) == expected_shape
+    assert torch.isfinite(activations).all()
+
+    return {
+        "source_order": expected_order,
+        "input_shape": [BATCH_WINDOWS, CONTEXT_TOKENS],
+        "bos_tokens_removed": BATCH_WINDOWS,
+        "activation_shape": list(activations.shape),
+        "activations_are_finite": True,
+        "first_records": {row["source"]: row["record_id"] for row in preview},
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(run_live_smoke(), indent=2, sort_keys=True))

--- a/scripts/issue288/saelens_compatibility.py
+++ b/scripts/issue288/saelens_compatibility.py
@@ -1,0 +1,477 @@
+"""Local SAELens compatibility spike for issue #288.
+
+This deliberately uses a tiny randomly initialized Qwen3 causal LM.  It tests
+the interfaces needed by an eventual m5.1 SAE experiment without downloading
+the 1.12B-parameter checkpoint or launching accelerator resources.
+
+Run from the repository root with the commit-pinned SAELens dependency::
+
+    uv run --with \
+      'sae-lens @ git+https://github.com/decoderesearch/SAELens@8be14080485952f729ed58d674bcddf9778e0aa4' \
+      python scripts/issue288/saelens_compatibility.py
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import torch
+from datasets import Dataset
+from sae_lens.config import LanguageModelSAERunnerConfig, LoggingConfig
+from sae_lens.evals import get_recons_loss
+from sae_lens.llm_sae_training_runner import LanguageModelSAETrainingRunner
+from sae_lens.load_model import HookedProxyLM
+from sae_lens.saes.batchtopk_sae import (
+    BatchTopKTrainingSAE,
+    BatchTopKTrainingSAEConfig,
+)
+from sae_lens.saes.jumprelu_sae import JumpReLUSAE
+from sae_lens.saes.sae import SAE, SAEMetadata, TrainStepInput
+from sae_lens.training.activation_scaler import ActivationScaler
+from sae_lens.training.activations_store import ActivationsStore
+from transformers import Qwen3Config, Qwen3ForCausalLM
+
+SAELENS_COMMIT = "8be14080485952f729ed58d674bcddf9778e0aa4"
+SEQUENCE_TOKENS = 256
+NUCLEOTIDE_TOKENS = 255
+BOS_TOKEN_ID = 1
+PAD_TOKEN_ID = 0
+VOCAB_SIZE = 8
+HIDDEN_SIZE = 32
+DICT_SIZE = 128
+K = 4
+BATCH_SIZE = 2
+HOOK_NAME = "model.layers.0"
+
+
+@dataclass(frozen=True)
+class SpikeResults:
+    saelens_commit: str
+    hook_name: str
+    hook_shape: tuple[int, ...]
+    hook_is_logit_invariant: bool
+    bos_tokens_removed: int
+    nucleotide_activations: int
+    batchtopk_total_nonzero: int
+    batchtopk_mean_l0: float
+    reconstruction_metrics_are_finite: bool
+    checkpoint_type: str
+    checkpoint_roundtrip_matches: bool
+    checkpoint_active_set_matches: bool
+    checkpoint_max_abs_diff: float
+    checkpoint_training_nonzero: int
+    checkpoint_inference_nonzero: int
+    inference_is_partition_invariant: bool
+    native_sequence_columns_supported: bool
+    activation_store_reset_works: bool
+    runner_completed: bool
+    runner_training_l0: float
+    runner_output_type: str
+    runner_checkpoint_saved: bool
+    runner_resume_completed: bool
+
+
+class TinyDnaTokenizer:
+    """Tokenizer metadata needed by SAELens for pretokenized toy inputs."""
+
+    bos_token_id = BOS_TOKEN_ID
+    pad_token_id = PAD_TOKEN_ID
+    eos_token_id = 2
+    all_special_ids = [PAD_TOKEN_ID, BOS_TOKEN_ID, eos_token_id]
+
+
+def make_input_ids() -> torch.Tensor:
+    generator = torch.Generator().manual_seed(288)
+    input_ids = torch.randint(
+        3,
+        VOCAB_SIZE,
+        (BATCH_SIZE, SEQUENCE_TOKENS),
+        generator=generator,
+        dtype=torch.long,
+    )
+    input_ids[:, 0] = BOS_TOKEN_ID
+    assert torch.all(input_ids[:, 0] == BOS_TOKEN_ID)
+    assert not torch.any(input_ids[:, 1:] == BOS_TOKEN_ID)
+    assert not torch.any(input_ids == PAD_TOKEN_ID)
+    return input_ids
+
+
+def make_model() -> Qwen3ForCausalLM:
+    torch.manual_seed(288)
+    config = Qwen3Config(
+        vocab_size=VOCAB_SIZE,
+        hidden_size=HIDDEN_SIZE,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        max_position_embeddings=SEQUENCE_TOKENS,
+        bos_token_id=BOS_TOKEN_ID,
+        eos_token_id=TinyDnaTokenizer.eos_token_id,
+        pad_token_id=PAD_TOKEN_ID,
+    )
+    model = Qwen3ForCausalLM(config)
+    model.eval()
+    return model
+
+
+def make_store(
+    model: HookedProxyLM,
+    input_ids: torch.Tensor,
+    *,
+    exclude_bos: bool,
+) -> ActivationsStore:
+    dataset = Dataset.from_dict({"input_ids": input_ids.tolist()})
+    excluded = torch.tensor([BOS_TOKEN_ID], dtype=torch.long) if exclude_bos else None
+    return ActivationsStore(
+        model=model,
+        dataset=dataset,
+        streaming=False,
+        hook_name=HOOK_NAME,
+        hook_head_index=None,
+        context_size=SEQUENCE_TOKENS,
+        d_in=HIDDEN_SIZE,
+        n_batches_in_buffer=2,
+        total_training_tokens=BATCH_SIZE,
+        store_batch_size_prompts=BATCH_SIZE,
+        train_batch_size_tokens=BATCH_SIZE * NUCLEOTIDE_TOKENS,
+        prepend_bos=True,
+        normalize_activations="none",
+        device=torch.device("cpu"),
+        dtype="float32",
+        cached_activations_path=None,
+        model_kwargs=None,
+        autocast_lm=False,
+        dataset_trust_remote_code=False,
+        seqpos_slice=(None,),
+        exclude_special_tokens=excluded,
+        disable_concat_sequences=True,
+        sequence_separator_token="bos",
+        activations_mixing_fraction=0.0,
+        use_chat_formatting=False,
+    )
+
+
+def native_sequence_columns_are_supported(model: HookedProxyLM) -> bool:
+    """Return whether SAELens accepts MarinDNA's raw ``seq`` column directly."""
+
+    dataset = Dataset.from_dict({"seq": ["A" * NUCLEOTIDE_TOKENS]})
+    try:
+        ActivationsStore(
+            model=model,
+            dataset=dataset,
+            streaming=False,
+            hook_name=HOOK_NAME,
+            hook_head_index=None,
+            context_size=SEQUENCE_TOKENS,
+            d_in=HIDDEN_SIZE,
+            n_batches_in_buffer=1,
+            total_training_tokens=1,
+            store_batch_size_prompts=1,
+            train_batch_size_tokens=NUCLEOTIDE_TOKENS,
+            prepend_bos=True,
+            normalize_activations="none",
+            device=torch.device("cpu"),
+            dtype="float32",
+            dataset_trust_remote_code=False,
+            disable_concat_sequences=True,
+        )
+    except ValueError as error:
+        assert "Dataset must have" in str(error)
+        return False
+    return True
+
+
+def activation_store_reset_works(model: HookedProxyLM, input_ids: torch.Tensor) -> bool:
+    """Exercise the public reset method before the input iterator is exhausted."""
+
+    store = make_store(model, input_ids, exclude_bos=True)
+    first = store.get_batch_tokens(batch_size=1)
+    store.reset_input_dataset()
+    after_reset = store.get_batch_tokens(batch_size=1)
+    return torch.equal(first, after_reset)
+
+
+def make_sae() -> BatchTopKTrainingSAE:
+    metadata = SAEMetadata(
+        model_name="tiny-random-qwen3",
+        model_class_name="AutoModelForCausalLM",
+        hook_name=HOOK_NAME,
+        hook_head_index=None,
+        context_size=SEQUENCE_TOKENS,
+        prepend_bos=True,
+        exclude_special_tokens=[BOS_TOKEN_ID],
+    )
+    config = BatchTopKTrainingSAEConfig(
+        d_in=HIDDEN_SIZE,
+        d_sae=DICT_SIZE,
+        k=K,
+        topk_threshold_lr=1.0,
+        dtype="float32",
+        device="cpu",
+        normalize_activations="none",
+        metadata=metadata,
+    )
+    return BatchTopKTrainingSAE(config)
+
+
+def run_one_step_runner(
+    model: HookedProxyLM,
+    input_ids: torch.Tensor,
+) -> tuple[bool, float, str, bool, bool]:
+    """Run the public training runner for one 510-activation optimizer step."""
+
+    dataset = Dataset.from_dict({"input_ids": input_ids.tolist()})
+    sae_config = make_sae().cfg
+    with tempfile.TemporaryDirectory(prefix="issue288-saelens-runner-") as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        runner_config = LanguageModelSAERunnerConfig(
+            sae=sae_config,
+            model_name="tiny-random-qwen3",
+            model_class_name="AutoModelForCausalLM",
+            hook_name=HOOK_NAME,
+            dataset_path="override-pretokenized-dna",
+            streaming=False,
+            context_size=SEQUENCE_TOKENS,
+            n_batches_in_buffer=2,
+            training_tokens=BATCH_SIZE * NUCLEOTIDE_TOKENS,
+            store_batch_size_prompts=BATCH_SIZE,
+            train_batch_size_tokens=BATCH_SIZE * NUCLEOTIDE_TOKENS,
+            prepend_bos=True,
+            activations_mixing_fraction=0.0,
+            device="cpu",
+            dtype="float32",
+            exclude_special_tokens=[BOS_TOKEN_ID],
+            n_batches_for_norm_estimate=1,
+            n_eval_batches=1,
+            logger=LoggingConfig(log_to_wandb=False, wandb_id="issue288"),
+            n_checkpoints=0,
+            checkpoint_path=str(tmp_path / "checkpoints"),
+            save_final_checkpoint=True,
+            output_path=str(tmp_path / "output"),
+            verbose=False,
+        )
+        runner = LanguageModelSAETrainingRunner(
+            runner_config,
+            override_dataset=dataset,
+            override_model=model,
+        )
+        with torch.enable_grad():
+            trained_sae = runner.run()
+
+        training_l0 = float(trained_sae.cfg.metadata.l0)
+        assert training_l0 == K
+        output_sae = SAE.load_from_disk(tmp_path / "output", device="cpu")
+        checkpoint_dir = (
+            tmp_path
+            / "checkpoints"
+            / "issue288"
+            / f"final_{BATCH_SIZE * NUCLEOTIDE_TOKENS}"
+        )
+        checkpoint_saved = checkpoint_dir.exists()
+        assert checkpoint_saved
+
+        resume_config = LanguageModelSAERunnerConfig(
+            sae=make_sae().cfg,
+            model_name="tiny-random-qwen3",
+            model_class_name="AutoModelForCausalLM",
+            hook_name=HOOK_NAME,
+            dataset_path="override-pretokenized-dna",
+            streaming=False,
+            context_size=SEQUENCE_TOKENS,
+            n_batches_in_buffer=2,
+            training_tokens=2 * BATCH_SIZE * NUCLEOTIDE_TOKENS,
+            store_batch_size_prompts=BATCH_SIZE,
+            train_batch_size_tokens=BATCH_SIZE * NUCLEOTIDE_TOKENS,
+            prepend_bos=True,
+            activations_mixing_fraction=0.0,
+            device="cpu",
+            dtype="float32",
+            exclude_special_tokens=[BOS_TOKEN_ID],
+            n_batches_for_norm_estimate=1,
+            n_eval_batches=1,
+            logger=LoggingConfig(log_to_wandb=False, wandb_id="issue288-resume"),
+            n_checkpoints=0,
+            checkpoint_path=str(tmp_path / "resumed-checkpoints"),
+            save_final_checkpoint=False,
+            output_path=None,
+            resume_from_checkpoint=str(checkpoint_dir),
+            verbose=False,
+        )
+        resume_runner = LanguageModelSAETrainingRunner(
+            resume_config,
+            override_dataset=dataset,
+            override_model=model,
+        )
+        with torch.enable_grad():
+            resumed_sae = resume_runner.run()
+        assert float(resumed_sae.cfg.metadata.l0) == K
+        return True, training_l0, type(output_sae).__name__, checkpoint_saved, True
+
+
+@torch.no_grad()
+def run_spike() -> SpikeResults:
+    input_ids = make_input_ids()
+    raw_model = make_model()
+    with torch.no_grad():
+        logits_before_hook = raw_model(input_ids=input_ids).logits.clone()
+
+    module_names = {name for name, _ in raw_model.named_modules()}
+    assert HOOK_NAME in module_names, (
+        f"expected Qwen3 hook {HOOK_NAME!r}; nearby names: "
+        f"{sorted(name for name in module_names if 'layers.0' in name)}"
+    )
+    wrapped_model = HookedProxyLM(
+        raw_model,
+        TinyDnaTokenizer(),  # type: ignore[arg-type]
+        hook_names=[HOOK_NAME],
+    )
+    logits_after_hook, cache = wrapped_model.run_with_cache(
+        input_ids,
+        names_filter=[HOOK_NAME],
+        prepend_bos=False,
+    )
+    hook_activations = cache[HOOK_NAME]
+    assert hook_activations.shape == (
+        BATCH_SIZE,
+        SEQUENCE_TOKENS,
+        HIDDEN_SIZE,
+    )
+    hook_is_logit_invariant = torch.equal(logits_before_hook, logits_after_hook)
+    assert hook_is_logit_invariant
+
+    raw_store = make_store(wrapped_model, input_ids, exclude_bos=False)
+    raw_activations, raw_tokens = raw_store.get_raw_llm_batch()
+    assert raw_tokens is not None
+    assert raw_activations.shape == (
+        BATCH_SIZE * SEQUENCE_TOKENS,
+        HIDDEN_SIZE,
+    )
+    assert torch.equal(raw_tokens.reshape_as(input_ids), input_ids)
+    assert int((raw_tokens == BOS_TOKEN_ID).sum()) == BATCH_SIZE
+
+    filtered_store = make_store(wrapped_model, input_ids, exclude_bos=True)
+    filtered_activations = filtered_store.get_filtered_llm_batch()
+    expected_nucleotide_activations = BATCH_SIZE * NUCLEOTIDE_TOKENS
+    assert filtered_activations.shape == (
+        expected_nucleotide_activations,
+        HIDDEN_SIZE,
+    )
+
+    sae = make_sae()
+    per_window_activations = filtered_activations.reshape(
+        BATCH_SIZE, NUCLEOTIDE_TOKENS, HIDDEN_SIZE
+    )
+    feature_acts = sae.encode(per_window_activations)
+    total_nonzero = int(torch.count_nonzero(feature_acts))
+    expected_nonzero = K * expected_nucleotide_activations
+    assert total_nonzero == expected_nonzero
+    mean_l0 = total_nonzero / expected_nucleotide_activations
+    assert mean_l0 == K
+
+    step_output = sae.training_forward_pass(
+        TrainStepInput(
+            sae_in=per_window_activations,
+            coefficients={},
+            dead_neuron_mask=None,
+            n_training_steps=0,
+            is_logging_step=False,
+        )
+    )
+    assert torch.isfinite(step_output.loss)
+    assert sae.topk_threshold.item() > 0
+
+    metrics = get_recons_loss(
+        sae=sae,
+        model=wrapped_model,
+        activation_scaler=ActivationScaler(),
+        batch_tokens=input_ids,
+        compute_kl=True,
+        compute_ce_loss=True,
+        ignore_tokens=[BOS_TOKEN_ID],
+    )
+    reconstruction_metrics_are_finite = all(
+        torch.isfinite(value).all().item() for value in metrics.values()
+    )
+    assert reconstruction_metrics_are_finite
+
+    with tempfile.TemporaryDirectory(prefix="issue288-saelens-") as tmp_dir:
+        sae.save_inference_model(tmp_dir)
+        inference_sae = SAE.load_from_disk(tmp_dir, device="cpu")
+        assert isinstance(inference_sae, JumpReLUSAE)
+
+        training_features = sae.encode(per_window_activations)
+        inference_features = inference_sae.encode(per_window_activations)
+        checkpoint_active_set_matches = torch.equal(
+            training_features != 0, inference_features != 0
+        )
+        checkpoint_max_abs_diff = float(
+            (training_features - inference_features).abs().max()
+        )
+        checkpoint_roundtrip_matches = torch.allclose(
+            training_features,
+            inference_features,
+            rtol=1e-5,
+            atol=1e-6,
+        )
+        checkpoint_training_nonzero = int(torch.count_nonzero(training_features))
+        checkpoint_inference_nonzero = int(torch.count_nonzero(inference_features))
+
+        whole = inference_sae(per_window_activations)
+        split = torch.cat(
+            [
+                inference_sae(per_window_activations[i : i + 1])
+                for i in range(BATCH_SIZE)
+            ],
+            dim=0,
+        )
+        inference_is_partition_invariant = torch.equal(whole, split)
+        assert inference_is_partition_invariant
+
+        config_path = Path(tmp_dir) / "cfg.json"
+        assert config_path.exists()
+
+    reset_works = activation_store_reset_works(wrapped_model, input_ids)
+    (
+        runner_completed,
+        runner_l0,
+        runner_output_type,
+        runner_checkpoint_saved,
+        runner_resume_completed,
+    ) = run_one_step_runner(wrapped_model, input_ids)
+
+    return SpikeResults(
+        saelens_commit=SAELENS_COMMIT,
+        hook_name=HOOK_NAME,
+        hook_shape=tuple(hook_activations.shape),
+        hook_is_logit_invariant=hook_is_logit_invariant,
+        bos_tokens_removed=BATCH_SIZE,
+        nucleotide_activations=expected_nucleotide_activations,
+        batchtopk_total_nonzero=total_nonzero,
+        batchtopk_mean_l0=mean_l0,
+        reconstruction_metrics_are_finite=reconstruction_metrics_are_finite,
+        checkpoint_type=type(inference_sae).__name__,
+        checkpoint_roundtrip_matches=checkpoint_roundtrip_matches,
+        checkpoint_active_set_matches=checkpoint_active_set_matches,
+        checkpoint_max_abs_diff=checkpoint_max_abs_diff,
+        checkpoint_training_nonzero=checkpoint_training_nonzero,
+        checkpoint_inference_nonzero=checkpoint_inference_nonzero,
+        inference_is_partition_invariant=inference_is_partition_invariant,
+        native_sequence_columns_supported=native_sequence_columns_are_supported(
+            wrapped_model
+        ),
+        activation_store_reset_works=reset_works,
+        runner_completed=runner_completed,
+        runner_training_l0=runner_l0,
+        runner_output_type=runner_output_type,
+        runner_checkpoint_saved=runner_checkpoint_saved,
+        runner_resume_completed=runner_resume_completed,
+    )
+
+
+if __name__ == "__main__":
+    print(json.dumps(asdict(run_spike()), indent=2, sort_keys=True))

--- a/src/marin_dna/model/sae.py
+++ b/src/marin_dna/model/sae.py
@@ -1,0 +1,468 @@
+"""m5.1 activation extraction and genomic-coordinate alignment for SAEs.
+
+The first SAE milestone needs two correctness properties before any training:
+
+* observing a post-block residual stream must not change model logits; and
+* every observed vector or next-base score must retain its 0-based, half-open
+  reference coordinate, including for reverse-complemented inputs.
+
+This module is intentionally specific to the m5.1 checkpoint.  Its fixed model
+and tokenizer dimensions make silent use of a wrong checkpoint, EOS-bearing
+tokenizer, padded batch, or incorrectly sized genomic window fail immediately.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Literal, Sequence
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+M51_NUM_BLOCKS = 19
+M51_HIDDEN_SIZE = 1920
+M51_WINDOW_BP = 255
+M51_BOS_TOKENS = 1
+M51_SEQUENCE_TOKENS = M51_BOS_TOKENS + M51_WINDOW_BP
+
+
+@dataclass(frozen=True)
+class M51GenomicWindow:
+    """Reference interval and source strand for one full m5.1 input window."""
+
+    chrom: str
+    start: int
+    end: int
+    strand: Literal["+", "-"]
+
+    def __post_init__(self) -> None:
+        assert self.chrom, "chrom must be non-empty"
+        assert self.start >= 0, f"window start must be non-negative, got {self.start}"
+        assert self.end > self.start, (
+            f"window end {self.end} must exceed start {self.start}"
+        )
+        assert self.end - self.start == M51_WINDOW_BP, (
+            f"m5.1 windows must span {M51_WINDOW_BP} bp, got "
+            f"{self.chrom}:{self.start}-{self.end} ({self.end - self.start} bp)"
+        )
+        assert self.strand in ("+", "-"), (
+            f"strand must be '+' or '-', got {self.strand!r}"
+        )
+
+
+@dataclass(frozen=True)
+class ReferenceCoordinateBatch:
+    """Per-position 0-based, half-open reference intervals in model order."""
+
+    chroms: tuple[str, ...]
+    strands: tuple[Literal["+", "-"], ...]
+    starts: Tensor
+    ends: Tensor
+
+    def __post_init__(self) -> None:
+        batch_size = len(self.chroms)
+        assert len(self.strands) == batch_size
+        assert self.starts.shape == (batch_size, M51_WINDOW_BP), (
+            f"coordinate starts must have shape ({batch_size}, {M51_WINDOW_BP}), "
+            f"got {tuple(self.starts.shape)}"
+        )
+        assert self.ends.shape == self.starts.shape
+        assert self.starts.dtype == torch.long
+        assert self.ends.dtype == torch.long
+        assert torch.equal(self.ends, self.starts + 1), (
+            "every stored nucleotide coordinate must be a 1-bp half-open interval"
+        )
+
+
+@dataclass(frozen=True)
+class M51ActivationBatch:
+    """BOS-stripped post-block residuals and their reference coordinates."""
+
+    activations: Tensor
+    coordinates: ReferenceCoordinateBatch
+    block_index: int
+
+    def __post_init__(self) -> None:
+        batch_size = len(self.coordinates.chroms)
+        assert self.activations.shape == (
+            batch_size,
+            M51_WINDOW_BP,
+            M51_HIDDEN_SIZE,
+        ), (
+            "BOS-stripped m5.1 activations must have shape "
+            f"({batch_size}, {M51_WINDOW_BP}, {M51_HIDDEN_SIZE}), got "
+            f"{tuple(self.activations.shape)}"
+        )
+        assert 0 <= self.block_index < M51_NUM_BLOCKS
+        assert torch.isfinite(self.activations).all(), "activations contain NaN or inf"
+
+    @property
+    def report_block(self) -> int:
+        """Human-facing 1-based block number corresponding to ``block_index``."""
+
+        return self.block_index + 1
+
+
+@dataclass(frozen=True)
+class M51NextBaseBatch:
+    """Next-base logits, target IDs, and target reference coordinates.
+
+    Entry ``logits[b, i]`` came from model token position ``i`` and predicts
+    ``target_ids[b, i] == input_ids[b, i + 1]``.  The attached coordinate is
+    therefore the following input base, never the base at the logit's own token
+    position.
+    """
+
+    logits: Tensor
+    target_ids: Tensor
+    coordinates: ReferenceCoordinateBatch
+
+    def __post_init__(self) -> None:
+        batch_size = len(self.coordinates.chroms)
+        assert self.logits.ndim == 3
+        assert self.logits.shape[:2] == (batch_size, M51_WINDOW_BP)
+        assert self.target_ids.shape == (batch_size, M51_WINDOW_BP)
+        assert torch.isfinite(self.logits).all(), "next-base logits contain NaN or inf"
+
+
+@dataclass(frozen=True)
+class FrozenM51:
+    """Frozen, evaluation-mode m5.1 model and its validated tokenizer."""
+
+    model: nn.Module
+    tokenizer: Any
+
+
+def _m51_blocks(model: nn.Module) -> nn.ModuleList:
+    """Return m5.1's Qwen3 decoder blocks, failing on a wrong model layout."""
+
+    base_model = getattr(model, "model", None)
+    blocks = getattr(base_model, "layers", None)
+    assert isinstance(blocks, nn.ModuleList), (
+        "expected m5.1 Qwen-style decoder blocks at model.model.layers"
+    )
+    assert len(blocks) == M51_NUM_BLOCKS, (
+        f"m5.1 must have {M51_NUM_BLOCKS} decoder blocks, got {len(blocks)}"
+    )
+    return blocks
+
+
+def validate_m51_model(model: nn.Module) -> None:
+    """Assert that ``model`` has the architecture expected by the SAE pipeline."""
+
+    config = getattr(model, "config", None)
+    assert config is not None, "model has no Hugging Face config"
+    hidden_size = getattr(config, "hidden_size", None)
+    num_hidden_layers = getattr(config, "num_hidden_layers", None)
+    assert hidden_size == M51_HIDDEN_SIZE, (
+        f"m5.1 hidden_size must be {M51_HIDDEN_SIZE}, got {hidden_size}"
+    )
+    assert num_hidden_layers == M51_NUM_BLOCKS, (
+        f"m5.1 num_hidden_layers must be {M51_NUM_BLOCKS}, got {num_hidden_layers}"
+    )
+    _m51_blocks(model)
+
+
+def _validate_m51_tokenizer(tokenizer: Any) -> None:
+    """Assert one BOS + 255 bases and no EOS/padding for a full window."""
+
+    assert tokenizer.bos_token_id is not None, "m5.1 tokenizer must define BOS"
+    assert tokenizer.pad_token_id is not None, "m5.1 tokenizer must define PAD"
+    encoded = tokenizer(
+        "A" * M51_WINDOW_BP,
+        add_special_tokens=True,
+        return_attention_mask=True,
+        return_tensors="pt",
+    )
+    input_ids = encoded["input_ids"]
+    attention_mask = encoded["attention_mask"]
+    assert input_ids.shape == (1, M51_SEQUENCE_TOKENS), (
+        "m5.1 tokenizer must encode 255 bp as one BOS + 255 nucleotide tokens; "
+        f"got shape {tuple(input_ids.shape)}"
+    )
+    assert input_ids[0, 0].item() == tokenizer.bos_token_id
+    assert not torch.eq(input_ids[:, 1:], tokenizer.bos_token_id).any()
+    assert torch.all(attention_mask == 1), (
+        "full m5.1 window unexpectedly contains padding"
+    )
+    assert not torch.eq(input_ids, tokenizer.pad_token_id).any(), (
+        "full m5.1 window unexpectedly contains a PAD token"
+    )
+
+
+def load_frozen_m51(
+    checkpoint_path: str | Path,
+    *,
+    device: str | torch.device,
+    dtype: torch.dtype = torch.bfloat16,
+) -> FrozenM51:
+    """Load the local Hugging Face m5.1 checkpoint for read-only extraction.
+
+    ``checkpoint_path`` is expected to be the locally staged form of the
+    registry's GCS checkpoint.  Staging is deliberately outside this function:
+    downloads and accelerator allocation are explicit experiment operations.
+    """
+
+    checkpoint_path = Path(checkpoint_path)
+    assert checkpoint_path.exists(), (
+        f"m5.1 checkpoint does not exist: {checkpoint_path}"
+    )
+    tokenizer: Any = AutoTokenizer.from_pretrained(checkpoint_path)
+    _validate_m51_tokenizer(tokenizer)
+    model: nn.Module = AutoModelForCausalLM.from_pretrained(
+        checkpoint_path,
+        trust_remote_code=True,
+        torch_dtype=dtype,
+    )
+    validate_m51_model(model)
+    model.to(device)
+    model.requires_grad_(False)
+    model.eval()
+    assert not model.training
+    assert all(not parameter.requires_grad for parameter in model.parameters())
+    return FrozenM51(model=model, tokenizer=tokenizer)
+
+
+def _post_block_hidden(output: Any) -> Tensor:
+    """Extract the residual tensor from the m5.1 decoder block hook output."""
+
+    hidden = output[0] if isinstance(output, (tuple, list)) else output
+    assert isinstance(hidden, Tensor), (
+        f"m5.1 decoder block returned {type(output).__name__}, expected Tensor or tuple[Tensor]"
+    )
+    return hidden
+
+
+class M51PostBlockCapture:
+    """Read-only forward hook for one m5.1 post-block residual stream.
+
+    The capture can span a streaming loop.  Call :meth:`pop` exactly once after
+    every model forward so a stale activation cannot be paired with a new batch.
+    """
+
+    def __init__(self, model: nn.Module, block_index: int) -> None:
+        validate_m51_model(model)
+        assert 0 <= block_index < M51_NUM_BLOCKS, (
+            f"block_index must be in [0, {M51_NUM_BLOCKS}), got {block_index}"
+        )
+        self._block = _m51_blocks(model)[block_index]
+        self.block_index = block_index
+        self._handle: torch.utils.hooks.RemovableHandle | None = None
+        self._captured: list[Tensor] = []
+
+    @property
+    def report_block(self) -> int:
+        """Human-facing 1-based block number corresponding to ``block_index``."""
+
+        return self.block_index + 1
+
+    def __enter__(self) -> M51PostBlockCapture:
+        assert self._handle is None, "capture hook is already registered"
+
+        def _capture(_module: nn.Module, _inputs: tuple[Any, ...], output: Any) -> None:
+            self._captured.append(_post_block_hidden(output).detach())
+
+        self._handle = self._block.register_forward_hook(_capture)
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        assert self._handle is not None, "capture hook was not registered"
+        self._handle.remove()
+        self._handle = None
+        if exc_type is None:
+            assert not self._captured, (
+                "unconsumed activation remains; call capture.pop() after every forward"
+            )
+        else:
+            self._captured.clear()
+
+    def pop(self) -> Tensor:
+        """Return the one activation emitted since the previous ``pop``."""
+
+        assert self._handle is not None, "capture hook is not registered"
+        assert len(self._captured) == 1, (
+            f"expected exactly one block activation, captured {len(self._captured)}; "
+            "run one model forward between capture.pop() calls"
+        )
+        return self._captured.pop()
+
+
+def _validate_m51_inputs(
+    input_ids: Tensor,
+    attention_mask: Tensor,
+    windows: Sequence[M51GenomicWindow],
+    *,
+    bos_token_id: int,
+    pad_token_id: int,
+) -> None:
+    batch_size = len(windows)
+    assert batch_size > 0, "m5.1 activation batch must be non-empty"
+    assert not input_ids.is_floating_point(), "input_ids must contain integer token IDs"
+    assert bos_token_id != pad_token_id, "m5.1 BOS and PAD token IDs must differ"
+    assert input_ids.shape == (batch_size, M51_SEQUENCE_TOKENS), (
+        f"input_ids must have shape ({batch_size}, {M51_SEQUENCE_TOKENS}), got "
+        f"{tuple(input_ids.shape)}"
+    )
+    assert attention_mask.shape == input_ids.shape
+    assert attention_mask.device == input_ids.device
+    assert torch.all(attention_mask == 1), (
+        "padded tokens must not enter SAE activations"
+    )
+    assert torch.all(input_ids[:, 0] == bos_token_id), (
+        "every m5.1 input must begin with BOS"
+    )
+    assert not torch.eq(input_ids[:, 1:], bos_token_id).any(), (
+        "BOS may appear only at token position 0"
+    )
+    assert not torch.eq(input_ids, pad_token_id).any(), (
+        "PAD token found in fixed-length m5.1 input"
+    )
+
+
+def reference_coordinates(
+    windows: Sequence[M51GenomicWindow],
+) -> ReferenceCoordinateBatch:
+    """Map 255 model-order nucleotide indices to reference intervals."""
+
+    assert windows, "coordinate batch must be non-empty"
+    offsets = torch.arange(M51_WINDOW_BP, dtype=torch.long)
+    starts = torch.stack(
+        [
+            window.start + offsets if window.strand == "+" else window.end - 1 - offsets
+            for window in windows
+        ]
+    )
+    ends = starts + 1
+    for row, window in enumerate(windows):
+        assert torch.all(starts[row] >= window.start)
+        assert torch.all(ends[row] <= window.end)
+        assert torch.unique(starts[row]).numel() == M51_WINDOW_BP
+    return ReferenceCoordinateBatch(
+        chroms=tuple(window.chrom for window in windows),
+        strands=tuple(window.strand for window in windows),
+        starts=starts,
+        ends=ends,
+    )
+
+
+def build_m51_activation_batch(
+    captured: Tensor,
+    input_ids: Tensor,
+    attention_mask: Tensor,
+    windows: Sequence[M51GenomicWindow],
+    *,
+    block_index: int,
+    bos_token_id: int,
+    pad_token_id: int,
+) -> M51ActivationBatch:
+    """Validate and strip BOS from one captured m5.1 residual-stream batch."""
+
+    _validate_m51_inputs(
+        input_ids,
+        attention_mask,
+        windows,
+        bos_token_id=bos_token_id,
+        pad_token_id=pad_token_id,
+    )
+    batch_size = len(windows)
+    assert captured.shape == (
+        batch_size,
+        M51_SEQUENCE_TOKENS,
+        M51_HIDDEN_SIZE,
+    ), (
+        "raw post-block residual must have shape "
+        f"({batch_size}, {M51_SEQUENCE_TOKENS}, {M51_HIDDEN_SIZE}), got "
+        f"{tuple(captured.shape)}"
+    )
+    assert torch.isfinite(captured).all(), "raw post-block residual contains NaN or inf"
+    activations = captured[:, M51_BOS_TOKENS:, :]
+    assert activations.shape[1] == M51_WINDOW_BP
+    return M51ActivationBatch(
+        activations=activations,
+        coordinates=reference_coordinates(windows),
+        block_index=block_index,
+    )
+
+
+def build_m51_next_base_batch(
+    logits: Tensor,
+    input_ids: Tensor,
+    attention_mask: Tensor,
+    windows: Sequence[M51GenomicWindow],
+    *,
+    bos_token_id: int,
+    pad_token_id: int,
+) -> M51NextBaseBatch:
+    """Align causal logits with the following input bases and coordinates."""
+
+    _validate_m51_inputs(
+        input_ids,
+        attention_mask,
+        windows,
+        bos_token_id=bos_token_id,
+        pad_token_id=pad_token_id,
+    )
+    batch_size = len(windows)
+    assert logits.ndim == 3
+    assert logits.shape[:2] == (batch_size, M51_SEQUENCE_TOKENS), (
+        f"logits must start with shape ({batch_size}, {M51_SEQUENCE_TOKENS}), "
+        f"got {tuple(logits.shape)}"
+    )
+    # Logit i predicts input token i+1.  Keep BOS's logit (it predicts the first
+    # genomic base) and drop the final logit (its target lies off-window).
+    next_base_logits = logits[:, :-1, :]
+    target_ids = input_ids[:, 1:]
+    assert next_base_logits.shape[1] == target_ids.shape[1] == M51_WINDOW_BP
+    return M51NextBaseBatch(
+        logits=next_base_logits,
+        target_ids=target_ids,
+        coordinates=reference_coordinates(windows),
+    )
+
+
+def run_m51_with_activations(
+    frozen: FrozenM51,
+    input_ids: Tensor,
+    attention_mask: Tensor,
+    windows: Sequence[M51GenomicWindow],
+    *,
+    block_index: int,
+) -> tuple[Any, M51ActivationBatch]:
+    """Run frozen m5.1 once and return its output plus aligned activations."""
+
+    model = frozen.model
+    tokenizer = frozen.tokenizer
+    validate_m51_model(model)
+    assert not model.training, "m5.1 must be in eval mode during activation extraction"
+    assert all(not parameter.requires_grad for parameter in model.parameters()), (
+        "m5.1 parameters must be frozen during SAE activation extraction"
+    )
+    _validate_m51_inputs(
+        input_ids,
+        attention_mask,
+        windows,
+        bos_token_id=tokenizer.bos_token_id,
+        pad_token_id=tokenizer.pad_token_id,
+    )
+    with torch.inference_mode(), M51PostBlockCapture(model, block_index) as capture:
+        output = model(input_ids=input_ids, attention_mask=attention_mask)
+        captured = capture.pop()
+    activation_batch = build_m51_activation_batch(
+        captured,
+        input_ids,
+        attention_mask,
+        windows,
+        block_index=block_index,
+        bos_token_id=tokenizer.bos_token_id,
+        pad_token_id=tokenizer.pad_token_id,
+    )
+    return output, activation_batch

--- a/tests/model/test_sae.py
+++ b/tests/model/test_sae.py
@@ -1,0 +1,263 @@
+"""Correctness tests for m5.1 SAE activation extraction (issue #288)."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+import marin_dna.model.sae as sae_module
+from marin_dna.model.sae import (
+    M51_HIDDEN_SIZE,
+    M51_NUM_BLOCKS,
+    M51_SEQUENCE_TOKENS,
+    M51_WINDOW_BP,
+    FrozenM51,
+    M51GenomicWindow,
+    build_m51_activation_batch,
+    build_m51_next_base_batch,
+    load_frozen_m51,
+    reference_coordinates,
+    run_m51_with_activations,
+)
+
+BOS_ID = 2
+PAD_ID = 0
+
+
+class _ToyBlock(nn.Module):
+    def __init__(self, increment: float) -> None:
+        super().__init__()
+        self.increment = increment
+
+    def forward(self, hidden: torch.Tensor) -> torch.Tensor:
+        return hidden + self.increment
+
+
+class _ToyBackbone(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [_ToyBlock(float(i + 1)) for i in range(M51_NUM_BLOCKS)]
+        )
+
+
+class _ToyM51(nn.Module):
+    """Small-compute model with m5.1's real sequence/hidden dimensions."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.marker = nn.Parameter(torch.zeros(()))
+        self.config = SimpleNamespace(
+            hidden_size=M51_HIDDEN_SIZE,
+            num_hidden_layers=M51_NUM_BLOCKS,
+        )
+        self.model = _ToyBackbone()
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+    ) -> SimpleNamespace:
+        assert attention_mask.shape == input_ids.shape
+        hidden = (
+            input_ids.to(torch.float32).unsqueeze(-1).expand(-1, -1, M51_HIDDEN_SIZE)
+        )
+        for layer in self.model.layers:
+            hidden = layer(hidden)
+        # A deterministic, small-vocabulary head is enough to prove that a
+        # read-only block hook leaves the full forward bitwise unchanged.
+        logits = hidden[..., :8]
+        return SimpleNamespace(logits=logits)
+
+
+class _ToyTokenizer:
+    bos_token_id = BOS_ID
+    pad_token_id = PAD_ID
+
+    def __call__(
+        self,
+        sequence: str,
+        *,
+        add_special_tokens: bool,
+        return_attention_mask: bool,
+        return_tensors: str,
+    ) -> dict[str, torch.Tensor]:
+        assert len(sequence) == M51_WINDOW_BP
+        assert add_special_tokens
+        assert return_attention_mask
+        assert return_tensors == "pt"
+        input_ids, attention_mask = _inputs(batch_size=1)
+        return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+
+def _inputs(batch_size: int = 2) -> tuple[torch.Tensor, torch.Tensor]:
+    input_ids = torch.full((batch_size, M51_SEQUENCE_TOKENS), 4, dtype=torch.long)
+    input_ids[:, 0] = BOS_ID
+    attention_mask = torch.ones_like(input_ids)
+    return input_ids, attention_mask
+
+
+def _windows() -> list[M51GenomicWindow]:
+    return [
+        M51GenomicWindow("chr1", 100, 100 + M51_WINDOW_BP, "+"),
+        M51GenomicWindow("chr2", 1000, 1000 + M51_WINDOW_BP, "-"),
+    ]
+
+
+def _frozen(model: nn.Module) -> FrozenM51:
+    model.requires_grad_(False)
+    model.eval()
+    tokenizer = SimpleNamespace(bos_token_id=BOS_ID, pad_token_id=PAD_ID)
+    return FrozenM51(model=model, tokenizer=tokenizer)
+
+
+def test_read_only_hook_preserves_logits_bitwise() -> None:
+    model = _ToyM51().eval()
+    input_ids, attention_mask = _inputs()
+    with torch.inference_mode():
+        expected_logits = model(
+            input_ids=input_ids, attention_mask=attention_mask
+        ).logits.clone()
+
+    output, batch = run_m51_with_activations(
+        _frozen(model),
+        input_ids,
+        attention_mask,
+        _windows(),
+        block_index=9,
+    )
+
+    assert torch.equal(output.logits, expected_logits)
+    assert batch.activations.shape == (2, M51_WINDOW_BP, M51_HIDDEN_SIZE)
+    assert batch.block_index == 9
+    assert batch.report_block == 10
+    # Block 10's output is input embedding + sum(1..10) = token + 55.
+    assert torch.all(batch.activations == 59)
+
+
+def test_load_frozen_m51_validates_and_freezes_local_checkpoint(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    model = _ToyM51()
+    tokenizer = _ToyTokenizer()
+    model_calls: list[tuple[object, dict[str, object]]] = []
+
+    monkeypatch.setattr(
+        sae_module.AutoTokenizer,
+        "from_pretrained",
+        lambda path: tokenizer,
+    )
+
+    def _load_model(path, **kwargs):
+        model_calls.append((path, kwargs))
+        return model
+
+    monkeypatch.setattr(sae_module.AutoModelForCausalLM, "from_pretrained", _load_model)
+
+    frozen = load_frozen_m51(tmp_path, device="cpu", dtype=torch.float32)
+
+    assert frozen.model is model
+    assert frozen.tokenizer is tokenizer
+    assert not model.training
+    assert all(not parameter.requires_grad for parameter in model.parameters())
+    assert model_calls == [
+        (tmp_path, {"trust_remote_code": True, "torch_dtype": torch.float32})
+    ]
+
+
+def test_activation_coordinates_strip_bos_and_map_current_base_on_both_strands() -> (
+    None
+):
+    captured = torch.zeros(2, M51_SEQUENCE_TOKENS, M51_HIDDEN_SIZE)
+    captured[:, 0, :] = -1  # distinctive BOS vector must be removed
+    captured[:, 1:, 0] = torch.arange(M51_WINDOW_BP)
+    input_ids, attention_mask = _inputs()
+
+    batch = build_m51_activation_batch(
+        captured,
+        input_ids,
+        attention_mask,
+        _windows(),
+        block_index=4,
+        bos_token_id=BOS_ID,
+        pad_token_id=PAD_ID,
+    )
+
+    assert torch.equal(batch.activations[:, 0, 0], torch.tensor([0.0, 0.0]))
+    assert torch.equal(batch.activations[:, -1, 0], torch.tensor([254.0, 254.0]))
+    assert batch.coordinates.chroms == ("chr1", "chr2")
+    assert batch.coordinates.strands == ("+", "-")
+    assert torch.equal(batch.coordinates.starts[0, :3], torch.tensor([100, 101, 102]))
+    assert torch.equal(batch.coordinates.starts[0, -3:], torch.tensor([352, 353, 354]))
+    assert torch.equal(
+        batch.coordinates.starts[1, :3], torch.tensor([1254, 1253, 1252])
+    )
+    assert torch.equal(
+        batch.coordinates.starts[1, -3:], torch.tensor([1002, 1001, 1000])
+    )
+    assert torch.equal(batch.coordinates.ends, batch.coordinates.starts + 1)
+
+
+def test_next_base_logits_map_to_following_base_on_both_strands() -> None:
+    input_ids, attention_mask = _inputs()
+    # Token identities make the causal one-token shift directly observable.
+    input_ids[:, 1:] = torch.arange(10, 10 + M51_WINDOW_BP)
+    logits = torch.zeros(2, M51_SEQUENCE_TOKENS, 3)
+    logits[:, :, 0] = torch.arange(M51_SEQUENCE_TOKENS)
+
+    batch = build_m51_next_base_batch(
+        logits,
+        input_ids,
+        attention_mask,
+        _windows(),
+        bos_token_id=BOS_ID,
+        pad_token_id=PAD_ID,
+    )
+
+    # Logit position 0 (the BOS position) predicts input token 1, at the first
+    # model-order genomic base. Logit 1 predicts input token 2, and so on.
+    assert torch.equal(batch.logits[0, :3, 0], torch.tensor([0.0, 1.0, 2.0]))
+    assert torch.equal(batch.target_ids[0, :3], torch.tensor([10, 11, 12]))
+    assert torch.equal(batch.coordinates.starts[0, :3], torch.tensor([100, 101, 102]))
+    assert torch.equal(
+        batch.coordinates.starts[1, :3], torch.tensor([1254, 1253, 1252])
+    )
+    assert batch.logits.shape[1] == M51_WINDOW_BP
+    assert batch.target_ids.shape[1] == M51_WINDOW_BP
+
+
+def test_reference_coordinates_reject_wrong_window_length() -> None:
+    with pytest.raises(AssertionError, match="must span 255 bp"):
+        M51GenomicWindow("chr1", 0, 254, "+")
+
+
+@pytest.mark.parametrize("corruption", ["padding", "bos", "nan"])
+def test_activation_batch_fails_fast_on_silent_corruption(corruption: str) -> None:
+    captured = torch.zeros(2, M51_SEQUENCE_TOKENS, M51_HIDDEN_SIZE)
+    input_ids, attention_mask = _inputs()
+    if corruption == "padding":
+        attention_mask[0, -1] = 0
+    elif corruption == "bos":
+        input_ids[0, 1] = BOS_ID
+    else:
+        captured[0, 1, 0] = torch.nan
+
+    with pytest.raises(AssertionError):
+        build_m51_activation_batch(
+            captured,
+            input_ids,
+            attention_mask,
+            _windows(),
+            block_index=0,
+            bos_token_id=BOS_ID,
+            pad_token_id=PAD_ID,
+        )
+
+
+def test_reference_coordinates_are_unique_and_in_bounds() -> None:
+    coordinates = reference_coordinates(_windows())
+    for starts, window in zip(coordinates.starts, _windows(), strict=True):
+        assert starts.unique().numel() == M51_WINDOW_BP
+        assert starts.min().item() == window.start
+        assert starts.max().item() == window.end - 1

--- a/tests/scripts/test_issue288_five_way_data.py
+++ b/tests/scripts/test_issue288_five_way_data.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+import pytest
+from datasets import Dataset
+
+from scripts.issue288.five_way_data import (
+    CONTEXT_TOKENS,
+    SOURCES,
+    WINDOW_BP,
+    balanced_budget,
+    interleave_five_sources,
+    normalize_and_tokenize_row,
+    reference_position,
+    tokenize_source,
+)
+
+
+class FakeDnaTokenizer:
+    bos_token_id = 2
+    pad_token_id = 0
+    unk_token_id = 1
+
+    def __call__(self, sequence: str, **_: Any) -> dict[str, list[int]]:
+        token_ids = {"a": 3, "c": 4, "g": 5, "t": 6}
+        return {
+            "input_ids": [self.bos_token_id]
+            + [token_ids.get(base.lower(), self.unk_token_id) for base in sequence]
+        }
+
+
+def _genomes_row(index: int, strand: str = "+") -> dict[str, Any]:
+    start = index * WINDOW_BP
+    return {
+        "id": f"NC_TEST.1:{start}-{start + WINDOW_BP}_{strand}",
+        "seq": "AcgT" * 63 + "ACN",
+    }
+
+
+def _zoonomia_row(
+    index: int,
+    *,
+    source_strand: str = "+",
+    augmentation: str = "+",
+) -> dict[str, Any]:
+    start = index * WINDOW_BP
+    return {
+        "query_name": f"win_1_{index:09d}",
+        "species": "Test_species",
+        "t_chrom": "chr1",
+        "t_start": start,
+        "t_end": start + WINDOW_BP,
+        "t_strand": source_strand,
+        "t_src_size": 100_000,
+        "sequence": "A" * WINDOW_BP,
+        "augmentation": augmentation,
+    }
+
+
+def test_balanced_budgets_round_up_to_whole_five_way_windows() -> None:
+    budget_1m = balanced_budget(1_000_000)
+    assert budget_1m.windows_per_source == 785
+    assert budget_1m.total_windows == 3_925
+    assert budget_1m.actual_activations == 1_000_875
+
+    budget_5m = balanced_budget(5_000_000)
+    assert budget_5m.windows_per_source == 3_922
+    assert budget_5m.total_windows == 19_610
+    assert budget_5m.actual_activations == 5_000_550
+
+
+@pytest.mark.parametrize(
+    "source_index,row,expected_sequence_strand",
+    [
+        (0, _genomes_row(2, "+"), "+"),
+        (0, _genomes_row(2, "-"), "-"),
+        (3, _zoonomia_row(2, source_strand="+", augmentation="+"), "+"),
+        (3, _zoonomia_row(2, source_strand="-", augmentation="+"), "-"),
+        (3, _zoonomia_row(2, source_strand="+", augmentation="-"), "-"),
+        (3, _zoonomia_row(2, source_strand="-", augmentation="-"), "+"),
+    ],
+)
+def test_normalization_preserves_coordinate_orientation(
+    source_index: int,
+    row: dict[str, Any],
+    expected_sequence_strand: str,
+) -> None:
+    normalized = normalize_and_tokenize_row(
+        row,
+        source=SOURCES[source_index],
+        tokenizer=FakeDnaTokenizer(),  # type: ignore[arg-type]
+    )
+    assert normalized["sequence_strand"] == expected_sequence_strand
+    assert len(normalized["input_ids"]) == CONTEXT_TOKENS
+    assert normalized["input_ids"][0] == FakeDnaTokenizer.bos_token_id
+    assert FakeDnaTokenizer.pad_token_id not in normalized["input_ids"]
+
+    if expected_sequence_strand == "+":
+        assert reference_position(normalized, 0) == normalized["start"]
+        assert reference_position(normalized, WINDOW_BP - 1) == normalized["end"] - 1
+    else:
+        assert reference_position(normalized, 0) == normalized["end"] - 1
+        assert reference_position(normalized, WINDOW_BP - 1) == normalized["start"]
+
+
+def test_tokenization_counts_lowercase_and_ambiguous_bases() -> None:
+    normalized = normalize_and_tokenize_row(
+        _genomes_row(0),
+        source=SOURCES[0],
+        tokenizer=FakeDnaTokenizer(),  # type: ignore[arg-type]
+    )
+    assert normalized["lowercase_bases"] == 126
+    assert normalized["unknown_tokens"] == 1
+
+
+def test_rejects_wrong_window_length() -> None:
+    row = _genomes_row(0)
+    row["seq"] = "A" * (WINDOW_BP - 1)
+    with pytest.raises(AssertionError):
+        normalize_and_tokenize_row(
+            row,
+            source=SOURCES[0],
+            tokenizer=FakeDnaTokenizer(),  # type: ignore[arg-type]
+        )
+
+
+def test_five_way_stream_is_exact_round_robin() -> None:
+    tokenizer = FakeDnaTokenizer()
+    streams = []
+    for source_index, source in enumerate(SOURCES):
+        if source.schema == "genomes_v5":
+            rows = [_genomes_row(i) for i in range(4)]
+        else:
+            rows = [_zoonomia_row(i) for i in range(4)]
+        raw = Dataset.from_list(rows).to_iterable_dataset(num_shards=1)
+        streams.append(
+            tokenize_source(
+                raw,
+                source,
+                tokenizer,  # type: ignore[arg-type]
+            )
+        )
+
+    mixed = list(interleave_five_sources(streams).take(15))
+    expected_order = [source.name for source in SOURCES] * 3
+    assert [row["source"] for row in mixed] == expected_order
+    assert Counter(row["source"] for row in mixed) == Counter(
+        {source.name: 3 for source in SOURCES}
+    )
+    assert all(len(row["input_ids"]) == CONTEXT_TOKENS for row in mixed)


### PR DESCRIPTION
🤖 Implements the first correctness-critical infrastructure milestone from #288.

## Summary

- Adds an m5.1-specific Hugging Face loader that validates the 19-block, 1,920-wide architecture and the exact one-BOS + 255-base tokenizer contract, then freezes the model in evaluation mode ([implementation](https://github.com/Open-Athena/marin-dna/blob/2329932926af3df8e718238eb346b7630f4803df/src/marin_dna/model/sae.py#L160-L227)).
- Adds a read-only post-block residual hook with explicit 0-based implementation indices and 1-based report block numbers; the hook enforces one capture per forward and always removes itself ([implementation](https://github.com/Open-Athena/marin-dna/blob/2329932926af3df8e718238eb346b7630f4803df/src/marin_dna/model/sae.py#L230-L296)).
- Adds defensive batch validation, BOS stripping, 0-based half-open FWD/RC reference-coordinate mapping, and causal alignment of logit position `i` to target token `i + 1` ([implementation](https://github.com/Open-Athena/marin-dna/blob/2329932926af3df8e718238eb346b7630f4803df/src/marin_dna/model/sae.py#L299-L468)).
- Adds CPU tests for bitwise logit invariance, frozen loading, block 10/index 9 reporting, both-strand coordinate arithmetic, the next-base one-token shift, and fail-fast corruption checks ([tests](https://github.com/Open-Athena/marin-dna/blob/2329932926af3df8e718238eb346b7630f4803df/tests/model/test_sae.py#L115-L263)).

## Scope

This PR establishes the tested activation/coordinate boundary needed by the SAE pipeline. It does not train an SAE or launch accelerator resources; those remain later milestones in #288.

## Verification

- `uv run pytest -q`: 889 passed, 5 skipped.
- `uv run mypy src/marin_dna/model/sae.py`: passed.
- Ruff format/lint and all relevant pre-commit hooks: passed.
- The repository-wide pre-commit mypy hook still reports 10 pre-existing errors in `src/marin_dna/pipelines/evals/leaderboard.py`; this new module has no mypy errors.