### PR TITLE
Update BRCA1 notebook link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Tracked as GitHub issues under a two-axis label taxonomy — **Type** (the kind 
 - [🤗 Models and datasets on Hugging Face](https://huggingface.co/marin-dna)
 - [🏆 Variant effect prediction leaderboard](https://openathena.ai/marin-dna/)
 - [🧬 Interactive sequence explorer](https://molab.marimo.io/notebooks/nb_MrPpr5xYcN3HGt5tLY86bk/app)
-- [💻 Model inference and BRCA1 variant effect prediction notebook](https://molab.marimo.io/github/Open-Athena/marin-dna/blob/20f48809013a34c4cf4bee94582e9ba94b56b5b2/examples/model_inference_and_vep.py)
+- [💻 Model inference and BRCA1 variant effect prediction notebook](https://molab.marimo.io/github/Open-Athena/marin-dna/blob/5d1925fe0d6569c0ee0c29db06b8f287c2347065/examples/model_inference_and_vep.py)
 
 ## Example
 


### PR DESCRIPTION
## Summary

- Point the root README's BRCA1 inference/VEP resource at the newly verified immutable notebook snapshot.
- The refreshed notebook uses the pinned public Ensembl 115 GRCh38 FASTA from `marin-dna/human-genome`, with credential-free HTTP range reads.
- Keep the notebook itself and its rendered GPU session on its permanent branch; this PR changes only the discoverability link on `main`.

## Impact

Readers opening the README resource now get the current public-reference notebook and its complete rendered BRCA1 run instead of the earlier Broad-reference snapshot.

## Validation

- [Notebook source and GPU session snapshot](https://github.com/Open-Athena/marin-dna/blob/5d1925fe0d6569c0ee0c29db06b8f287c2347065/examples/model_inference_and_vep.py) are commit-pinned.
- `uvx marimo check examples/model_inference_and_vep.py`
- `uv run pytest tests/examples/test_model_inference_and_vep.py -q` (`7 passed, 1 skipped`)
- Opt-in remote reference equivalence test (`1 passed`), covering the TH sequence, every 255 bp BRCA1 context, and all 2,751 REF alleles.
- Fresh A10G session export: 28 cells, no error outputs, and all AUPRC deltas remain within the notebook's required `0.001` tolerance.
- New Molab URL returns HTTP 200.
- Root README pre-commit checks pass.