### PR TITLE
Fix Dependabot uv compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ umap = [
 [tool.uv]
 # Keep local and CI dependency resolution on the same uv release. GitHub
 # Actions reads this pin through setup-uv's version-file input.
-required-version = "==0.11.7"
+required-version = "==0.11.31"
 # awscli (in the `aws-cli` group) pins fsspec/s3fs strictly below the versions
 # the `genome-s3` group's modern s3fs needs; resolve them in separate
 # "universes" so each group locks against its own compatible set.


### PR DESCRIPTION
## Summary

- update the project’s exact uv pin from `0.11.7` to `0.11.31`
- retain identical local and CI uv version enforcement
- allow Dependabot’s uv updater to process the managed `pre-commit` and `mypy` dependencies

## Root cause

Dependabot currently runs uv 0.11.31 and rejects projects that require the older exact uv 0.11.7 release, so its initial uv update job stopped before it could create dependency PRs.

## Validation

- `uv 0.11.31 lock --check`
- `uv 0.11.31 sync --locked --group dev`
- `uv 0.11.31 run pre-commit run --all-files --show-diff-on-failure`
- `uv 0.11.31 run pytest -m "not slow"` (`881 passed, 5 skipped`)
- `git diff --check`