### PR TITLE
Improve research issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/eda.md
+++ b/.github/ISSUE_TEMPLATE/eda.md
@@ -15,8 +15,7 @@ assignees: ''
 
 ## Informs research-question(s)
 
-<!-- Plain references to any research-question issues this EDA bears on.
-Optional and many-to-many; do not use sub-issue metadata. -->
+<!-- Plain references to any research-question issues this EDA bears on. Optional and many-to-many; do not use sub-issue metadata. -->
 
 ## Approach
 

--- a/.github/ISSUE_TEMPLATE/eda.md
+++ b/.github/ISSUE_TEMPLATE/eda.md
@@ -11,17 +11,24 @@ assignees: ''
 
 ## Question
 
-(What we're poking at and why — 2–4 sentences.)
+<!-- What are we poking at and why? Write 2–4 sentences. -->
+
+## Informs research-question(s)
+
+<!-- Plain references to any research-question issues this EDA bears on.
+Optional and many-to-many; do not use sub-issue metadata. -->
 
 ## Approach
 
-(Data inputs, methods, link to any `snakemake/analysis/<name>/` pipeline.)
+<!-- Record data inputs, methods, and a link to any relevant pipeline. -->
 
 ## Findings
 
-(Living — edited as results settle. Plots via gist links.)
+<!-- Living synthesis, edited as results settle. Embed plots via gist links. -->
 
 ## Open questions / next steps
+
+<!-- Living list, edited rather than appended. -->
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/experiment.md
+++ b/.github/ISSUE_TEMPLATE/experiment.md
@@ -1,6 +1,6 @@
 ---
 name: Experiment
-about: Tracking issue for an experiment
+about: Tracking issue for a preregistered experiment
 title: Experiment
 labels: experiment
 assignees: ''
@@ -11,26 +11,47 @@ assignees: ''
 
 ## Description
 
-(Add enough context someone outside could understand what you're trying to do. Doesn't need to be too long, but enough you could explain it to someone working on LLMs at another lab.)
+<!-- Add enough context for someone outside the immediate project. -->
 
-## Hypothesis or Goal
+## Hypothesis or goal
 
-(What are you trying to learn or achieve? An experiment is preregistered — fill this in before running.)
+<!-- State the falsifiable prediction or fixed objective before running. -->
 
 ## Informs research-question(s)
 
-(Plain references to any `research-question` issues this bears on, e.g. `#287` — not a sub-issue link. Optional; an experiment may inform several, or none.)
+<!-- Plain references to any research-question issues this bears on.
+Optional and many-to-many; do not use sub-issue metadata. -->
 
+## Prior evidence / why now
 
-### Links
+<!-- Record the internal results and external literature motivating this
+experiment. State which design decisions follow from that evidence. -->
 
-(Delete any that aren't applicable.)
+## Preregistered design
 
-* WandB Report:  (link)
-* Data Browser: (link)
-* (etc.)
+<!-- Specify the fixed arms and invariants, data and splits, primary endpoint
+or success criterion, and important secondary diagnostics. -->
 
+## Execution and scope
+
+<!-- Record implementation sequencing, resource or stopping constraints when
+relevant, failure handling, and anything explicitly out of scope. -->
+
+## Deviations from preregistration
+
+<!-- None at launch. Announce material deviations in a comment before updating
+this section. -->
 
 ## Results
 
-(What did you find, including relevant evaluation metrics, etc.)
+<!-- Report every preregistered arm, including nulls, uncertainty, artifacts,
+provenance, and actual resource use where relevant. -->
+
+## Links
+
+<!-- Delete entries that do not apply.
+
+- WandB report:
+- Data browser:
+- Code or artifacts:
+-->

--- a/.github/ISSUE_TEMPLATE/experiment.md
+++ b/.github/ISSUE_TEMPLATE/experiment.md
@@ -19,39 +19,30 @@ assignees: ''
 
 ## Informs research-question(s)
 
-<!-- Plain references to any research-question issues this bears on.
-Optional and many-to-many; do not use sub-issue metadata. -->
+<!-- Plain references to any research-question issues this bears on. Optional and many-to-many; do not use sub-issue metadata. -->
 
 ## Prior evidence / why now
 
-<!-- Record the internal results and external literature motivating this
-experiment. State which design decisions follow from that evidence. -->
+<!-- Record the internal results and external literature motivating this experiment. State which design decisions follow from that evidence. -->
 
 ## Preregistered design
 
-<!-- Specify the fixed arms and invariants, data and splits, primary endpoint
-or success criterion, and important secondary diagnostics. -->
+<!-- Specify the fixed arms and invariants, data and splits, primary endpoint or success criterion, and important secondary diagnostics. -->
 
 ## Execution and scope
 
-<!-- Record implementation sequencing, resource or stopping constraints when
-relevant, failure handling, and anything explicitly out of scope. -->
+<!-- Record implementation sequencing, resource or stopping constraints when relevant, failure handling, and anything explicitly out of scope. -->
 
 ## Deviations from preregistration
 
-<!-- None at launch. Announce material deviations in a comment before updating
-this section. -->
+None at launch.
+
+<!-- Announce material deviations in a comment before updating this section. -->
 
 ## Results
 
-<!-- Report every preregistered arm, including nulls, uncertainty, artifacts,
-provenance, and actual resource use where relevant. -->
+<!-- Report every preregistered arm, including nulls, uncertainty, artifacts, provenance, and actual resource use where relevant. -->
 
 ## Links
 
-<!-- Delete entries that do not apply.
-
-- WandB report:
-- Data browser:
-- Code or artifacts:
--->
+<!-- Add applicable WandB, data-browser, code, and artifact links below as visible Markdown. Delete this section if none apply. -->

--- a/.github/ISSUE_TEMPLATE/research-question.md
+++ b/.github/ISSUE_TEMPLATE/research-question.md
@@ -11,29 +11,19 @@ assignees: ''
 
 ## Question
 
-<!-- What are we trying to learn? Write 2–4 sentences for a reader who knows
-the broad field but not this research thread. -->
+<!-- What are we trying to learn? Write 2–4 sentences for a reader who knows the broad field but not this research thread. -->
 
 ## Current findings
 
-<!-- Living synthesis, edited as results settle across experiments.
-Embed plots via gist links. -->
+<!-- Living synthesis, edited as results settle across experiments. Embed plots via gist links. -->
 
 ## Related experiments & EDAs
 
-<!-- Curated links to issues bearing on this question. The relationship is
-many-to-many and uses plain issue references, not sub-issue metadata. -->
+<!-- Curated links to issues bearing on this question. The relationship is many-to-many and uses plain issue references, not sub-issue metadata. -->
 
 ## Relevant literature
 
-<!-- Curated, not exhaustive. Include work only when it materially changes
-the current answer or experiment program. For each entry, briefly record:
-
-- **Author et al. (year), [title](link).**
-  **Studied:** …
-  **Found:** …
-  **Relevance and remaining gap:** …
--->
+<!-- Curated, not exhaustive. Include work only when it materially changes the current answer or experiment program. Add each entry below as visible Markdown and briefly record the work's setup, main findings, methodological implications, hypotheses or observables it suggests, and remaining gap. -->
 
 ## Open questions
 

--- a/.github/ISSUE_TEMPLATE/research-question.md
+++ b/.github/ISSUE_TEMPLATE/research-question.md
@@ -11,19 +11,33 @@ assignees: ''
 
 ## Question
 
-(What we're trying to learn, 2–4 sentences, written for a reader who knows genomics and ML broadly but not this thread.)
+<!-- What are we trying to learn? Write 2–4 sentences for a reader who knows
+the broad field but not this research thread. -->
 
 ## Current findings
 
-(Living — edited as results settle across experiments. Plots via gist links.)
+<!-- Living synthesis, edited as results settle across experiments.
+Embed plots via gist links. -->
 
 ## Related experiments & EDAs
 
-(Curated links to the issues bearing on this question, added as they accrue. Many-to-many: an experiment may inform several questions, and this is a plain reference list, not sub-issue metadata.)
+<!-- Curated links to issues bearing on this question. The relationship is
+many-to-many and uses plain issue references, not sub-issue metadata. -->
+
+## Relevant literature
+
+<!-- Curated, not exhaustive. Include work only when it materially changes
+the current answer or experiment program. For each entry, briefly record:
+
+- **Author et al. (year), [title](link).**
+  **Studied:** …
+  **Found:** …
+  **Relevance and remaining gap:** …
+-->
 
 ## Open questions
 
-(Edited, not appended.)
+<!-- Living list, edited rather than appended. -->
 
 ---
 


### PR DESCRIPTION
## Summary

- add a curated `Relevant literature` section to research questions
- make experiment preregistration explicit about prior evidence, fixed design, scope, stopping conditions, and deviations
- let EDAs reference the research questions they inform
- move author guidance into HTML comments so empty templates render cleanly

## Why

The current templates do not consistently capture the evidence-to-design-to-result chain. Recent experiment issues repeatedly recreated design, implementation, scope, and diagnostic sections by hand, while EDAs lacked a reciprocal link to durable research questions.

This keeps the templates domain-general and distinguishes evolving research-question synthesis from the fixed prior evidence motivating a particular experiment.

## Impact

Existing issues are unchanged. Newly created research questions, experiments, and EDAs receive clearer scientific structure without visible placeholder prose.

## Checks

- validated exact front-matter keys and Type labels for all three templates
- validated hidden-comment balance and expected rendered heading order
- `git diff --check`
- `uv run pre-commit run --files .github/ISSUE_TEMPLATE/research-question.md .github/ISSUE_TEMPLATE/experiment.md .github/ISSUE_TEMPLATE/eda.md`