### PR TITLE
Reflow research questions one sentence per line

### DIFF
--- a/docs/research/questions/bidirectional-models.md
+++ b/docs/research/questions/bidirectional-models.md
@@ -2,19 +2,28 @@
 
 ## TL;DR
 
-Causal checkpoints can plausibly gain bidirectional representations through mixed objectives or lightweight adaptation, but no MarinDNA experiment has shown that this improves representation quality or VEP while preserving autoregressive generation. Confidence is low; the main gap is a matched conversion ablation with explicit generation-retention tests.
+Causal checkpoints can plausibly gain bidirectional representations through mixed objectives or lightweight adaptation, but no MarinDNA experiment has shown that this improves representation quality or VEP while preserving autoregressive generation.
+Confidence is low; the main gap is a matched conversion ablation with explicit generation-retention tests.
 
 ## Question
 
-Can we adapt existing MarinDNA causal/autoregressive checkpoints into models that use both left and right sequence context, without retraining from scratch or sacrificing their useful autoregressive capabilities? The primary goal is better position- and sequence-level embeddings for downstream genomic tasks; secondary goals are stronger variant-effect prediction and flexible sequence generation, including fill-in-the-middle (FIM), inpainting/infilling, and arbitrary-order generation.
+Can we adapt existing MarinDNA causal/autoregressive checkpoints into models that use both left and right sequence context, without retraining from scratch or sacrificing their useful autoregressive capabilities?
+The primary goal is better position- and sequence-level embeddings for downstream genomic tasks; secondary goals are stronger variant-effect prediction and flexible sequence generation, including fill-in-the-middle (FIM), inpainting/infilling, and arbitrary-order generation.
 
 ## Current answer
 
-No MarinDNA checkpoint-conversion experiment has been run. The shortest test of the representation hypothesis is to remove the causal mask, continue training with a masked or masked-next-token objective, and compare against causal continued pretraining at matched data and compute.
+No MarinDNA checkpoint-conversion experiment has been run.
+The shortest test of the representation hypothesis is to remove the causal mask, continue training with a masked or masked-next-token objective, and compare against causal continued pretraining at matched data and compute.
 
-Three end states should be kept separate. A converted bidirectional encoder may improve token and pooled representations while losing ordinary generation. A mixed-mode decoder could preserve left-to-right generation while adding bidirectional representation and infilling, but objective interference is a risk. Masked diffusion offers bidirectional states and arbitrary-order generation through one interface, with different likelihood semantics and iterative sampling cost. Fill-in-the-middle is a useful generation-preserving control but does not create jointly bidirectional per-position states.
+Three end states should be kept separate.
+A converted bidirectional encoder may improve token and pooled representations while losing ordinary generation.
+A mixed-mode decoder could preserve left-to-right generation while adding bidirectional representation and infilling, but objective interference is a risk.
+Masked diffusion offers bidirectional states and arbitrary-order generation through one interface, with different likelihood semantics and iterative sampling cost.
+Fill-in-the-middle is a useful generation-preserving control but does not create jointly bidirectional per-position states.
 
-The current hypothesis is feasible but low confidence. Language and biological-sequence precedents show each component separately; none demonstrates that a causal MarinDNA checkpoint can gain better VEP representations while retaining its strongest autoregressive behavior. The first decision gate should measure representation quality, zero-shot and probed VEP, ordinary generation retention, and compute cost before attempting a unified arbitrary-order model.
+The current hypothesis is feasible but low confidence.
+Language and biological-sequence precedents show each component separately; none demonstrates that a causal MarinDNA checkpoint can gain better VEP representations while retaining its strongest autoregressive behavior.
+The first decision gate should measure representation quality, zero-shot and probed VEP, ordinary generation retention, and compute cost before attempting a unified arbitrary-order model.
 
 <details>
 <summary>Related work</summary>
@@ -33,9 +42,12 @@ The current hypothesis is feasible but low confidence. Language and biological-s
 <details>
 <summary>Related experiments</summary>
 
-- [#3](https://github.com/Open-Athena/marin-dna/issues/3) compared causal language modeling, masked language modeling, and masked diffusion during early promoter training. Causal modeling led at the earliest steps and the issue proposed a causal-to-masked curriculum; it did not convert a mature checkpoint or test representation retention.
-- [#110](https://github.com/Open-Athena/marin-dna/issues/110) explored mixed next-token, fill-in-the-middle, and autoregressive blank-infilling objectives. It motivates generation-preserving controls but contains no completed conversion result.
-- [#314](https://github.com/Open-Athena/marin-dna/issues/314) evaluated frozen causal gLM embeddings across VEP datasets and representation choices. It provides a baseline for any converted model, including the limits of two-pass FWD/RC representations, but does not test jointly bidirectional states.
+- [#3](https://github.com/Open-Athena/marin-dna/issues/3) compared causal language modeling, masked language modeling, and masked diffusion during early promoter training.
+  Causal modeling led at the earliest steps and the issue proposed a causal-to-masked curriculum; it did not convert a mature checkpoint or test representation retention.
+- [#110](https://github.com/Open-Athena/marin-dna/issues/110) explored mixed next-token, fill-in-the-middle, and autoregressive blank-infilling objectives.
+  It motivates generation-preserving controls but contains no completed conversion result.
+- [#314](https://github.com/Open-Athena/marin-dna/issues/314) evaluated frozen causal gLM embeddings across VEP datasets and representation choices.
+  It provides a baseline for any converted model, including the limits of two-pass FWD/RC representations, but does not test jointly bidirectional states.
 
 </details>
 
@@ -44,9 +56,11 @@ The current hypothesis is feasible but low confidence. Language and biological-s
 ### What exactly should be converted?
 
 - Is the first target a separate bidirectional encoder fork of a MarinDNA checkpoint, or one checkpoint that can switch between causal, bidirectional, FIM, and/or diffusion modes?
-- How much adaptation is needed after removing the causal mask: no training, parameter-efficient training, or full continued pretraining? Which layers change most?
+- How much adaptation is needed after removing the causal mask: no training, parameter-efficient training, or full continued pretraining?
+  Which layers change most?
 - Should the first recipe use fixed-rate MLM, LLM2Vec-style masked next-token prediction, a variable-mask diffusion objective, or a mixture with the original next-token loss?
-- Does the answer differ for attention-based Transformers versus causal convolution/SSM architectures? Removing an attention mask is straightforward for the former; models such as Hyena/Mamba need an explicit forward/backward construction rather than an attention-mask change.
+- Does the answer differ for attention-based Transformers versus causal convolution/SSM architectures?
+  Removing an attention mask is straightforward for the former; models such as Hyena/Mamba need an explicit forward/backward construction rather than an attention-mask change.
 
 ### Do the representations actually improve?
 
@@ -54,12 +68,16 @@ The current hypothesis is feasible but low confidence. Language and biological-s
   - functional-region separation in [#246](https://github.com/Open-Athena/marin-dna/issues/246);
   - frozen-embedding VEP probes from [#314](https://github.com/Open-Athena/marin-dna/issues/314);
   - token-level tasks where downstream context should matter, such as splice-site or exon annotation?
-- Which layer and pooling rule work best? Mean pooling is a baseline, but NV-Embed suggests learned pooling may matter.
-- Do improvements come from bidirectionality, the masked objective, extra training, or contrastive learning? Each needs a matched ablation.
+- Which layer and pooling rule work best?
+  Mean pooling is a baseline, but NV-Embed suggests learned pooling may matter.
+- Do improvements come from bidirectionality, the masked objective, extra training, or contrastive learning?
+  Each needs a matched ablation.
 
 ### Does variant-effect prediction improve?
 
-SNV scoring is fixed per orientation: mask the variant position, read the reference- and alternate-allele probabilities from the same output distribution, and compute their log-likelihood ratio in one forward pass. This is the standard zero-shot scoring protocol for masked protein and genomic language models. For a fair comparison with the existing MarinDNA protocol, score both the forward and reverse-complement orientations and average them identically across models; this is a matched evaluation control, not a consequence or test of bidirectionality.
+SNV scoring is fixed per orientation: mask the variant position, read the reference- and alternate-allele probabilities from the same output distribution, and compute their log-likelihood ratio in one forward pass.
+This is the standard zero-shot scoring protocol for masked protein and genomic language models.
+For a fair comparison with the existing MarinDNA protocol, score both the forward and reverse-complement orientations and average them identically across models; this is a matched evaluation control, not a consequence or test of bidirectionality.
 
 - Does a converted model's strand-averaged masked-site SNV LLR beat the equivalently strand-averaged causal score and frozen-embedding probe at matched context and parameter count?
 - How do we define a comparable score for indels and other multi-base variants without giving one model extra context or an easier normalization?
@@ -67,13 +85,22 @@ SNV scoring is fixed per orientation: mask the variant position, read the refere
 ### Which generation capability do we actually need?
 
 - Is FIM/blank infilling sufficient for near-term applications, or do we need true arbitrary-order iterative generation?
-- For masked diffusion, should sampling unmask single bases, spans, or blocks? Can known sequence outside a target interval remain exactly fixed during inpainting?
+- For masked diffusion, should sampling unmask single bases, spans, or blocks?
+  Can known sequence outside a target interval remain exactly fixed during inpainting?
 - Can one model retain high-quality left-to-right generation while gaining infilling and refinement, or is a dedicated bidirectional/diffusion fork cleaner?
 - What biological generation tests should gate progress: held-out infill recovery, motif preservation, k-mer/GC distributions, sequence novelty, predicted regulatory activity, or task-specific design constraints?
 
 ### Candidate experiment ladder
 
-1. **Checkpoint-conversion smoke test.** Start from one small/medium MarinDNA Qwen3 checkpoint. Compare matched-budget causal continued pretraining against bidirectional masked adaptation. Measure held-out causal loss, masked-token accuracy, [#246](https://github.com/Open-Athena/marin-dna/issues/246) embeddings, and [#314](https://github.com/Open-Athena/marin-dna/issues/314) probes.
-2. **Objective ablation.** Compare fixed-rate MLM or masked next-token prediction, mixed NTP + masked training, and a lightweight contrastive term. Keep data, steps, and parameter updates matched.
-3. **Infilling control.** Train a causal FIM/blank-infilling arm at the same budget. This tests whether practical infilling can be obtained without changing the model into an encoder or diffusion model.
-4. **Masked-diffusion arm.** Only after the cheaper conversions are understood, adapt the same checkpoint with a variable mask-rate objective and test full-sequence inpainting/arbitrary-order generation.
+1. **Checkpoint-conversion smoke test.**
+   Start from one small/medium MarinDNA Qwen3 checkpoint.
+   Compare matched-budget causal continued pretraining against bidirectional masked adaptation.
+   Measure held-out causal loss, masked-token accuracy, [#246](https://github.com/Open-Athena/marin-dna/issues/246) embeddings, and [#314](https://github.com/Open-Athena/marin-dna/issues/314) probes.
+2. **Objective ablation.**
+   Compare fixed-rate MLM or masked next-token prediction, mixed NTP + masked training, and a lightweight contrastive term.
+   Keep data, steps, and parameter updates matched.
+3. **Infilling control.**
+   Train a causal FIM/blank-infilling arm at the same budget.
+   This tests whether practical infilling can be obtained without changing the model into an encoder or diffusion model.
+4. **Masked-diffusion arm.**
+   Only after the cheaper conversions are understood, adapt the same checkpoint with a variable mask-rate objective and test full-sequence inpainting/arbitrary-order generation.

--- a/docs/research/questions/complex-trait-vep.md
+++ b/docs/research/questions/complex-trait-vep.md
@@ -2,57 +2,93 @@
 
 ## TL;DR
 
-MarinDNA's complex-trait VEP gap is real but has not been causally attributed. Training-footprint undercoverage has direct supporting evidence, while shallower evolutionary timescales and retrieval remain plausible; confidence is moderate on undercoverage as one contributor and low on which intervention will close the gap.
+MarinDNA's complex-trait VEP gap is real but has not been causally attributed.
+Training-footprint undercoverage has direct supporting evidence, while shallower evolutionary timescales and retrieval remain plausible; confidence is moderate on undercoverage as one contributor and low on which intervention will close the gap.
 
 ## Question
 
-Why do MarinDNA single-sequence models lag GPN-Star on complex-trait variant-effect prediction (VEP), even when region-specialized models can approach GPN-Star on the corresponding Mendelian subsets? Is the main bottleneck (1) training-data selection that omits weakly conserved regions, (2) an evolutionary timescale that is too deep for recent, small-effect human variation, or (3) the absence of alignment-conditioned retrieval at inference? The goal is to identify which factor causally explains the gap and which intervention is most likely to close it.
+Why do MarinDNA single-sequence models lag GPN-Star on complex-trait variant-effect prediction (VEP), even when region-specialized models can approach GPN-Star on the corresponding Mendelian subsets?
+Is the main bottleneck (1) training-data selection that omits weakly conserved regions, (2) an evolutionary timescale that is too deep for recent, small-effect human variation, or (3) the absence of alignment-conditioned retrieval at inference?
+The goal is to identify which factor causally explains the gap and which intervention is most likely to close it.
 
 ## Current answer
 
-MarinDNA’s complex-trait VEP deficit is clearest in matched regulatory comparisons. The enhancer specialist is within 0.057 AUPRC of the strongest GPN-Star arm on Mendelian distal variants but 0.084 behind on complex-trait distal variants. A whole-genome 1B model also trails GPN-Star-M by 0.039 global and 0.097 macro AUPRC on complex traits.
+MarinDNA’s complex-trait VEP deficit is clearest in matched regulatory comparisons.
+The enhancer specialist is within 0.057 AUPRC of the strongest GPN-Star arm on Mendelian distal variants but 0.084 behind on complex-trait distal variants.
+A whole-genome 1B model also trails GPN-Star-M by 0.039 global and 0.097 macro AUPRC on complex traits.
 
-Training-footprint undercoverage is the strongest supported explanation. At the production conservation cutoff, kept windows cover 83.9% of Mendelian positives and 42.6% of complex-trait positives; only about 22% of distal complex-trait positives overlap a kept window. This is direct evidence for distribution mismatch, but it is observational. No fixed-compute experiment has shown that adding weakly conserved sequence closes the gap.
+Training-footprint undercoverage is the strongest supported explanation.
+At the production conservation cutoff, kept windows cover 83.9% of Mendelian positives and 42.6% of complex-trait positives; only about 22% of distal complex-trait positives overlap a kept window.
+This is direct evidence for distribution mismatch, but it is observational.
+No fixed-compute experiment has shown that adding weakly conserved sequence closes the gap.
 
-Scoring contributes but does not appear sufficient. Richer embedding or downstream-effect scores and ensembling improve complex-trait readouts, while tested supervised probes and LoRA variants did not break the frozen-representation ceiling. Shallower evolutionary timescales and alignment-conditioned retrieval remain plausible, but current comparisons confound them with data, architecture, calibration, and objective.
+Scoring contributes but does not appear sufficient.
+Richer embedding or downstream-effect scores and ensembling improve complex-trait readouts, while tested supervised probes and LoRA variants did not break the frozen-representation ceiling.
+Shallower evolutionary timescales and alignment-conditioned retrieval remain plausible, but current comparisons confound them with data, architecture, calibration, and objective.
 
-Confidence is moderate that conservation-focused coverage is one contributor and low on the intervention that will close the gap. The decisive next evidence is a fixed-compute footprint ablation, followed by matched timescale and retrieval controls if undercoverage does not explain enough of the deficit.
+Confidence is moderate that conservation-focused coverage is one contributor and low on the intervention that will close the gap.
+The decisive next evidence is a fixed-compute footprint ablation, followed by matched timescale and retrieval controls if undercoverage does not explain enough of the deficit.
 
 <details>
 <summary>Related work</summary>
 
-- The [Mendelian leaderboard](https://open-athena.github.io/marin-dna/leaderboards/mendelian), [complex-trait leaderboard](https://open-athena.github.io/marin-dna/leaderboards/complex), [#161](https://github.com/Open-Athena/marin-dna/issues/161), [#162](https://github.com/Open-Athena/marin-dna/issues/162), and [#145](https://github.com/Open-Athena/marin-dna/issues/145) define the current evaluation and GPN-Star baseline contract. They expose the Mendelian-versus-complex gap under consistent dashboard metrics. They do not identify whether data coverage, timescale, architecture, or scoring causes it.
-- [Ye, Benegas et al., Predicting functional constraints across evolutionary timescales with phylogeny-informed genomic language models](https://www.biorxiv.org/content/10.1101/2025.09.21.677619v1) compares vertebrate-, mammal-, and primate-alignment models. Deeper evolution favors coding and rarer large-effect variants, while shallower models can favor non-coding or broader complex-trait endpoints; mammal and primate models lead different complex-trait readouts. This motivates a mammal-versus-primate test rather than assuming the closest clade wins. The paper does not isolate timescale from alignment-conditioned architecture for MarinDNA.
-- [How should evolutionary timescale shape training?](evolutionary-timescale.md) is the broader evolutionary-timescale synthesis. Its implication here is that region and endpoint can prefer different breadths; it does not yet contain a matched complex-trait timescale result.
-- [Which genomic regions to train on, and how to find them?](training-regions.md) covers the training footprint. It connects conservation filtering, weakly conserved regulatory sequence, sampling, and loss weighting, but no completed experiment yet tests the causal coverage hypothesis.
-- [Can autoregressive RAG gLMs be accurate and practical?](retrieval-augmented-models.md) covers retrieval. Alignment-conditioned context is a plausible explanation for GPN-Star’s advantage, but the current RAG evidence lacks a matched no-retrieval control.
+- The [Mendelian leaderboard](https://open-athena.github.io/marin-dna/leaderboards/mendelian), [complex-trait leaderboard](https://open-athena.github.io/marin-dna/leaderboards/complex), [#161](https://github.com/Open-Athena/marin-dna/issues/161), [#162](https://github.com/Open-Athena/marin-dna/issues/162), and [#145](https://github.com/Open-Athena/marin-dna/issues/145) define the current evaluation and GPN-Star baseline contract.
+  They expose the Mendelian-versus-complex gap under consistent dashboard metrics.
+  They do not identify whether data coverage, timescale, architecture, or scoring causes it.
+- [Ye, Benegas et al., Predicting functional constraints across evolutionary timescales with phylogeny-informed genomic language models](https://www.biorxiv.org/content/10.1101/2025.09.21.677619v1) compares vertebrate-, mammal-, and primate-alignment models.
+  Deeper evolution favors coding and rarer large-effect variants, while shallower models can favor non-coding or broader complex-trait endpoints; mammal and primate models lead different complex-trait readouts.
+  This motivates a mammal-versus-primate test rather than assuming the closest clade wins.
+  The paper does not isolate timescale from alignment-conditioned architecture for MarinDNA.
+- [How should evolutionary timescale shape training?](evolutionary-timescale.md) is the broader evolutionary-timescale synthesis.
+  Its implication here is that region and endpoint can prefer different breadths; it does not yet contain a matched complex-trait timescale result.
+- [Which genomic regions to train on, and how to find them?](training-regions.md) covers the training footprint.
+  It connects conservation filtering, weakly conserved regulatory sequence, sampling, and loss weighting, but no completed experiment yet tests the causal coverage hypothesis.
+- [Can autoregressive RAG gLMs be accurate and practical?](retrieval-augmented-models.md) covers retrieval.
+  Alignment-conditioned context is a plausible explanation for GPN-Star’s advantage, but the current RAG evidence lacks a matched no-retrieval control.
 
 </details>
 
 <details>
 <summary>Related experiments</summary>
 
-- [#21](https://github.com/Open-Athena/marin-dna/issues/21) reported an early promoter model that generally approached Evo 2 but retained a particularly clear complex-trait promoter deficit. It established that the gap predates the current dashboard.
-- [#55](https://github.com/Open-Athena/marin-dna/issues/55) compared promoter timescales on Mendelian VEP. Mammalian data learned faster than smaller human/primate corpora, but it did not evaluate a controlled complex-trait timescale effect.
-- [#136](https://github.com/Open-Athena/marin-dna/issues/136) showed that human-anchored enhancer projection can produce strong home-domain Mendelian distal VEP. The remaining complex-trait gap shows that Mendelian success does not imply transfer to common-variant regulation.
-- [#142](https://github.com/Open-Athena/marin-dna/issues/142) compared mammal-wide and primate-specific source filters for enhancer projection. Mammal-wide filtering was modestly better on Mendelian distal VEP, providing counterevidence to a generic “shallower is better” claim while leaving complex traits untested.
-- [#175](https://github.com/Open-Athena/marin-dna/issues/175) showed that embedding-distance and downstream-effect scores, plus AlphaGenome ensembling, improve complex-trait VEP over absolute likelihood ratios. The remaining gap means scoring is one lever rather than a complete explanation.
-- [#180](https://github.com/Open-Athena/marin-dna/issues/180) tested frozen supervised heads and LoRA variants on the whole-genome model. Neither broke the complex-trait frozen-embedding ceiling, supporting a data or representation bottleneck under the tested setup.
-- [#213](https://github.com/Open-Athena/marin-dna/issues/213) measured evaluation-positive coverage by the conservation-filtered training footprint. Coverage was 83.9% for Mendelian positives, 42.6% for complex-trait positives, and about 22% for distal complex positives, providing the strongest direct evidence for distribution mismatch.
+- [#21](https://github.com/Open-Athena/marin-dna/issues/21) reported an early promoter model that generally approached Evo 2 but retained a particularly clear complex-trait promoter deficit.
+  It established that the gap predates the current dashboard.
+- [#55](https://github.com/Open-Athena/marin-dna/issues/55) compared promoter timescales on Mendelian VEP.
+  Mammalian data learned faster than smaller human/primate corpora, but it did not evaluate a controlled complex-trait timescale effect.
+- [#136](https://github.com/Open-Athena/marin-dna/issues/136) showed that human-anchored enhancer projection can produce strong home-domain Mendelian distal VEP.
+  The remaining complex-trait gap shows that Mendelian success does not imply transfer to common-variant regulation.
+- [#142](https://github.com/Open-Athena/marin-dna/issues/142) compared mammal-wide and primate-specific source filters for enhancer projection.
+  Mammal-wide filtering was modestly better on Mendelian distal VEP, providing counterevidence to a generic “shallower is better” claim while leaving complex traits untested.
+- [#175](https://github.com/Open-Athena/marin-dna/issues/175) showed that embedding-distance and downstream-effect scores, plus AlphaGenome ensembling, improve complex-trait VEP over absolute likelihood ratios.
+  The remaining gap means scoring is one lever rather than a complete explanation.
+- [#180](https://github.com/Open-Athena/marin-dna/issues/180) tested frozen supervised heads and LoRA variants on the whole-genome model.
+  Neither broke the complex-trait frozen-embedding ceiling, supporting a data or representation bottleneck under the tested setup.
+- [#213](https://github.com/Open-Athena/marin-dna/issues/213) measured evaluation-positive coverage by the conservation-filtered training footprint.
+  Coverage was 83.9% for Mendelian positives, 42.6% for complex-trait positives, and about 22% for distal complex positives, providing the strongest direct evidence for distribution mismatch.
 
 </details>
 
 ## Possible directions
 
-1. **Does training-footprint coverage explain the gap?** Stratify current predictions by [#213](https://github.com/Open-Athena/marin-dna/issues/213)'s variant-centered conserved fraction, kept-window membership, and consequence group. Compare MarinDNA with GPN-Star within each stratum.
+1. **Does training-footprint coverage explain the gap?**
+   Stratify current predictions by [#213](https://github.com/Open-Athena/marin-dna/issues/213)'s variant-centered conserved fraction, kept-window membership, and consequence group.
+   Compare MarinDNA with GPN-Star within each stratum.
 
-2. **Does less-conserved training sequence causally help?** At fixed architecture, tokens, genome mixture, and window size, sweep the conservation cutoff and add a weakly conserved/background arm. Evaluate complex global/distal AUPRC and the Mendelian tradeoff; explicitly check coordinate and sequence-similarity leakage.
+2. **Does less-conserved training sequence causally help?**
+   At fixed architecture, tokens, genome mixture, and window size, sweep the conservation cutoff and add a weakly conserved/background arm.
+   Evaluate complex global/distal AUPRC and the Mendelian tradeoff; explicitly check coordinate and sequence-similarity leakage.
 
-3. **What is the best timescale at fixed data quantity?** Train matched primate, mammal, and deeper-vertebrate arms while controlling tokens and unique human loci. Consider a deliberately reweighted mammal+primate mixture.
+3. **What is the best timescale at fixed data quantity?**
+   Train matched primate, mammal, and deeper-vertebrate arms while controlling tokens and unique human loci.
+   Consider a deliberately reweighted mammal+primate mixture.
 
-4. **Is retrieval the missing capability?** Compare one backbone with and without human-anchored ortholog retrieval using the same loci, species, objective, and compute. As a cheaper first test, ask whether MarinDNA's error relative to GPN-Star grows as conservation weakens or alignment evidence becomes more informative.
+4. **Is retrieval the missing capability?**
+   Compare one backbone with and without human-anchored ortholog retrieval using the same loci, species, objective, and compute.
+   As a cheaper first test, ask whether MarinDNA's error relative to GPN-Star grows as conservation weakens or alignment evidence becomes more informative.
 
-5. **How much is evaluation/readout?** Use a fixed, leakage-free scoring protocol informed by [#175](https://github.com/Open-Athena/marin-dna/issues/175) and cluster-bootstrap uncertainty. Stratify by PIP, consequence, MAF, and conservation to estimate any ceiling from fine-mapping ambiguity.
+5. **How much is evaluation/readout?**
+   Use a fixed, leakage-free scoring protocol informed by [#175](https://github.com/Open-Athena/marin-dna/issues/175) and cluster-bootstrap uncertainty.
+   Stratify by PIP, consequence, MAF, and conservation to estimate any ceiling from fine-mapping ambiguity.
 
 6. **What would distinguish the hypotheses?**
    - Improvement from a fixed-compute less-conserved-data arm, concentrated on low-conservation variants, supports hypothesis 1.

--- a/docs/research/questions/data-mixtures.md
+++ b/docs/research/questions/data-mixtures.md
@@ -2,40 +2,61 @@
 
 ## TL;DR
 
-No validated genomic mixture-optimization method exists yet. Proxy-swarm regression is promising but depends on small-to-large-scale rank transfer, objective signal, finite-data repetition, and leakage controls; confidence is low, and the next gap is a bounded proxy study before any broad or paid sweep.
+No validated genomic mixture-optimization method exists yet.
+Proxy-swarm regression is promising but depends on small-to-large-scale rank transfer, objective signal, finite-data repetition, and leakage controls; confidence is low, and the next gap is a bounded proxy study before any broad or paid sweep.
 
 ## Question
 
-How should we optimize genomic pretraining data mixtures to improve downstream genomic performance at target scale? This includes deciding how to partition the data, what objective to optimize, and which optimization strategies are reliable and compute-efficient.
+How should we optimize genomic pretraining data mixtures to improve downstream genomic performance at target scale?
+This includes deciding how to partition the data, what objective to optimize, and which optimization strategies are reliable and compute-efficient.
 
-This issue tracks evidence across multiple possible approaches; swarm-based regression with small proxy models is one especially promising candidate, but it is not the definition of the research question. The intended outcome is a reproducible way to choose mixtures, not only a single set of weights.
+This issue tracks evidence across multiple possible approaches; swarm-based regression with small proxy models is one especially promising candidate, but it is not the definition of the research question.
+The intended outcome is a reproducible way to choose mixtures, not only a single set of weights.
 
 ## Current answer
 
-No validated method for optimizing genomic pretraining mixtures exists yet. The current evidence shows that mixture components matter: region specialists differ sharply by downstream class, and mammalian species density affects some regions but not others. It does not show how to select a joint mixture.
+No validated method for optimizing genomic pretraining mixtures exists yet.
+The current evidence shows that mixture components matter: region specialists differ sharply by downstream class, and mammalian species density affects some regions but not others.
+It does not show how to select a joint mixture.
 
-Proxy-swarm regression is a plausible candidate, not the answer. Its usefulness depends on four unverified conditions: the downstream objective must have measurable signal in small models; mixture rankings must transfer to target scale; finite high-value components must tolerate the repetitions implied by target weights; and the component manifest, overlap policy, and leakage rules must remain fixed.
+Proxy-swarm regression is a plausible candidate, not the answer.
+Its usefulness depends on four unverified conditions: the downstream objective must have measurable signal in small models; mixture rankings must transfer to target scale; finite high-value components must tolerate the repetitions implied by target weights; and the component manifest, overlap policy, and leakage rules must remain fixed.
 
-The optimization target is also unresolved. Macro-average VEP, minimax performance, zero-shot scores, global probes, per-subset probes, and later regulatory tasks can favor different recipes. Selecting whichever readout looks best after the swarm would invalidate the optimization claim.
+The optimization target is also unresolved.
+Macro-average VEP, minimax performance, zero-shot scores, global probes, per-subset probes, and later regulatory tasks can favor different recipes.
+Selecting whichever readout looks best after the swarm would invalidate the optimization claim.
 
-Confidence is low. The next useful work is a bounded proxy-noise study with fixed anchor mixtures and repeated seeds, followed by held-out-mixture prediction. A broad swarm or target-scale launch is not justified until rank stability, repetition feasibility, and leakage controls pass those gates.
+Confidence is low.
+The next useful work is a bounded proxy-noise study with fixed anchor mixtures and repeated seeds, followed by held-out-mixture prediction.
+A broad swarm or target-scale launch is not justified until rank stability, repetition feasibility, and leakage controls pass those gates.
 
 <details>
 <summary>Related work</summary>
 
-- The [Open Athena pretraining data community meeting slides](https://www.figma.com/deck/LcfkIgrKJUHV1DrJ40XbXb/Open-Athena-Pretraining-Data-Community-Meeting) define a source → normalize → deduplicate/decontaminate → bucket → optimize → train/evaluate pipeline and treat a mixture as a sampling policy over fixed buckets. The implication is that component definitions and overlap policy are part of the optimization contract. The remaining gap is a versioned MarinDNA manifest with unique-token budgets and leakage audits.
-- [RegMix](https://arxiv.org/abs/2407.01492) samples mixtures, trains small proxy models, fits a surrogate, and optimizes predicted performance. [Olmix](https://arxiv.org/abs/2602.12237) studies this family more systematically. These methods motivate offline proxy swarms and held-out-mixture validation. Their proxy sizes, swarm sizes, and rank-transfer behavior cannot be assumed to carry over to genomic objectives.
-- [Scaling Data-Constrained Language Models](https://arxiv.org/abs/2305.16264) shows diminishing returns from repeated data. This makes target-scale epoching part of mixture feasibility: a component that is barely repeated in a proxy may be heavily repeated in the final run. The missing observable is performance as a function of realized repetition for each genomic component.
-- Candidate surrogate families include linear/log-linear models, regularized interactions, tree models, and rank or pairwise objectives. Flexible models require held-out mixtures or nested validation; in-swarm fit alone does not support mixture selection.
-- Candidate outputs should include intended and realized weights, unique tokens and repetitions per component, per-subset downstream scores, uncertainty, held-out ranking, and target-scale regret. Without those fields, a selected weight vector is not a reproducible optimization result.
+- The [Open Athena pretraining data community meeting slides](https://www.figma.com/deck/LcfkIgrKJUHV1DrJ40XbXb/Open-Athena-Pretraining-Data-Community-Meeting) define a source → normalize → deduplicate/decontaminate → bucket → optimize → train/evaluate pipeline and treat a mixture as a sampling policy over fixed buckets.
+  The implication is that component definitions and overlap policy are part of the optimization contract.
+  The remaining gap is a versioned MarinDNA manifest with unique-token budgets and leakage audits.
+- [RegMix](https://arxiv.org/abs/2407.01492) samples mixtures, trains small proxy models, fits a surrogate, and optimizes predicted performance.
+  [Olmix](https://arxiv.org/abs/2602.12237) studies this family more systematically.
+  These methods motivate offline proxy swarms and held-out-mixture validation.
+  Their proxy sizes, swarm sizes, and rank-transfer behavior cannot be assumed to carry over to genomic objectives.
+- [Scaling Data-Constrained Language Models](https://arxiv.org/abs/2305.16264) shows diminishing returns from repeated data.
+  This makes target-scale epoching part of mixture feasibility: a component that is barely repeated in a proxy may be heavily repeated in the final run.
+  The missing observable is performance as a function of realized repetition for each genomic component.
+- Candidate surrogate families include linear/log-linear models, regularized interactions, tree models, and rank or pairwise objectives.
+  Flexible models require held-out mixtures or nested validation; in-swarm fit alone does not support mixture selection.
+- Candidate outputs should include intended and realized weights, unique tokens and repetitions per component, per-subset downstream scores, uncertainty, held-out ranking, and target-scale regret.
+  Without those fields, a selected weight vector is not a reproducible optimization result.
 
 </details>
 
 <details>
 <summary>Related experiments</summary>
 
-- [#232](https://github.com/Open-Athena/marin-dna/issues/232) trained six region specialists and a background arm. Home-region specialists won their matched Mendelian classes, showing that biological-domain mixture components can have distinct downstream utility; it did not optimize a combined mixture.
-- [#255](https://github.com/Open-Athena/marin-dna/issues/255) compared 108-family and 19-order mammalian cohorts at matched compute across five regions. Species density was neutral for some regions and harmful for others, showing interaction between taxonomic mixture and biological domain; one seed and different epoch counts limit surrogate use.
+- [#232](https://github.com/Open-Athena/marin-dna/issues/232) trained six region specialists and a background arm.
+  Home-region specialists won their matched Mendelian classes, showing that biological-domain mixture components can have distinct downstream utility; it did not optimize a combined mixture.
+- [#255](https://github.com/Open-Athena/marin-dna/issues/255) compared 108-family and 19-order mammalian cohorts at matched compute across five regions.
+  Species density was neutral for some regions and harmful for others, showing interaction between taxonomic mixture and biological domain; one seed and different epoch counts limit surrogate use.
 
 </details>
 
@@ -55,15 +76,18 @@ Confidence is low. The next useful work is a bounded proxy-noise study with fixe
 
 ### Candidate optimization approaches
 
-The research question does not presuppose one optimization method. Candidate approaches include, but are not limited to:
+The research question does not presuppose one optimization method.
+Candidate approaches include, but are not limited to:
 
 1. **Expert-designed mixtures and controlled ablations:** useful as baselines and for testing a small number of strong biological hypotheses.
 2. **Direct search:** random, structured, Bayesian, or evolutionary search over mixture weights when the number of components and training cost permit.
 3. **Offline proxy-swarm regression:** train small models on sampled mixtures, fit a surrogate, and optimize its predicted downstream utility, as in RegMix and Olmix.
 4. **Online or adaptive reweighting:** update mixture weights during training using learning dynamics, validation signals, or estimated domain utility.
-5. **Scaling-law, analytical, or hybrid methods:** model how data quantity, repetition, model scale, and domain interactions affect utility, possibly combined with proxy or online measurements. Structured saturation and overexposure models such as the Domain Saturation-Penalty (DSP) form highlighted in the community slides are concrete candidates alongside black-box regressors.
+5. **Scaling-law, analytical, or hybrid methods:** model how data quantity, repetition, model scale, and domain interactions affect utility, possibly combined with proxy or online measurements.
+   Structured saturation and overexposure models such as the Domain Saturation-Penalty (DSP) form highlighted in the community slides are concrete candidates alongside black-box regressors.
 
-Comparisons should account for the compute spent selecting the mixture, not only the compute of the final training run. Different approaches may also be appropriate at different stages or scales.
+Comparisons should account for the compute spent selecting the mixture, not only the compute of the final training run.
+Different approaches may also be appropriate at different stages or scales.
 
 ### Candidate mixture axes
 
@@ -79,13 +103,16 @@ Use the five v4 specialist partitions from the latest per-region experiment ([ex
 - ncRNA exon (`v4_ncrna_exon`); and
 - TSS region plus 5′ UTR (`v4_tss_region_and_utr5`).
 
-These are the five specialist v4 partitions; `v4_bg` is the separate background partition. Retain background as an optional mixture component or control rather than calling it a sixth functional region.
+These are the five specialist v4 partitions; `v4_bg` is the separate background partition.
+Retain background as an optional mixture component or control rather than calling it a sixth functional region.
 
 #### Axis 2: putative data quality
 
-Partition each biological domain into pinned conservation tiers, such as high, medium, and low conservation, rather than assuming only a binary conserved/unconserved split. The exact conservation statistic, species panel, thresholds, and missing-value policy remain part of this research question.
+Partition each biological domain into pinned conservation tiers, such as high, medium, and low conservation, rather than assuming only a binary conserved/unconserved split.
+The exact conservation statistic, species panel, thresholds, and missing-value policy remain part of this research question.
 
-Conservation should initially be described as a *putative quality proxy*, not as ground-truth data quality. The experiment should be able to discover that less-conserved data are useful, either in general or for particular downstream tasks.
+Conservation should initially be described as a *putative quality proxy*, not as ground-truth data quality.
+The experiment should be able to discover that less-conserved data are useful, either in general or for particular downstream tasks.
 
 The resulting components are cells such as:
 
@@ -100,20 +127,29 @@ TSS region + 5′ UTR × low conservation
 
 #### Axis 3 (optional): evolutionary scale
 
-A third axis could control the evolutionary distances represented in training: for example, how much data should come from primates, mammals, vertebrates, plants, or other clades. This is scientifically important but substantially expands the search space, so it can remain an optional follow-up direction.
+A third axis could control the evolutionary distances represented in training: for example, how much data should come from primates, mammals, vertebrates, plants, or other clades.
+This is scientifically important but substantially expands the search space, so it can remain an optional follow-up direction.
 
-The example taxonomic groups are nested: primates are mammals, and mammals are vertebrates. Do not assign independent mixture weights to overlapping groups. Use one of two explicit formulations:
+The example taxonomic groups are nested: primates are mammals, and mammals are vertebrates.
+Do not assign independent mixture weights to overlapping groups.
+Use one of two explicit formulations:
 
 1. **Disjoint clade buckets:** for example, primates, non-primate mammals, non-mammalian vertebrates, plants, and any additional non-overlapping groups supported by the data.
 2. **Hierarchical allocation:** first allocate weight among broad clades, then allocate each clade's weight across its descendant groups and the biological-domain-by-conservation cells.
 
-This axis is also confounded by the number of available species and their phylogenetic redundancy. Raw sequence counts should not make a densely sampled clade dominate by construction. Compare species-sampling policies such as all available species, one species per family, and one species per order, and record both token exposure and phylogenetic coverage.
+This axis is also confounded by the number of available species and their phylogenetic redundancy.
+Raw sequence counts should not make a densely sampled clade dominate by construction.
+Compare species-sampling policies such as all available species, one species per family, and one species per order, and record both token exposure and phylogenetic coverage.
 
-Avoid beginning with the full domain-by-conservation-by-clade Cartesian product. It may create too many small or weakly identifiable cells. Start with a factorized or hierarchical parameterization and add cross-axis interactions only when proxy data support estimating them.
+Avoid beginning with the full domain-by-conservation-by-clade Cartesian product.
+It may create too many small or weakly identifiable cells.
+Start with a factorized or hierarchical parameterization and add cross-axis interactions only when proxy data support estimating them.
 
 ### Static versus phase-specific mixtures
 
-The community slides distinguish a broad-coverage Phase 0 from a cooldown or midtraining Phase 1, using the same buckets with different weights and fitting those weights for a particular model size and token budget. This is a schedule decision, not another biological component axis. A phase-aware formulation would optimize vectors `p^(0)` and `p^(1)` together with pinned phase budgets `R^(0)` and `R^(1)`.
+The community slides distinguish a broad-coverage Phase 0 from a cooldown or midtraining Phase 1, using the same buckets with different weights and fitting those weights for a particular model size and token budget.
+This is a schedule decision, not another biological component axis.
+A phase-aware formulation would optimize vectors `p^(0)` and `p^(1)` together with pinned phase budgets `R^(0)` and `R^(1)`.
 
 For component `j` with `N_j` unique tokens, total target-scale exposure becomes
 
@@ -127,12 +163,16 @@ For components with nonzero total exposure, the late-phase share can also be rec
 r_j = \frac{R^{(1)}p_j^{(1)}}{R^{(0)}p_j^{(0)} + R^{(1)}p_j^{(1)}}.
 ```
 
-Start with a stationary mixture as the identifiable baseline. Add a phase-specific arm only if proxy or intermediate-scale evidence can distinguish schedule effects, and compare schedules at matched total per-component exposure so that a cooldown effect is not confused with simply seeing more copies of a scarce component.
+Start with a stationary mixture as the identifiable baseline.
+Add a phase-specific arm only if proxy or intermediate-scale evidence can distinguish schedule effects, and compare schedules at matched total per-component exposure so that a cooldown effect is not confused with simply seeing more copies of a scarce component.
 ### What should the mixture optimize?
 
-A plausible initial follow-up issue could focus on the project's current Mendelian-trait variant-effect-prediction (VEP) evaluation and treat [DART-Eval](https://arxiv.org/abs/2412.05430) as a separate target. DART-Eval covers regulatory DNA in zero-shot, probing, and fine-tuning settings, and may favor a different data mixture from Mendelian VEP. That difference is scientifically useful and should not be hidden by immediately collapsing every evaluation into one score.
+A plausible initial follow-up issue could focus on the project's current Mendelian-trait variant-effect-prediction (VEP) evaluation and treat [DART-Eval](https://arxiv.org/abs/2412.05430) as a separate target.
+DART-Eval covers regulatory DNA in zero-shot, probing, and fine-tuning settings, and may favor a different data mixture from Mendelian VEP.
+That difference is scientifically useful and should not be hidden by immediately collapsing every evaluation into one score.
 
-Let `s_t(p)` be AUPRC for trait or evaluation subset `t` after training on mixture `p`. Candidate objectives include:
+Let `s_t(p)` be AUPRC for trait or evaluation subset `t` after training on mixture `p`.
+Candidate objectives include:
 
 1. **Macro average:** `U_mean(p) = (1/T) sum_t s_t(p)`
 
@@ -148,7 +188,8 @@ Let `s_t(p)` be AUPRC for trait or evaluation subset `t` after training on mixtu
 
 4. **Baseline-relative constrained improvement**
 
-   Let `p_0` be a pinned baseline or expert proposal. Optimize a predeclared primary utility while requiring every guardrail subset to remain within a tolerance of its baseline score:
+   Let `p_0` be a pinned baseline or expert proposal.
+   Optimize a predeclared primary utility while requiring every guardrail subset to remain within a tolerance of its baseline score:
 
    ```math
    \max_p U_{\mathrm{primary}}(p) - \eta D(p,p_0)
@@ -156,22 +197,27 @@ Let `s_t(p)` be AUPRC for trait or evaluation subset `t` after training on mixtu
    s_t(p) \geq s_t(p_0) - \epsilon_t \;\; \text{for all guardrail subsets } t.
    ```
 
-   This adapts the A2B pattern in the community slides: guard all tasks, improve selected targets, and stay local to the proposal. It may be easier to interpret than collapsing primary and guardrail tasks into one scalar, but the tolerances, distance, and primary target must be preregistered.
+   This adapts the A2B pattern in the community slides: guard all tasks, improve selected targets, and stay local to the proposal.
+   It may be easier to interpret than collapsing primary and guardrail tasks into one scalar, but the tolerances, distance, and primary target must be preregistered.
 #### Which evaluation readout defines the objective?
 
-The optimization metric must also specify how model performance is read out. Candidate definitions are:
+The optimization metric must also specify how model performance is read out.
+Candidate definitions are:
 
 - zero-shot variant scores;
 - one global linear probe shared across applicable subsets; and
 - separate per-subset linear probes.
 
-Avoid defining the objective as the post hoc "best of zero-shot and probe." That gives every mixture multiple chances to win and makes the selected objective depend on evaluation noise. Better options are to:
+Avoid defining the objective as the post hoc "best of zero-shot and probe."
+That gives every mixture multiple chances to win and makes the selected objective depend on evaluation noise.
+Better options are to:
 
 - preregister one readout as primary and report the others as secondary;
 - define a fixed composite of normalized zero-shot and probe scores; or
 - treat the readouts as a multi-objective problem and report a Pareto frontier.
 
-Probe training data, hyperparameter searches, and random seeds must be identical across mixtures. The test split used to report the final comparison must not be used to fit mixture weights.
+Probe training data, hyperparameter searches, and random seeds must be identical across mixtures.
+The test split used to report the final comparison must not be used to fit mixture weights.
 
 ### Can proxy models provide signal at small scale?
 
@@ -186,9 +232,12 @@ For each proxy scale and evaluation readout, estimate:
 - stability over training checkpoints; and
 - Spearman/Kendall rank agreement across proxy sizes and token budgets.
 
-The mixture signal must be distinguishable from run and evaluation noise. If a metric is effectively random at proxy scale, it should not be used as a regression target merely because it is meaningful at large scale. Options are to increase proxy size or duration, use a lower-variance intermediate metric, or stop and record that the proposed optimization is not currently cost-effective.
+The mixture signal must be distinguishable from run and evaluation noise.
+If a metric is effectively random at proxy scale, it should not be used as a regression target merely because it is meaningful at large scale.
+Options are to increase proxy size or duration, use a lower-variance intermediate metric, or stop and record that the proposed optimization is not currently cost-effective.
 
-The community slides sharpen the intermediate-metric option into a concrete open problem: build low-cost, smooth evaluations that emerge at swarm scale and correlate with the intended target-scale objective, because many hard benchmarks show no signal in small proxies. A smooth proxy metric may be used for screening only after its cross-mixture correlation and rank transfer are evaluated on held-out mixtures at one or more larger scales; smoothness alone is not evidence of relevance.
+The community slides sharpen the intermediate-metric option into a concrete open problem: build low-cost, smooth evaluations that emerge at swarm scale and correlate with the intended target-scale objective, because many hard benchmarks show no signal in small proxies.
+A smooth proxy metric may be used for screening only after its cross-mixture correlation and rank transfer are evaluated on held-out mixtures at one or more larger scales; smoothness alone is not evidence of relevance.
 
 ### Proxy-swarm targets: absolute versus relative performance
 
@@ -198,7 +247,9 @@ Possible surrogate targets include:
 2. **Centered or ranked performance:** predict a mixture's rank or its score after centering within a common swarm/evaluation batch.
 3. **Pairwise preference:** predict which of two mixtures performs better, preferably using matched evaluation and training seeds where possible.
 
-Relative targets may suppress shared run-level noise and align directly with the goal of selecting the best mixture. They also discard effect-size information and can become incomparable across independently trained swarms. Include the same anchor mixtures in every swarm batch so batches can be calibrated, and evaluate all target formulations on held-out mixtures.
+Relative targets may suppress shared run-level noise and align directly with the goal of selecting the best mixture.
+They also discard effect-size information and can become incomparable across independently trained swarms.
+Include the same anchor mixtures in every swarm batch so batches can be calibrated, and evaluate all target formulations on held-out mixtures.
 
 Surrogate quality should be judged by selection behavior, not training fit:
 
@@ -215,7 +266,8 @@ For target training budget `R` tokens, component `j` with `N_j` unique tokens an
 ```math
 e_j(p) = \frac{R p_j}{N_j}.
 ```
-This exposes a mismatch between a short proxy run and a long target run. Possible treatments include:
+This exposes a mismatch between a short proxy run and a long target run.
+Possible treatments include:
 
 1. **Hard repetition constraints:** `p_j <= e_j^max N_j / R`
 
@@ -223,19 +275,25 @@ This exposes a mismatch between a short proxy run and a long target run. Possibl
 
 2. **Repetition-aware utility**
 
-   Penalize or discount weights whose implied target-scale epochs enter a diminishing-return regime. The penalty must be fixed from an independent repetition study or estimated in a nested training split, not tuned on the final evaluation.
+   Penalize or discount weights whose implied target-scale epochs enter a diminishing-return regime.
+   The penalty must be fixed from an independent repetition study or estimated in a nested training split, not tuned on the final evaluation.
 
 3. **Simulated target exposure in proxy training**
 
    Construct proxy sampling schedules that reproduce the target run's component-level epoch counts or repetition pattern at reduced compute, then test whether this improves rank transfer.
 
-The first approach follows Olmix's practical recommendation to enforce finite-data feasibility during mixture optimization. The third most directly captures the "simulated epoching" hypothesis. A follow-up experiment could compare them rather than assuming that scarce high-conservation cells must simply be downweighted in the regression itself.
+The first approach follows Olmix's practical recommendation to enforce finite-data feasibility during mixture optimization.
+The third most directly captures the "simulated epoching" hypothesis.
+A follow-up experiment could compare them rather than assuming that scarce high-conservation cells must simply be downweighted in the regression itself.
 
-Report the unconstrained optimum as a diagnostic. A large gap between the unconstrained and feasible optima is evidence that data availability, not only estimated utility, is determining the final recipe.
+Report the unconstrained optimum as a diagnostic.
+A large gap between the unconstrained and feasible optima is evidence that data availability, not only estimated utility, is determining the final recipe.
 
 ### Implementation ideas for follow-up issues
 
-The following are a menu of possible implementation and analysis directions, not a prescribed study or ordered roadmap. The proxy-swarm path is currently the most developed because it appears especially promising, not because this issue has selected it over the alternatives. Each item could become a separate EDA or experiment issue.
+The following are a menu of possible implementation and analysis directions, not a prescribed study or ordered roadmap.
+The proxy-swarm path is currently the most developed because it appears especially promising, not because this issue has selected it over the alternatives.
+Each item could become a separate EDA or experiment issue.
 
 #### Possible comparison: Benchmark optimization approaches
 
@@ -268,7 +326,8 @@ The following are a menu of possible implementation and analysis directions, not
 - Record both sampled weights and realized token counts; assert that sampling noise does not materially change the intended mixtures.
 - Choose swarm size from a documented power/sample-complexity analysis rather than copying a fixed run count from NLP.
 
-Dense versus sparse Dirichlet swarms should be treated as a design choice to validate. With a grid of correlated genomic cells, sparse mixtures may expose cell effects more clearly, while dense mixtures may better resemble feasible target recipes.
+Dense versus sparse Dirichlet swarms should be treated as a design choice to validate.
+With a grid of correlated genomic cells, sparse mixtures may expose cell effects more clearly, while dense mixtures may better resemble feasible target recipes.
 
 #### Possible analysis: Fit and validate surrogates
 
@@ -279,7 +338,8 @@ Compare simple baselines before more flexible regressors:
 - a tree-based model such as LightGBM when the swarm is large enough; and
 - rank or pairwise models for the relative-performance hypothesis.
 
-Use held-out mixtures or nested cross-validation for all model and hyperparameter selection. A flexible regressor with excellent in-swarm fit but poor held-out ranking is not useful.
+Use held-out mixtures or nested cross-validation for all model and hyperparameter selection.
+A flexible regressor with excellent in-swarm fit but poor held-out ranking is not useful.
 
 When optimizing the surrogate:
 
@@ -298,9 +358,11 @@ A confirmatory comparison could train matched models on:
 4. the proxy-predicted robust/minimax mixture; and
 5. a deliberately different or randomly selected held-out mixture.
 
-One risk-reducing option is to validate at an intermediate scale not used to fit the surrogate before comparing the best-supported candidates at the intended target scale. Architecture, tokenizer, optimizer, total training tokens, evaluation protocol, and number of seeds should be matched wherever feasible.
+One risk-reducing option is to validate at an intermediate scale not used to fit the surrogate before comparing the best-supported candidates at the intended target scale.
+Architecture, tokenizer, optimizer, total training tokens, evaluation protocol, and number of seeds should be matched wherever feasible.
 
-This research-question issue does not authorize paid large-scale training or a broad swarm. Any follow-up experiment proposing such a launch must obtain explicit approval.
+This research-question issue does not authorize paid large-scale training or a broad swarm.
+Any follow-up experiment proposing such a launch must obtain explicit approval.
 
 #### Possible follow-up: Test objective specificity with DART-Eval
 
@@ -344,7 +406,8 @@ Depending on which follow-up issues are pursued, useful outputs could include:
 
 ### Evidence that would advance the question
 
-This research question can accumulate evidence across several independent issues. Meaningful progress would include one or more of:
+This research question can accumulate evidence across several independent issues.
+Meaningful progress would include one or more of:
 
 - defining interpretable, versioned mixture components;
 - identifying an evaluation objective with measurable proxy-scale signal;
@@ -372,8 +435,11 @@ This draft makes the following non-blocking interpretations of the transcription
 
 1. "Mendelian traits barne effect prediction" means the current **Mendelian-trait variant-effect-prediction** evaluation, summarized by AUPRC across trait subsets.
 2. "OlmoMix" refers to **Olmix**, the data-mixing framework developed in the OLMo ecosystem, rather than OLMoE or a dataset named OLMo-mix.
-3. "Simulated epoching" means accounting for the number and pattern of times each finite data component would be repeated at the target training budget. If it refers to a specific named method, add that citation and align the experimental arm with its definition.
-4. The initial biological-domain axis is the five v4 specialist partitions used by exp255: CDS, non-promoter cCRE, 3′ UTR, ncRNA exon, and TSS region plus 5′ UTR. Background remains a separate candidate component/control.
+3. "Simulated epoching" means accounting for the number and pattern of times each finite data component would be repeated at the target training budget.
+   If it refers to a specific named method, add that citation and align the experimental arm with its definition.
+4. The initial biological-domain axis is the five v4 specialist partitions used by exp255: CDS, non-promoter cCRE, 3′ UTR, ncRNA exon, and TSS region plus 5′ UTR.
+   Background remains a separate candidate component/control.
 5. DART-Eval is a separate possible follow-up target rather than necessarily part of the same scalar objective as Mendelian VEP.
-6. Evolutionary scale is an optional follow-up axis. If included, nested taxonomic groups must be converted to disjoint buckets or modeled hierarchically so the same data are not counted under multiple weights.
+6. Evolutionary scale is an optional follow-up axis.
+   If included, nested taxonomic groups must be converted to disjoint buckets or modeled hierarchically so the same data are not counted under multiple weights.
 7. Phase-specific mixing means separate weight vectors over the same semantic cells for broad pretraining and cooldown or midtraining; phase is not an additional biological bucket axis.

--- a/docs/research/questions/evolutionary-timescale.md
+++ b/docs/research/questions/evolutionary-timescale.md
@@ -2,57 +2,88 @@
 
 ## TL;DR
 
-Existing MarinDNA experiments show that useful evolutionary breadth depends on genomic region: promoter and CDS specialists prefer different timescales, and reducing mammalian species diversity hurts some regions more than others. Confidence is moderate that there is no universal best clade depth; the main gap is a matched factorial test of breadth, quantity, and downstream task.
+Existing MarinDNA experiments show that useful evolutionary breadth depends on genomic region: promoter and CDS specialists prefer different timescales, and reducing mammalian species diversity hurts some regions more than others.
+Confidence is moderate that there is no universal best clade depth; the main gap is a matched factorial test of breadth, quantity, and downstream task.
 
 ## Question
 
-For a target organism or clade, how should we choose the phylogenetic breadth and sampling density of genomic language model training data to balance raw sequence diversity against evolutionary relevance? Does the optimal timescale depend on genomic region and downstream task—for example, with deeply conserved coding biology benefiting from broader animal data while rapidly evolving regulatory sequence benefits from mammal- or primate-focused data? Can broad pretraining followed by adaptation to the target clade capture both advantages, and when is that curriculum better than training on a fixed mixture from scratch?
+For a target organism or clade, how should we choose the phylogenetic breadth and sampling density of genomic language model training data to balance raw sequence diversity against evolutionary relevance?
+Does the optimal timescale depend on genomic region and downstream task—for example, with deeply conserved coding biology benefiting from broader animal data while rapidly evolving regulatory sequence benefits from mammal- or primate-focused data?
+Can broad pretraining followed by adaptation to the target clade capture both advantages, and when is that curriculum better than training on a fixed mixture from scratch?
 
 ## Current answer
 
-There is no universal best evolutionary timescale in the current evidence. Promoter, CDS, UTR, ncRNA, enhancer, and different evaluation endpoints respond differently to phylogenetic breadth. Broader data can improve diversity and expose conserved rules; closer species spend more tokens on lineage-relevant grammar; and each genomic feature evolves on a different timescale.
+There is no universal best evolutionary timescale in the current evidence.
+Promoter, CDS, UTR, ncRNA, enhancer, and different evaluation endpoints respond differently to phylogenetic breadth.
+Broader data can improve diversity and expose conserved rules; closer species spend more tokens on lineage-relevant grammar; and each genomic feature evolves on a different timescale.
 
-Promoter and 3′ UTR comparisons favor mammals for learning speed, while broad animal CDS can become stronger later for missense VEP. Reducing mammalian species density at matched compute is neutral for several regions but harmful for ncRNA and 5′ UTR/TSS. Animal-versus-vertebrate CDS results also change with evaluation and data-construction method. Nominal clade breadth can differ from effective breadth when a projection method recovers few distant species.
+Promoter and 3′ UTR comparisons favor mammals for learning speed, while broad animal CDS can become stronger later for missense VEP.
+Reducing mammalian species density at matched compute is neutral for several regions but harmful for ncRNA and 5′ UTR/TSS.
+Animal-versus-vertebrate CDS results also change with evaluation and data-construction method.
+Nominal clade breadth can differ from effective breadth when a projection method recovers few distant species.
 
-Confidence is moderate that timescale should be chosen by region and objective and low on the optimal schedule. Most experiments change unique data, epochs, species density, or sequence-selection method alongside clade depth. A matched factorial comparison is still needed.
+Confidence is moderate that timescale should be chosen by region and objective and low on the optimal schedule.
+Most experiments change unique data, epochs, species density, or sequence-selection method alongside clade depth.
+A matched factorial comparison is still needed.
 
-The leading strategy is broad pretraining followed by target-clade adaptation or an explicit mixture, compared against broad-only and target-only training at matched total compute. This would separate early sample efficiency from final endpoint quality and test whether one static species mixture is unnecessarily restrictive.
+The leading strategy is broad pretraining followed by target-clade adaptation or an explicit mixture, compared against broad-only and target-only training at matched total compute.
+This would separate early sample efficiency from final endpoint quality and test whether one static species mixture is unnecessarily restrictive.
 
 <details>
 <summary>Related work</summary>
 
-- [Does conditioning on species/clade help?](species-conditioning.md) asks whether explicit species or clade conditioning can expose taxonomic context that sequence-only training must infer. Conditioning could reduce the need to choose one static timescale, but no matched MarinDNA conditioning ablation exists.
-- [Why do MarinDNA models lag on complex-trait VEP?](complex-trait-vep.md) asks whether shallower evolutionary context helps complex-trait VEP. GPN-Star’s mammal and primate models lead different complex-trait endpoints, so the relevant comparison is endpoint-specific rather than a generic “closer is better” claim.
-- The distinction between nominal and effective breadth is methodological: annotation, whole-genome alignment, and human-anchored nucleotide projection admit different distant species even under the same taxonomic label. Future comparisons should report realized per-species tokens and locus coverage, not only the requested clade.
+- [Does conditioning on species/clade help?](species-conditioning.md) asks whether explicit species or clade conditioning can expose taxonomic context that sequence-only training must infer.
+  Conditioning could reduce the need to choose one static timescale, but no matched MarinDNA conditioning ablation exists.
+- [Why do MarinDNA models lag on complex-trait VEP?](complex-trait-vep.md) asks whether shallower evolutionary context helps complex-trait VEP.
+  GPN-Star’s mammal and primate models lead different complex-trait endpoints, so the relevant comparison is endpoint-specific rather than a generic “closer is better” claim.
+- The distinction between nominal and effective breadth is methodological: annotation, whole-genome alignment, and human-anchored nucleotide projection admit different distant species even under the same taxonomic label.
+  Future comparisons should report realized per-species tokens and locus coverage, not only the requested clade.
 
 </details>
 
 <details>
 <summary>Related experiments</summary>
 
-- [#6](https://github.com/Open-Athena/marin-dna/issues/6) established the initial evolutionary-timescale experiment series. It framed human, primate, mammal, vertebrate, and animal corpora as an empirical axis but did not by itself resolve region-specific optima.
-- [#55](https://github.com/Open-Athena/marin-dna/issues/55) compared promoter training across those scopes. Mammalian data reached strong human Mendelian VEP sooner, while smaller human/primate corpora overfit; scope, unique-data quantity, and epochs remained confounded.
-- [#58](https://github.com/Open-Athena/marin-dna/issues/58) compared CDS timescales. Shallower arms led early on missense VEP, while the animal arm later surpassed them, showing that learning speed and final quality can prefer different breadths.
-- [#59](https://github.com/Open-Athena/marin-dna/issues/59) extended the comparison to downstream regions. Mammalian training learned 3′ UTR VEP faster, while vertebrate and animal arms later approached similar performance.
-- [#142](https://github.com/Open-Athena/marin-dna/issues/142) compared primate-specific and mammal-wide conservation filters for projected enhancers. The mammal-wide filter was modestly better on Mendelian distal VEP, although source selection and projection coverage changed with the filter.
-- [#255](https://github.com/Open-Athena/marin-dna/issues/255) compared 108-family and 19-order mammalian cohorts at matched compute. Coding, 3′ UTR, and enhancer VEP were similar; ncRNA and 5′ UTR/TSS worsened with fewer species, with one seed and different epoch counts.
-- [#353](https://github.com/Open-Athena/marin-dna/issues/353) compared animal- and vertebrate-scale CDS built by native annotation and human-anchored projection. The preferred scope depended on evaluation and construction method, and low invertebrate recovery showed that nominal animal breadth did not imply broad nucleotide coverage.
+- [#6](https://github.com/Open-Athena/marin-dna/issues/6) established the initial evolutionary-timescale experiment series.
+  It framed human, primate, mammal, vertebrate, and animal corpora as an empirical axis but did not by itself resolve region-specific optima.
+- [#55](https://github.com/Open-Athena/marin-dna/issues/55) compared promoter training across those scopes.
+  Mammalian data reached strong human Mendelian VEP sooner, while smaller human/primate corpora overfit; scope, unique-data quantity, and epochs remained confounded.
+- [#58](https://github.com/Open-Athena/marin-dna/issues/58) compared CDS timescales.
+  Shallower arms led early on missense VEP, while the animal arm later surpassed them, showing that learning speed and final quality can prefer different breadths.
+- [#59](https://github.com/Open-Athena/marin-dna/issues/59) extended the comparison to downstream regions.
+  Mammalian training learned 3′ UTR VEP faster, while vertebrate and animal arms later approached similar performance.
+- [#142](https://github.com/Open-Athena/marin-dna/issues/142) compared primate-specific and mammal-wide conservation filters for projected enhancers.
+  The mammal-wide filter was modestly better on Mendelian distal VEP, although source selection and projection coverage changed with the filter.
+- [#255](https://github.com/Open-Athena/marin-dna/issues/255) compared 108-family and 19-order mammalian cohorts at matched compute.
+  Coding, 3′ UTR, and enhancer VEP were similar; ncRNA and 5′ UTR/TSS worsened with fewer species, with one seed and different epoch counts.
+- [#353](https://github.com/Open-Athena/marin-dna/issues/353) compared animal- and vertebrate-scale CDS built by native annotation and human-anchored projection.
+  The preferred scope depended on evaluation and construction method, and low invertebrate recovery showed that nominal animal breadth did not imply broad nucleotide coverage.
 
 </details>
 
 ## Possible directions
 
-1. **What exactly should “evolutionary timescale” mean experimentally?** Phylogenetic breadth (primates versus mammals versus vertebrates versus animals), species density within a clade, total unique bases, and distance from the target organism are separate axes and should not be collapsed into one variable.
+1. **What exactly should “evolutionary timescale” mean experimentally?**
+   Phylogenetic breadth (primates versus mammals versus vertebrates versus animals), species density within a clade, total unique bases, and distance from the target organism are separate axes and should not be collapsed into one variable.
 
-2. **What is the clean fixed-compute comparison?** Train matched primate-, mammal-, vertebrate-, and animal-scope arms with the same model, optimizer, total tokens, sequence-selection method, and evaluation checkpoints. Report both fixed-token and matched-epoch or matched-unique-locus views so that breadth is not mistaken for repetition or dataset size.
+2. **What is the clean fixed-compute comparison?**
+   Train matched primate-, mammal-, vertebrate-, and animal-scope arms with the same model, optimizer, total tokens, sequence-selection method, and evaluation checkpoints.
+   Report both fixed-token and matched-epoch or matched-unique-locus views so that breadth is not mistaken for repetition or dataset size.
 
-3. **Does broad-to-narrow training dominate a static mixture?** At matched total tokens, compare broad-only, target-clade-only, broad pretraining followed by target-clade adaptation, and an interleaved/reweighted mixture. Sweep the fraction of compute spent in each stage and measure both target-task gains and catastrophic forgetting of broader capabilities.
+3. **Does broad-to-narrow training dominate a static mixture?**
+   At matched total tokens, compare broad-only, target-clade-only, broad pretraining followed by target-clade adaptation, and an interleaved/reweighted mixture.
+   Sweep the fraction of compute spent in each stage and measure both target-task gains and catastrophic forgetting of broader capabilities.
 
-4. **How does the answer vary by genomic region?** Run the comparison separately for CDS, promoters/TSS, 5′ and 3′ UTRs, ncRNA exons, enhancers/distal regulatory sequence, and background. A region-specific species mixture or curriculum may be better than a single whole-genome recipe.
+4. **How does the answer vary by genomic region?**
+   Run the comparison separately for CDS, promoters/TSS, 5′ and 3′ UTRs, ncRNA exons, enhancers/distal regulatory sequence, and background.
+   A region-specific species mixture or curriculum may be better than a single whole-genome recipe.
 
-5. **How does the answer vary by biological endpoint?** Separate language-model loss and functional-versus-background LL gaps from human Mendelian VEP, complex-trait VEP, eQTL/regulatory effects, saturation assays, and cross-species transfer. Rare coding variants and common regulatory variants may reflect different evolutionary timescales.
+5. **How does the answer vary by biological endpoint?**
+   Separate language-model loss and functional-versus-background LL gaps from human Mendelian VEP, complex-trait VEP, eQTL/regulatory effects, saturation assays, and cross-species transfer.
+   Rare coding variants and common regulatory variants may reflect different evolutionary timescales.
 
-6. **Does the optimum change with model scale, context length, or token budget?** A small or short-context model may benefit more from narrowly relevant data, whereas a larger model may have enough capacity and compute to absorb broad diversity without sacrificing target-clade performance.
+6. **Does the optimum change with model scale, context length, or token budget?**
+   A small or short-context model may benefit more from narrowly relevant data, whereas a larger model may have enough capacity and compute to absorb broad diversity without sacrificing target-clade performance.
 
 7. **What result would support each training strategy?**
    - Broad-only winning at matched compute would support diversity and deeper conservation as the dominant source of signal.

--- a/docs/research/questions/genomic-anchors.md
+++ b/docs/research/questions/genomic-anchors.md
@@ -2,59 +2,94 @@
 
 ## TL;DR
 
-The current full-window projection contract is operational and has supported viable training datasets, but its anchor criterion, fragment semantics, and homology-versus-yield tradeoff remain unsettled. Confidence is high in the documented baseline behavior and low in its optimality; the main gap is a matched projection-policy comparison tied to downstream performance.
+The current full-window projection contract is operational and has supported viable training datasets, but its anchor criterion, fragment semantics, and homology-versus-yield tradeoff remain unsettled.
+Confidence is high in the documented baseline behavior and low in its optimality; the main gap is a matched projection-policy comparison tied to downstream performance.
 
 ## Question
 
-How do human anchor-inclusion and cross-species alignment-projection choices change which genomic regions and species are represented in multispecies DNA language-model training data, and how do those choices affect downstream model quality? We want to understand the genome-wide trade-off among evolutionary breadth, confidence that an extracted target window is homologous to its human anchor, and usefulness for model training. Projection yield and clade recovery are intermediate measurements; downstream model performance is the final criterion.
+How do human anchor-inclusion and cross-species alignment-projection choices change which genomic regions and species are represented in multispecies DNA language-model training data, and how do those choices affect downstream model quality?
+We want to understand the genome-wide trade-off among evolutionary breadth, confidence that an extracted target window is homologous to its human anchor, and usefulness for model training.
+Projection yield and clade recovery are intermediate measurements; downstream model performance is the final criterion.
 
 ## Current answer
 
-The full-window projection baseline is operational and well specified, but its optimality is unknown. It starts from conservation-filtered 255 bp human anchors, projects the full interval, requires all compatible fragments to map to one target chromosome and strand without overlap, takes their outer span, accepts spans from 128 to 512 bp, and resizes around the span midpoint to 255 bp. The final target window can therefore contain unaligned flanking sequence.
+The full-window projection baseline is operational and well specified, but its optimality is unknown.
+It starts from conservation-filtered 255 bp human anchors, projects the full interval, requires all compatible fragments to map to one target chromosome and strand without overlap, takes their outer span, accepts spans from 128 to 512 bp, and resizes around the span midpoint to 255 bp.
+The final target window can therefore contain unaligned flanking sequence.
 
-This contract has produced viable mammalian and vertebrate training data and supports backend-uniform rejection accounting. It does not establish that full-window projection selects the best homologous locus or balances homology confidence and species recovery optimally. Tiny fragments, duplicated loci, midpoint definition, span thresholds, and allowed unaligned flank remain policy choices.
+This contract has produced viable mammalian and vertebrate training data and supports backend-uniform rejection accounting.
+It does not establish that full-window projection selects the best homologous locus or balances homology confidence and species recovery optimally.
+Tiny fragments, duplicated loci, midpoint definition, span thresholds, and allowed unaligned flank remain policy choices.
 
-A center-seeded alternative would project one central landmark, require a unique target locus, and extract a fixed target-genome window around it. This could increase distant-species recovery while weakening evidence that the surrounding bases are homologous. Multiple landmarks or fragment-selection policies occupy intermediate points.
+A center-seeded alternative would project one central landmark, require a unique target locus, and extract a fixed target-genome window around it.
+This could increase distant-species recovery while weakening evidence that the surrounding bases are homologous.
+Multiple landmarks or fragment-selection policies occupy intermediate points.
 
-Confidence is high in the documented behavior of the baseline and low in its optimality. The next decision gate is a matched policy comparison on fixed anchors with per-species and per-region recovery, mapping ambiguity, aligned coverage, unaligned flank, and downstream training at matched tokens. Projection yield alone is insufficient.
+Confidence is high in the documented behavior of the baseline and low in its optimality.
+The next decision gate is a matched policy comparison on fixed anchors with per-species and per-region recovery, mapping ambiguity, aligned coverage, unaligned flank, and downstream training at matched tokens.
+Projection yield alone is insufficient.
 
 <details>
 <summary>Related work</summary>
 
-- [#121](https://github.com/Open-Athena/marin-dna/issues/121) developed the early Zoonomia HAL enhancer-projection path. It established operational feasibility for human-anchored mammalian data but was limited to an enhancer-oriented pipeline.
-- [#149](https://github.com/Open-Athena/marin-dna/issues/149) generalized human-anchored projection into a genome-wide mammalian training program. It established the reusable data concept; projection semantics were inherited rather than experimentally optimized.
-- [#153](https://github.com/Open-Athena/marin-dna/issues/153) compared MAF streaming with halLiftover using no-duplicate mappings and selected HAL for speed and operational simplicity. It also established the single-locus, 128–512 bp outer-span, midpoint-resize baseline. The comparison chose a backend, not the best biological projection policy.
-- [#227](https://github.com/Open-Athena/marin-dna/issues/227) fixed the v4 base-pair and window-labeling contract used after projection. It separates annotation semantics from projection semantics but does not measure homolog quality.
-- [#230](https://github.com/Open-Athena/marin-dna/issues/230) and [#233](https://github.com/Open-Athena/marin-dna/issues/233) added rank-based species subsetting and built the 19-order cohort. They make recovery-versus-species-density experiments possible; they do not choose anchor or projection policy.
-- [#417](https://github.com/Open-Athena/marin-dna/issues/417) applies one projection contract across Zoonomia HAL and UCSC MultiZ sources and records backend-uniform rejection reasons. It improves comparability and accounting while leaving the contract itself unvalidated.
-- [Ye et al., Predicting functional constraints across evolutionary timescales with phylogeny-informed genomic language models](https://pmc.ncbi.nlm.nih.gov/articles/PMC12458161/) shows that GPN-Star calibrated entropy can outperform classical phyloP or PhastCons for constraint and variant prioritization and that primate, mammal, and vertebrate timescales differ by endpoint. This motivates alternative anchor-inclusion scores. It does not determine the best projection semantics.
-- The released [GPN-Star genome-wide scores](https://huggingface.co/datasets/songlab/gpn-star-scores) provide calibrated position-level entropy at primate, mammal, and vertebrate timescales. Count-matched thresholds can separate score choice from selected-genome fraction; within-window selected-base fraction remains a separate axis.
+- [#121](https://github.com/Open-Athena/marin-dna/issues/121) developed the early Zoonomia HAL enhancer-projection path.
+  It established operational feasibility for human-anchored mammalian data but was limited to an enhancer-oriented pipeline.
+- [#149](https://github.com/Open-Athena/marin-dna/issues/149) generalized human-anchored projection into a genome-wide mammalian training program.
+  It established the reusable data concept; projection semantics were inherited rather than experimentally optimized.
+- [#153](https://github.com/Open-Athena/marin-dna/issues/153) compared MAF streaming with halLiftover using no-duplicate mappings and selected HAL for speed and operational simplicity.
+  It also established the single-locus, 128–512 bp outer-span, midpoint-resize baseline.
+  The comparison chose a backend, not the best biological projection policy.
+- [#227](https://github.com/Open-Athena/marin-dna/issues/227) fixed the v4 base-pair and window-labeling contract used after projection.
+  It separates annotation semantics from projection semantics but does not measure homolog quality.
+- [#230](https://github.com/Open-Athena/marin-dna/issues/230) and [#233](https://github.com/Open-Athena/marin-dna/issues/233) added rank-based species subsetting and built the 19-order cohort.
+  They make recovery-versus-species-density experiments possible; they do not choose anchor or projection policy.
+- [#417](https://github.com/Open-Athena/marin-dna/issues/417) applies one projection contract across Zoonomia HAL and UCSC MultiZ sources and records backend-uniform rejection reasons.
+  It improves comparability and accounting while leaving the contract itself unvalidated.
+- [Ye et al., Predicting functional constraints across evolutionary timescales with phylogeny-informed genomic language models](https://pmc.ncbi.nlm.nih.gov/articles/PMC12458161/) shows that GPN-Star calibrated entropy can outperform classical phyloP or PhastCons for constraint and variant prioritization and that primate, mammal, and vertebrate timescales differ by endpoint.
+  This motivates alternative anchor-inclusion scores.
+  It does not determine the best projection semantics.
+- The released [GPN-Star genome-wide scores](https://huggingface.co/datasets/songlab/gpn-star-scores) provide calibrated position-level entropy at primate, mammal, and vertebrate timescales.
+  Count-matched thresholds can separate score choice from selected-genome fraction; within-window selected-base fraction remains a separate axis.
 
 </details>
 
 <details>
 <summary>Related experiments</summary>
 
-- [#120](https://github.com/Open-Athena/marin-dna/issues/120) compared cheap pairwise methods against lifted enhancer orthologs. It showed that local similarity search can recover useful cross-species cCRE candidates with a measurable recall frontier and motivated projection alternatives.
-- [#136](https://github.com/Open-Athena/marin-dna/issues/136) compared enhancer-curation strategies through training and VEP. Human-anchored projection outperformed per-species segmentation in that setting, supporting the general projection idea without isolating fragment semantics.
-- [#160](https://github.com/Open-Athena/marin-dna/issues/160) trained on the first whole-genome and TSS-proximal Zoonomia projections. The successful runs established end-to-end viability of the baseline dataset, not its optimality.
-- [#166](https://github.com/Open-Athena/marin-dna/issues/166) scaled models on the whole-genome projected dataset. It tests whether the materialized corpus supports larger training, while anchor and projection choices remain fixed.
-- [#177](https://github.com/Open-Athena/marin-dna/issues/177) audited N stretches and repeat masking in the projected corpus. It did not find major corruption from those sources and documented repeat handling; homolog correctness was outside scope.
-- [#187](https://github.com/Open-Athena/marin-dna/issues/187) trained 1B region specialists on the v3 projected partitions. It showed that projected region-specific corpora carry differentiated training signal but used the inherited projection policy.
-- [#213](https://github.com/Open-Athena/marin-dna/issues/213) measured how VEP positives intersect conservation-selected anchors. It found much higher Mendelian than complex-trait coverage, showing that anchor inclusion changes downstream scope before projection begins.
-- [#221](https://github.com/Open-Athena/marin-dna/issues/221) compared region-label assignment policies and found that 34% of anchors changed label. It shows that annotation assignment is a major independent source of dataset variation.
-- [#232](https://github.com/Open-Athena/marin-dna/issues/232) trained matched v4 region specialists. The home-domain diagonal supports the usefulness of the projected partitions and supplies downstream metrics for future policy comparisons.
-- [#255](https://github.com/Open-Athena/marin-dna/issues/255) compared 108-family and 19-order projected cohorts at matched compute. Region-dependent differences show that species recovery and density can matter even when projection semantics are fixed.
-- [#351](https://github.com/Open-Athena/marin-dna/issues/351) compared clean enhancer-centered anchors with uniform tiling. Centering was suggestively better for distal VEP but unequal epoch counts prevented attribution to anchor geometry.
-- [#353](https://github.com/Open-Athena/marin-dna/issues/353) compared human-anchored nucleotide CDS projection with native per-species annotation at vertebrate and animal scales. Projection produced useful data but lost distant species and did not dominate every evaluation, directly exposing the recovery-versus-construction tradeoff.
+- [#120](https://github.com/Open-Athena/marin-dna/issues/120) compared cheap pairwise methods against lifted enhancer orthologs.
+  It showed that local similarity search can recover useful cross-species cCRE candidates with a measurable recall frontier and motivated projection alternatives.
+- [#136](https://github.com/Open-Athena/marin-dna/issues/136) compared enhancer-curation strategies through training and VEP.
+  Human-anchored projection outperformed per-species segmentation in that setting, supporting the general projection idea without isolating fragment semantics.
+- [#160](https://github.com/Open-Athena/marin-dna/issues/160) trained on the first whole-genome and TSS-proximal Zoonomia projections.
+  The successful runs established end-to-end viability of the baseline dataset, not its optimality.
+- [#166](https://github.com/Open-Athena/marin-dna/issues/166) scaled models on the whole-genome projected dataset.
+  It tests whether the materialized corpus supports larger training, while anchor and projection choices remain fixed.
+- [#177](https://github.com/Open-Athena/marin-dna/issues/177) audited N stretches and repeat masking in the projected corpus.
+  It did not find major corruption from those sources and documented repeat handling; homolog correctness was outside scope.
+- [#187](https://github.com/Open-Athena/marin-dna/issues/187) trained 1B region specialists on the v3 projected partitions.
+  It showed that projected region-specific corpora carry differentiated training signal but used the inherited projection policy.
+- [#213](https://github.com/Open-Athena/marin-dna/issues/213) measured how VEP positives intersect conservation-selected anchors.
+  It found much higher Mendelian than complex-trait coverage, showing that anchor inclusion changes downstream scope before projection begins.
+- [#221](https://github.com/Open-Athena/marin-dna/issues/221) compared region-label assignment policies and found that 34% of anchors changed label.
+  It shows that annotation assignment is a major independent source of dataset variation.
+- [#232](https://github.com/Open-Athena/marin-dna/issues/232) trained matched v4 region specialists.
+  The home-domain diagonal supports the usefulness of the projected partitions and supplies downstream metrics for future policy comparisons.
+- [#255](https://github.com/Open-Athena/marin-dna/issues/255) compared 108-family and 19-order projected cohorts at matched compute.
+  Region-dependent differences show that species recovery and density can matter even when projection semantics are fixed.
+- [#351](https://github.com/Open-Athena/marin-dna/issues/351) compared clean enhancer-centered anchors with uniform tiling.
+  Centering was suggestively better for distal VEP but unequal epoch counts prevented attribution to anchor geometry.
+- [#353](https://github.com/Open-Athena/marin-dna/issues/353) compared human-anchored nucleotide CDS projection with native per-species annotation at vertebrate and animal scales.
+  Projection produced useful data but lost distant species and did not dominate every evaluation, directly exposing the recovery-versus-construction tradeoff.
 
 </details>
 
 ## Possible directions
 
 - Which projection semantics best balance species recovery with confidence that the extracted target window is homologous to the human anchor: full-window projection, center-seeded projection, multiple projected landmarks, or fragment/locus-based alternatives?
-- Within full-window projection, should tiny fragments be removed before locus checks, should one fragment be selected as canonical, or should all compatible fragments define the target span? How should same-chromosome/strand requirements, span-length cutoffs, midpoint choice, and permitted unaligned flank vary?
+- Within full-window projection, should tiny fragments be removed before locus checks, should one fragment be selected as canonical, or should all compatible fragments define the target span?
+  How should same-chromosome/strand requirements, span-length cutoffs, midpoint choice, and permitted unaligned flank vary?
 - How do phyloP and GPN-Star inclusion criteria, the evolutionary timescale of the score, the base-level cutoff, and the required within-window selected fraction change genome-wide anchor composition and the percentage of primates, mammals, and vertebrates recovered?
-- How heterogeneous are these effects across genomic annotations and sequence contexts? CDS-centered and cCRE-enhancer-centered windows are useful contrasting initial probes, rather than the scope of the research question itself.
+- How heterogeneous are these effects across genomic annotations and sequence contexts?
+  CDS-centered and cCRE-enhancer-centered windows are useful contrasting initial probes, rather than the scope of the research question itself.
 - Which projection diagnostics are needed beyond overall yield, including unique versus multiple mappings, aligned coverage around center-seeded windows, and per-species, per-clade, and per-region recovery?
 - How should controlled training comparisons separate sequence quality and evolutionary breadth from dataset quantity, and which independent coding, regulatory, and genome-wide evaluations should determine success?

--- a/docs/research/questions/latent-features.md
+++ b/docs/research/questions/latent-features.md
@@ -2,57 +2,100 @@
 
 ## TL;DR
 
-Sparse-autoencoder analyses identify reproducible splice, stop-codon, accessibility, and coding-context feature responses across layers and dictionaries, while several broader semantic claims failed to replicate. The program is paused indefinitely; confidence is moderate for the local causal features and low for a complete biological inventory, with reference-annotation and broader variant tiers still unfinished.
+Sparse-autoencoder analyses identify reproducible splice, stop-codon, accessibility, and coding-context feature responses across layers and dictionaries, while several broader semantic claims failed to replicate.
+The program is paused indefinitely; confidence is moderate for the local causal features and low for a complete biological inventory, with reference-annotation and broader variant tiers still unfinished.
 
 ## Question
 
 What biologically meaningful latent features do genomic language models learn, how are those features organized across layers, orientations, training stages, and model families, and what genomic computations do they support?
 
-MarinDNA m5.1 is the first experimental system for this question, not its scope. We will use sparse autoencoders as the best reasonable feature-discovery instrument available today. The goal is not to establish that SAEs beat every raw-activation, probe, or sequence method. Comparisons and controls should be included only when they rule out a concrete artifact or are necessary for a stronger robustness or causal claim; the priority is rapid, FDR-controlled association discovery, biological interpretation, and targeted follow-up.
+MarinDNA m5.1 is the first experimental system for this question, not its scope.
+We will use sparse autoencoders as the best reasonable feature-discovery instrument available today.
+The goal is not to establish that SAEs beat every raw-activation, probe, or sequence method.
+Comparisons and controls should be included only when they rule out a concrete artifact or are necessary for a stronger robustness or causal claim; the priority is rapid, FDR-controlled association discovery, biological interpretation, and targeted follow-up.
 
-**Primary discovery principle:** prioritize how features change between matched reference and alternate sequences at real or designed variants. Paired Δ features are less studied than single-sequence annotation features, align directly with variant effect prediction, and provide a local counterfactual that removes much background-locus variation. Absolute reference/alternate activations, human-reference inventories, and sequence logos remain essential supporting views for interpreting a response, but they are not the main endpoint.
+**Primary discovery principle:** prioritize how features change between matched reference and alternate sequences at real or designed variants.
+Paired Δ features are less studied than single-sequence annotation features, align directly with variant effect prediction, and provide a local counterfactual that removes much background-locus variation.
+Absolute reference/alternate activations, human-reference inventories, and sequence logos remain essential supporting views for interpreting a response, but they are not the main endpoint.
 
 ## Current answer
 
-The program is paused indefinitely as of 2026-08-10, and all scoped experiment issues are closed. The strongest result is that m5.1 contains sparse features with reproducible local biological responses, but the inventory is selective and strongly dependent on layer, dictionary, orientation, and response definition.
+The program is paused indefinitely as of 2026-08-10, and all scoped experiment issues are closed.
+The strongest result is that m5.1 contains sparse features with reproducible local biological responses, but the inventory is selective and strongly dependent on layer, dictionary, orientation, and response definition.
 
-Splice-acceptor, splice-donor, and stop-creation responses survive targeted perturbation, untouched-context replication, and transfer across independently trained dictionaries. A broad synonymous/codon-degeneracy interpretation did not replicate. A better-trained dictionary instead exposed a narrow leucine-codon-family response. These results support local causal sequence grammars with moderate confidence and argue against assigning semantics from decoder similarity or a single association.
+Splice-acceptor, splice-donor, and stop-creation responses survive targeted perturbation, untouched-context replication, and transfer across independently trained dictionaries.
+A broad synonymous/codon-degeneracy interpretation did not replicate.
+A better-trained dictionary instead exposed a narrow leucine-codon-family response.
+These results support local causal sequence grammars with moderate confidence and argue against assigning semantics from decoder similarity or a single association.
 
-Layer choice is task-specific. Middle layers performed best on the frozen broad-consequence endpoint, while final-layer features carried the strongest Mendelian-label, complex-trait-label, and accessibility-direction associations. Reconstruction quality improved with more SAE training but did not reliably predict biological yield. Feature counts also overstate biological multiplicity because correlated response families can contain many feature IDs.
+Layer choice is task-specific.
+Middle layers performed best on the frozen broad-consequence endpoint, while final-layer features carried the strongest Mendelian-label, complex-trait-label, and accessibility-direction associations.
+Reconstruction quality improved with more SAE training but did not reliably predict biological yield.
+Feature counts also overstate biological multiplicity because correlated response families can contain many feature IDs.
 
-The paired-variant protocol is part of the current answer: retain reference, alternate, signed change, and magnitude; report forward and reverse-complement orientations separately; predeclare any aggregate; test all eligible features with complete-family correction; and distinguish association, interpretation, and intervention. Unsigned AlphaGenome associations currently identify broad GC/CpG-conditioned accessibility or promoter-effect magnitude rather than tissue-specific semantics. Accessibility-direction discoveries are highly redundant and overlap broad consequence response, so accessibility causality remains untested.
+The paired-variant protocol is part of the current answer: retain reference, alternate, signed change, and magnitude; report forward and reverse-complement orientations separately; predeclare any aggregate; test all eligible features with complete-family correction; and distinguish association, interpretation, and intervention.
+Unsigned AlphaGenome associations currently identify broad GC/CpG-conditioned accessibility or promoter-effect magnitude rather than tissue-specific semantics.
+Accessibility-direction discoveries are highly redundant and overlap broad consequence response, so accessibility causality remains untested.
 
-Reference-sequence analyses show substantial repeat and annotation-state capacity. Final-layer repeat information remains after strict composition matching, while promoter-like sequence is easier to identify than enhancer-like sequence. Composition/repeat qualification and exact boundary localization are still needed before claiming genomic segmentation. The next useful biological tiers are UTR, promoter/TSS-proximal, and annotated ncRNA variants, followed later by enhancer/cCRE variants.
+Reference-sequence analyses show substantial repeat and annotation-state capacity.
+Final-layer repeat information remains after strict composition matching, while promoter-like sequence is easier to identify than enhancer-like sequence.
+Composition/repeat qualification and exact boundary localization are still needed before claiming genomic segmentation.
+The next useful biological tiers are UTR, promoter/TSS-proximal, and annotated ncRNA variants, followed later by enhancer/cCRE variants.
 
 <details>
 <summary>Related work</summary>
 
-- [Inside a genomic language model](https://marindna-latent-feature-atlas.gsbenegas.chatgpt.site) is the current visual synthesis of the project’s methods, layer organization, positive findings, negative results, and claim boundaries. The [commit-pinned source](https://github.com/Open-Athena/marin-dna/blob/234f3073121d8de1f51a5e16e8637ac1986152e2/experiments/issue288_latent_feature_atlas/index.html) preserves the reviewed version. It is a summary artifact, not independent evidence.
-- [Korsakova and Kelley, Learning monosemantic features in multitask DNA regulatory sequence models via sparse autoencoder decomposition](https://openreview.net/forum?id=AlLZnZX01x) trained TopK SAEs on early Borzoi layers and annotated features with repeats, motifs, and regulatory elements. Motifs specialized by depth, orientation, and flanking context, and larger dictionaries split concepts. This motivates layer panels, normalized activations, FWD/RC inspection, and context-aware interpretation. The remaining gap is transfer from a supervised regulatory model to paired variant effects in a causal gLM.
-- [Evo 2 feature work](https://www.biorxiv.org/content/10.1101/2025.02.18.638918v1) trained a large BatchTopK SAE on a genomic foundation model and recovered biological sequence features at scale. It supports SAE feasibility but does not establish that individual features are monosemantic or causally relevant to variant effects.
-- [Language Modeling Materializes a World Model of Protein Biology](https://www.biorxiv.org/content/10.1101/2024.12.18.629098v1) reports concept splitting, decoder neighborhoods, and feature combinations in protein models. It motivates analyzing feature families and co-activation systems alongside individual IDs. The open question is whether the same organizational principles hold for genomic sequence and across reverse-complement views.
-- The fixed methodology treats biological labels and automated descriptions as discovery aids. A strong interpretation requires corrected association evidence, sequence localization, paired or designed perturbations, orientation analysis, and independent contexts when the claim warrants it. Causal intervention on the base model remains a higher bar than activation response alone.
+- [Inside a genomic language model](https://marindna-latent-feature-atlas.gsbenegas.chatgpt.site) is the current visual synthesis of the project’s methods, layer organization, positive findings, negative results, and claim boundaries.
+  The [commit-pinned source](https://github.com/Open-Athena/marin-dna/blob/234f3073121d8de1f51a5e16e8637ac1986152e2/experiments/issue288_latent_feature_atlas/index.html) preserves the reviewed version.
+  It is a summary artifact, not independent evidence.
+- [Korsakova and Kelley, Learning monosemantic features in multitask DNA regulatory sequence models via sparse autoencoder decomposition](https://openreview.net/forum?id=AlLZnZX01x) trained TopK SAEs on early Borzoi layers and annotated features with repeats, motifs, and regulatory elements.
+  Motifs specialized by depth, orientation, and flanking context, and larger dictionaries split concepts.
+  This motivates layer panels, normalized activations, FWD/RC inspection, and context-aware interpretation.
+  The remaining gap is transfer from a supervised regulatory model to paired variant effects in a causal gLM.
+- [Evo 2 feature work](https://www.biorxiv.org/content/10.1101/2025.02.18.638918v1) trained a large BatchTopK SAE on a genomic foundation model and recovered biological sequence features at scale.
+  It supports SAE feasibility but does not establish that individual features are monosemantic or causally relevant to variant effects.
+- [Language Modeling Materializes a World Model of Protein Biology](https://www.biorxiv.org/content/10.1101/2024.12.18.629098v1) reports concept splitting, decoder neighborhoods, and feature combinations in protein models.
+  It motivates analyzing feature families and co-activation systems alongside individual IDs.
+  The open question is whether the same organizational principles hold for genomic sequence and across reverse-complement views.
+- The fixed methodology treats biological labels and automated descriptions as discovery aids.
+  A strong interpretation requires corrected association evidence, sequence localization, paired or designed perturbations, orientation analysis, and independent contexts when the claim warrants it.
+  Causal intervention on the base model remains a higher bar than activation response alone.
 
 </details>
 
 <details>
 <summary>Related experiments</summary>
 
-- [#418](https://github.com/Open-Athena/marin-dna/issues/418) trained and validated the first production-shaped m5.1 block-10 BatchTopK SAE. It established workable reconstruction and sparsity and produced initial splice and nucleotide features, but did not by itself validate biological semantics.
-- [#420](https://github.com/Open-Athena/marin-dna/issues/420) tested the first fixed feature panel on Mendelian variants. Pathogenic label was null overall and within subsets, while seven-way consequence/region prediction reached macro-AUPRC 0.2409 versus 0.1429 chance, showing encoded region information without pathogenicity separation.
-- [#421](https://github.com/Open-Athena/marin-dna/issues/421) scanned unsigned SAE changes against AlphaGenome tracks. Leading block-10/19 signals were broad GC/CpG-conditioned accessibility or promoter-effect magnitude features; tissue-specific interpretations failed robustness checks, and one tail-sensitive lead instead connected to Mendelian label.
-- [#422](https://github.com/Open-Athena/marin-dna/issues/422) ran the broad 35-consequence inventory across blocks 1, 10, and 19. Splice, stop, missense, miRNA, promoter-like, and 5′ UTR signals were selective rather than universal, and FWD/RC discoveries agreed in direction when shared despite incomplete ID overlap.
-- [#424](https://github.com/Open-Athena/marin-dna/issues/424) froze the paired-variant and strand protocol. It retained ref, alt, signed and unsigned responses, required separate FWD/RC reporting, and selected signed mean as the then-best global reducer while documenting that same-ID strand invariance is uncommon.
-- [#426](https://github.com/Open-Athena/marin-dna/issues/426) compared SAE layer and 5M versus 25M activation budgets. Block 10/5M led the frozen broad-consequence endpoint, later layers led some coding tasks, and better reconstruction at 25M did not consistently improve biological yield.
-- [#428](https://github.com/Open-Athena/marin-dna/issues/428) replicated fixed coding-context features on a larger phase- and substitution-matched panel. Effects persisted but attenuated, and a local 31-bp sequence model was stronger, narrowing the interpretation to orientation-complementary local coding context.
-- [#429](https://github.com/Open-Athena/marin-dna/issues/429) prospectively replicated causal acceptor, donor, stop-creation, and synonymous/codon-degeneracy perturbation effects on untouched contexts. This established the first local causal feature set for the program.
-- [#431](https://github.com/Open-Athena/marin-dna/issues/431) transferred those semantic queries across independently trained dictionaries. Acceptor, donor, and stop creation replicated; synonymous/codon degeneracy did not, despite stable decoder-neighborhood geometry.
-- [#432](https://github.com/Open-Athena/marin-dna/issues/432) repeated the causal protocol in the healthier 25M dictionary. Splice and stop semantics persisted; the broad synonymous interpretation remained null, while exhaustive search found a narrow leucine-codon-family response.
-- [#434](https://github.com/Open-Athena/marin-dna/issues/434) scanned accessibility-QTL causality and direction. A final-layer signed-direction family appeared in the 559-positive dsQTL pilot, but it was highly redundant, overlapped broad consequence response, and did not test causality because negatives were absent.
-- [#435](https://github.com/Open-Athena/marin-dna/issues/435) mapped repeat capacity across blocks 1, 10, and 19. Repeat hierarchy became more specific with depth; final-layer repeat information survived composition matching, and selected repeat grammars showed causal motif-loss responses, while many shallower signals were composition-linked.
-- [#436](https://github.com/Open-Athena/marin-dna/issues/436) mapped Mendelian pathogenicity across layers. Individual-feature signal was weak in blocks 1/10 and stronger but distributed in block 19; focal associations do not yet bridge the full performance of official likelihood or whole-window embedding readouts.
-- [#438](https://github.com/Open-Athena/marin-dna/issues/438) mapped complex-trait label signal across layers. Block 19 dominated the fixed panel, magnitude was more useful than signed change, and recurrent feature 1662 transferred to held-out data but currently supports local coding-impact/codon-context sensitivity rather than a broad causal mechanism.
-- [#440](https://github.com/Open-Athena/marin-dna/issues/440) tested reference annotation states. The first pass found layer-specific gene-state inventories and strong promoter-like signals but little enhancer-specific signal; composition/repeat controls and transcript-boundary case studies remain unfinished.
+- [#418](https://github.com/Open-Athena/marin-dna/issues/418) trained and validated the first production-shaped m5.1 block-10 BatchTopK SAE.
+  It established workable reconstruction and sparsity and produced initial splice and nucleotide features, but did not by itself validate biological semantics.
+- [#420](https://github.com/Open-Athena/marin-dna/issues/420) tested the first fixed feature panel on Mendelian variants.
+  Pathogenic label was null overall and within subsets, while seven-way consequence/region prediction reached macro-AUPRC 0.2409 versus 0.1429 chance, showing encoded region information without pathogenicity separation.
+- [#421](https://github.com/Open-Athena/marin-dna/issues/421) scanned unsigned SAE changes against AlphaGenome tracks.
+  Leading block-10/19 signals were broad GC/CpG-conditioned accessibility or promoter-effect magnitude features; tissue-specific interpretations failed robustness checks, and one tail-sensitive lead instead connected to Mendelian label.
+- [#422](https://github.com/Open-Athena/marin-dna/issues/422) ran the broad 35-consequence inventory across blocks 1, 10, and 19.
+  Splice, stop, missense, miRNA, promoter-like, and 5′ UTR signals were selective rather than universal, and FWD/RC discoveries agreed in direction when shared despite incomplete ID overlap.
+- [#424](https://github.com/Open-Athena/marin-dna/issues/424) froze the paired-variant and strand protocol.
+  It retained ref, alt, signed and unsigned responses, required separate FWD/RC reporting, and selected signed mean as the then-best global reducer while documenting that same-ID strand invariance is uncommon.
+- [#426](https://github.com/Open-Athena/marin-dna/issues/426) compared SAE layer and 5M versus 25M activation budgets.
+  Block 10/5M led the frozen broad-consequence endpoint, later layers led some coding tasks, and better reconstruction at 25M did not consistently improve biological yield.
+- [#428](https://github.com/Open-Athena/marin-dna/issues/428) replicated fixed coding-context features on a larger phase- and substitution-matched panel.
+  Effects persisted but attenuated, and a local 31-bp sequence model was stronger, narrowing the interpretation to orientation-complementary local coding context.
+- [#429](https://github.com/Open-Athena/marin-dna/issues/429) prospectively replicated causal acceptor, donor, stop-creation, and synonymous/codon-degeneracy perturbation effects on untouched contexts.
+  This established the first local causal feature set for the program.
+- [#431](https://github.com/Open-Athena/marin-dna/issues/431) transferred those semantic queries across independently trained dictionaries.
+  Acceptor, donor, and stop creation replicated; synonymous/codon degeneracy did not, despite stable decoder-neighborhood geometry.
+- [#432](https://github.com/Open-Athena/marin-dna/issues/432) repeated the causal protocol in the healthier 25M dictionary.
+  Splice and stop semantics persisted; the broad synonymous interpretation remained null, while exhaustive search found a narrow leucine-codon-family response.
+- [#434](https://github.com/Open-Athena/marin-dna/issues/434) scanned accessibility-QTL causality and direction.
+  A final-layer signed-direction family appeared in the 559-positive dsQTL pilot, but it was highly redundant, overlapped broad consequence response, and did not test causality because negatives were absent.
+- [#435](https://github.com/Open-Athena/marin-dna/issues/435) mapped repeat capacity across blocks 1, 10, and 19.
+  Repeat hierarchy became more specific with depth; final-layer repeat information survived composition matching, and selected repeat grammars showed causal motif-loss responses, while many shallower signals were composition-linked.
+- [#436](https://github.com/Open-Athena/marin-dna/issues/436) mapped Mendelian pathogenicity across layers.
+  Individual-feature signal was weak in blocks 1/10 and stronger but distributed in block 19; focal associations do not yet bridge the full performance of official likelihood or whole-window embedding readouts.
+- [#438](https://github.com/Open-Athena/marin-dna/issues/438) mapped complex-trait label signal across layers.
+  Block 19 dominated the fixed panel, magnitude was more useful than signed change, and recurrent feature 1662 transferred to held-out data but currently supports local coding-impact/codon-context sensitivity rather than a broad causal mechanism.
+- [#440](https://github.com/Open-Athena/marin-dna/issues/440) tested reference annotation states.
+  The first pass found layer-specific gene-state inventories and strong promoter-like signals but little enhancer-specific signal; composition/repeat controls and transcript-boundary case studies remain unfinished.
 
 </details>
 
@@ -60,7 +103,9 @@ Reference-sequence analyses show substantial repeat and annotation-state capacit
 
 ### 1. Paired-variant protocol: current answer and extensions
 
-Reference and alternate sequences are a matched counterfactual pair, not two independent examples. This paired response is the default scientific unit for this question; single-sequence enrichment is supporting interpretation. [#424](https://github.com/Open-Athena/marin-dna/issues/424) established the current protocol:
+Reference and alternate sequences are a matched counterfactual pair, not two independent examples.
+This paired response is the default scientific unit for this question; single-sequence enrichment is supporting interpretation.
+[#424](https://github.com/Open-Athena/marin-dna/issues/424) established the current protocol:
 
 - retain reference activation, alternate activation, signed Δ, |Δ|, and inactive→active / active→inactive states for each orientation;
 - use signed Δ as the primary variant-effect quantity because threshold crossings miss graded splice effects and magnitude-only views erase informative direction for dense features such as the stop-codon feature;
@@ -69,21 +114,29 @@ Reference and alternate sequences are a matched counterfactual pair, not two ind
 
 Still open:
 
-- [#429](https://github.com/Open-Athena/marin-dna/issues/429) has now frozen and tested the first spatial extension: reverse RC positions into genomic coordinates; preserve focal scoring; choose focal, ±15 bp local maximum, or local sum on validation blocks only; and report held-out profiles. Local maximum decisively improves acceptor and stop-gain features, while donor-fifth-base and synonymous remain focal;
+- [#429](https://github.com/Open-Athena/marin-dna/issues/429) has now frozen and tested the first spatial extension: reverse RC positions into genomic coordinates; preserve focal scoring; choose focal, ±15 bp local maximum, or local sum on validation blocks only; and report held-out profiles.
+  Local maximum decisively improves acceptor and stop-gain features, while donor-fifth-base and synonymous remain focal;
 - how to condition or stratify on substitution type, local annotation, repeat family, and labels when needed without turning the program into a general baseline bake-off;
-- the direct missense-versus-synonymous task is heavily phase-confounded: a discovery-fit codon-position score reaches held-out AUROC 0.927. [#428](https://github.com/Open-Athena/marin-dna/issues/428) now replicates the three frozen SAE scores after matching within codon position and transcript-oriented substitution, but at conditional AUROC 0.590–0.603 rather than the pilot's 0.825–0.853; a fixed 31-bp local-sequence model reaches 0.760. Treat these as stable but modest codon-context features. CDS and splice variants remain the first substantive biological tier as well as the protocol proving ground; broaden beyond missense-versus-synonymous and do not spend the whole program trying to force an amino-acid interpretation.
+- the direct missense-versus-synonymous task is heavily phase-confounded: a discovery-fit codon-position score reaches held-out AUROC 0.927.
+  [#428](https://github.com/Open-Athena/marin-dna/issues/428) now replicates the three frozen SAE scores after matching within codon position and transcript-oriented substitution, but at conditional AUROC 0.590–0.603 rather than the pilot's 0.825–0.853; a fixed 31-bp local-sequence model reaches 0.760.
+  Treat these as stable but modest codon-context features.
+  CDS and splice variants remain the first substantive biological tier as well as the protocol proving ground; broaden beyond missense-versus-synonymous and do not spend the whole program trying to force an amino-acid interpretation.
 
 ### 2. Bidirectionality and reverse complementation
 
-FWD and RC remain primary, separately reported views. [#424](https://github.com/Open-Athena/marin-dna/issues/424) found that same-ID rowwise invariance is uncommon: on held-out variants only 3.86% of adequately supported features had `|r| ≥ 0.05`. Nevertheless, signed same-ID mean won the global validation comparison and transferred best to held-out blocks because useful features can cover complementary strand contexts.
+FWD and RC remain primary, separately reported views.
+[#424](https://github.com/Open-Athena/marin-dna/issues/424) found that same-ID rowwise invariance is uncommon: on held-out variants only 3.86% of adequately supported features had `|r| ≥ 0.05`.
+Nevertheless, signed same-ID mean won the global validation comparison and transferred best to held-out blocks because useful features can cover complementary strand contexts.
 
 Current decision:
 
 - use `(ΔFWD + ΔRC) / 2` as the primary aggregate for broad consequence-family screens, retain both component views, and report `max(|ΔFWD|, |ΔRC|)` as a sensitivity analysis; [#426](https://github.com/Open-Athena/marin-dna/issues/426) shows that max absolute may become the better endpoint for a narrower binary mutation-response question, but this must be declared per analysis rather than selected post hoc;
-- explicit coding-strand alignment is not a better reducer for the three selected coding IDs: aligned versus anti-aligned AUROC is 0.643/0.656 for f12658 and 0.632/0.629 for f13637, both below signed mean; f11064 coding-aligned absolute is 0.734 versus 0.806 for max absolute. These features are not currently strict transcript-orientation features;
+- explicit coding-strand alignment is not a better reducer for the three selected coding IDs: aligned versus anti-aligned AUROC is 0.643/0.656 for f12658 and 0.632/0.629 for f13637, both below signed mean; f11064 coding-aligned absolute is 0.734 versus 0.806 for max absolute.
+  These features are not currently strict transcript-orientation features;
 - do not enforce same-ID RC consistency in the first SAE sweep;
 - begin with RC-balanced SAE training examples under the ordinary objective;
-- treat brute-force cross-ID matching as exploratory. Stable pairs exist, but 13–14 of 70 discovery winners became constant on validation/test, demonstrating winner's curse.
+- treat brute-force cross-ID matching as exploratory.
+  Stable pairs exist, but 13–14 of 70 discovery winners became constant on validation/test, demonstrating winner's curse.
 
 Still open:
 
@@ -93,9 +146,14 @@ Still open:
 
 ### 3. SAE quality and scaling
 
-Experiment [#426](https://github.com/Open-Athena/marin-dna/issues/426) completed the first coarse budget × layer comparison. It rejects two convenient shortcuts: the final layer is not globally best, and longer training / better reconstruction do not imply greater biological feature yield. Blocks 10/16 are the best starting points for broad consequence discovery, while block 19 remains valuable for narrower coding contrasts. The 25M arm is not an upper bound: later runs may scale up to eight billion activations when a biological endpoint, feature stability, or model-relevant reconstruction—not MSE alone—justifies the cost and the run receives its own compute authorization.
+Experiment [#426](https://github.com/Open-Athena/marin-dna/issues/426) completed the first coarse budget × layer comparison.
+It rejects two convenient shortcuts: the final layer is not globally best, and longer training / better reconstruction do not imply greater biological feature yield.
+Blocks 10/16 are the best starting points for broad consequence discovery, while block 19 remains valuable for narrower coding contrasts.
+The 25M arm is not an upper bound: later runs may scale up to eight billion activations when a biological endpoint, feature stability, or model-relevant reconstruction—not MSE alone—justifies the cost and the run receives its own compute authorization.
 
-[#431](https://github.com/Open-Athena/marin-dna/issues/431) adds a sharper failure mode: the [#426](https://github.com/Open-Athena/marin-dna/issues/426) and fresh 5M normalized exports both have negative FVE and JumpReLU L0 around 1,700, while the existing block-10/25M export reaches FVE 0.809 and L0 242.8. [#432](https://github.com/Open-Athena/marin-dna/issues/432) then showed that the healthier 25M checkpoint preserves the robust splice/stop features and exposes a narrow leucine codon-family response, but does not recover a broad or decoder-aligned synonymous feature. Reconstruction health appears useful for resolving specificity, yet still does not substitute for biological association and targeted causal evidence.
+[#431](https://github.com/Open-Athena/marin-dna/issues/431) adds a sharper failure mode: the [#426](https://github.com/Open-Athena/marin-dna/issues/426) and fresh 5M normalized exports both have negative FVE and JumpReLU L0 around 1,700, while the existing block-10/25M export reaches FVE 0.809 and L0 242.8.
+[#432](https://github.com/Open-Athena/marin-dna/issues/432) then showed that the healthier 25M checkpoint preserves the robust splice/stop features and exposes a narrow leucine codon-family response, but does not recover a broad or decoder-aligned synonymous feature.
+Reconstruction health appears useful for resolving specificity, yet still does not substitute for biological association and targeted causal evidence.
 
 SAE improvements should be evaluated by rerunning the fixed first/middle/final biological panels; the layer hypothesis does not prescribe a particular SAE recipe.
 
@@ -108,28 +166,43 @@ SAE improvements should be evaluated by rerunning the fixed first/middle/final b
 7. Compare decoder-space neighborhoods and direction alignment across dictionaries, checkpoints, and seeds; measure biological yield for feature families as well as individual IDs.
 8. After robust individual features emerge, test whether co-activation modules capture higher-order motif or region grammar.
 
-The decisive research metrics are FDR-controlled biological association yield, feature and feature-family stability across seeds/checkpoints, motif/context coherence, FWD/RC behavior, and causal validation. Reuse fixed datasets and analysis definitions when comparing SAE recipes; preserve untouched contexts only for targeted robustness, transfer, or causal claims that require them.
+The decisive research metrics are FDR-controlled biological association yield, feature and feature-family stability across seeds/checkpoints, motif/context coherence, FWD/RC behavior, and causal validation.
+Reuse fixed datasets and analysis definitions when comparing SAE recipes; preserve untouched contexts only for targeted robustness, transfer, or causal claims that require them.
 
 ### 4. Biological follow-up
 
-The literature suggests the following prioritized **variant-response** inventory for short-context m5.1 analysis. Reference-sequence scans are useful both for naming and localizing Δ features and as a distinct annotation/segmentation application:
+The literature suggests the following prioritized **variant-response** inventory for short-context m5.1 analysis.
+Reference-sequence scans are useful both for naming and localizing Δ features and as a distinct annotation/segmentation application:
 
 - **Sequence and composition responses:** how substitutions perturb nucleotide, GC/CpG, homopolymer, low-complexity, and local compositional features.
-- **Repeats and mobile sequence:** variant responses stratified by repeat class, family, subfamily, and divergence/age—including endogenous retroviral/LTR, LINE/SINE, satellite, and simple-repeat sequence. Audit both Δ-responsive feature IDs and their share of nonzero Δ slots and total |Δ| mass; reference activation capacity is a secondary diagnostic.
+- **Repeats and mobile sequence:** variant responses stratified by repeat class, family, subfamily, and divergence/age—including endogenous retroviral/LTR, LINE/SINE, satellite, and simple-repeat sequence.
+  Audit both Δ-responsive feature IDs and their share of nonzero Δ slots and total |Δ| mass; reference activation capacity is a secondary diagnostic.
 - **Local regulatory variant grammar:** perturbations in 5′ and 3′ UTRs, TF and RBP motifs, motif orientation/flanking context, promoters/TSS, cCRE categories, and local motif combinations or spacing.
 - **Gene architecture and RNA variants:** splice donors/acceptors, polypyrimidine tracts, exon/intron boundaries, polyadenylation signals, ORF/intergenic sequence, and annotated tRNA, rRNA, miRNA, snoRNA, lncRNA, and other ncRNA classes.
 - **Coding variant effects:** codon phase/frame, start and stop signals, synonymous versus missense changes, frameshifts, premature stops, and amino-acid or protein-secondary-structure signals recoverable from coding DNA.
 - **Feature organization:** FWD/RC feature pairs or sets, broad-to-specific feature hierarchies, context-specialized members of one motif family, decoder-space neighborhoods, and compositional feature programs.
 
-The practical paired-variant ladder is: **CDS and splicing variants as the first biological step and substantive tier** → 5′/3′ UTR variants → promoter/TSS-proximal and annotated ncRNA variants → enhancer/cCRE variants. Enhancers are the hardest tier because their local sequence vocabulary is heterogeneous and cell-state dependent; claims about distal enhancer–promoter relationships remain out of scope for a 255 bp model.
+The practical paired-variant ladder is: **CDS and splicing variants as the first biological step and substantive tier** → 5′/3′ UTR variants → promoter/TSS-proximal and annotated ncRNA variants → enhancer/cCRE variants.
+Enhancers are the hardest tier because their local sequence vocabulary is heterogeneous and cell-state dependent; claims about distal enhancer–promoter relationships remain out of scope for a 255 bp model.
 
 Applied follow-ups:
 
-- **Reference-sequence segmentation and gene annotation ([#440](https://github.com/Open-Athena/marin-dna/issues/440)):** Scan the human reference at base-pair resolution for features whose activation identifies local genomic states or sharply marks boundaries—for example exon versus intron, CDS versus 5′/3′ UTR, splice boundaries, promoter/TSS, intergenic sequence, and cCRE classes. Evaluate both pointwise class association and boundary localization, keeping FWD/RC separate initially. This is a standalone application of the learned feature inventory rather than a variant-effect endpoint; for the 255 bp m5.1 system it concerns local sequence annotation, not long-range regulatory interactions.
-- **CDS and splicing variants:** This is the first biological step, because known splice and genetic-code grammar provides unusually strong falsification tests while remaining central to variant effect prediction. [#429](https://github.com/Open-Athena/marin-dna/issues/429) has held-out donor/acceptor/stop/synonymous leads, matched discovery-context perturbations, and a prospective hash-sampled test-context panel on which all five original-dictionary causal contrasts clear zero. [#431](https://github.com/Open-Athena/marin-dna/issues/431) then showed that acceptor, donor, and stop semantics survive two independent dictionaries even when IDs permute, while synonymous/codon degeneracy does not survive either 5M dictionary or either exhaustive search. [#432](https://github.com/Open-Athena/marin-dna/issues/432) confirmed the three robust semantics at 25M and found only a narrower leucine codon-family/local-degeneracy feature under exhaustive search, not general synonymous semantics. Broader missense, start/stop-loss, splice-subclass, and real frameshift/indel panels remain separate follow-ups. This tier remains scientifically important after the protocol is validated.
-- **Local regulatory variant ladder:** Find Δ features for 5′/3′ UTR variants first, then strand-aware promoter/TSS-proximal and annotated ncRNA variants, before the harder enhancer/cCRE tier. Use FDR-controlled paired associations, spatial localization around the edit, motif/context inspection, and targeted mutagenesis at every stage; add independent-context replication when advancing a stronger mechanistic claim.
-- **Repeat response capacity:** At each tier, quantify repeat class/family/subfamily associations and the share of Δ-responsive feature IDs, nonzero Δ slots, total |Δ| mass, and decoder neighborhoods devoted to repeat-overlapping variants. Reference-sequence capacity is supporting context.
-- **Regulatory interpretation:** [#421](https://github.com/Open-Athena/marin-dna/issues/421) now characterizes block-19 feature 219 and block-10 feature 11137 as broad, strand-reproducible, GC/CpG-conditioned accessibility/promoter-effect magnitude features. Feature 11928's AlphaGenome association is tail-driven, but its Mendelian-label association is strand-consistent and should be compared with [#436](https://github.com/Open-Athena/marin-dna/issues/436)'s final-layer inventory. Next resolve track-composition robustness, then use targeted perturbation for mechanism and review the signed/default-scorer phase.
+- **Reference-sequence segmentation and gene annotation ([#440](https://github.com/Open-Athena/marin-dna/issues/440)):** Scan the human reference at base-pair resolution for features whose activation identifies local genomic states or sharply marks boundaries—for example exon versus intron, CDS versus 5′/3′ UTR, splice boundaries, promoter/TSS, intergenic sequence, and cCRE classes.
+  Evaluate both pointwise class association and boundary localization, keeping FWD/RC separate initially.
+  This is a standalone application of the learned feature inventory rather than a variant-effect endpoint; for the 255 bp m5.1 system it concerns local sequence annotation, not long-range regulatory interactions.
+- **CDS and splicing variants:** This is the first biological step, because known splice and genetic-code grammar provides unusually strong falsification tests while remaining central to variant effect prediction.
+  [#429](https://github.com/Open-Athena/marin-dna/issues/429) has held-out donor/acceptor/stop/synonymous leads, matched discovery-context perturbations, and a prospective hash-sampled test-context panel on which all five original-dictionary causal contrasts clear zero.
+  [#431](https://github.com/Open-Athena/marin-dna/issues/431) then showed that acceptor, donor, and stop semantics survive two independent dictionaries even when IDs permute, while synonymous/codon degeneracy does not survive either 5M dictionary or either exhaustive search.
+  [#432](https://github.com/Open-Athena/marin-dna/issues/432) confirmed the three robust semantics at 25M and found only a narrower leucine codon-family/local-degeneracy feature under exhaustive search, not general synonymous semantics.
+  Broader missense, start/stop-loss, splice-subclass, and real frameshift/indel panels remain separate follow-ups.
+  This tier remains scientifically important after the protocol is validated.
+- **Local regulatory variant ladder:** Find Δ features for 5′/3′ UTR variants first, then strand-aware promoter/TSS-proximal and annotated ncRNA variants, before the harder enhancer/cCRE tier.
+  Use FDR-controlled paired associations, spatial localization around the edit, motif/context inspection, and targeted mutagenesis at every stage; add independent-context replication when advancing a stronger mechanistic claim.
+- **Repeat response capacity:** At each tier, quantify repeat class/family/subfamily associations and the share of Δ-responsive feature IDs, nonzero Δ slots, total |Δ| mass, and decoder neighborhoods devoted to repeat-overlapping variants.
+  Reference-sequence capacity is supporting context.
+- **Regulatory interpretation:** [#421](https://github.com/Open-Athena/marin-dna/issues/421) now characterizes block-19 feature 219 and block-10 feature 11137 as broad, strand-reproducible, GC/CpG-conditioned accessibility/promoter-effect magnitude features.
+  Feature 11928's AlphaGenome association is tail-driven, but its Mendelian-label association is strand-consistent and should be compared with [#436](https://github.com/Open-Athena/marin-dna/issues/436)'s final-layer inventory.
+  Next resolve track-composition robustness, then use targeted perturbation for mechanism and review the signed/default-scorer phase.
 - **Curriculum and generalization:** Which features appeared or sharpened during the three-way to five-way continuation, and do they generalize across held-out human loci and homologous mammalian loci?
 - **Causality:** For a small preregistered set of robust features, do in-distribution ablation or clamping change downstream predictions in the biologically expected direction?
 - **Efficiency:** What is the cheapest correctness-equivalent extraction and SAE training recipe that preserves the scientific conclusions?

--- a/docs/research/questions/long-context.md
+++ b/docs/research/questions/long-context.md
@@ -2,51 +2,89 @@
 
 ## TL;DR
 
-No MarinDNA experiment directly compares long-context strategies. Existing work favors reusing short-context representations through staged, hierarchical, or downstream adaptation, but the best choice depends on required output resolution and compute; confidence is low, and a matched comparison is the main gap.
+No MarinDNA experiment directly compares long-context strategies.
+Existing work favors reusing short-context representations through staged, hierarchical, or downstream adaptation, but the best choice depends on required output resolution and compute; confidence is low, and a matched comparison is the main gap.
 
 ## Question
 
-How should we turn a genomic language model pretrained on short windows—typically sized to model a single functional element—into a model that can use long-range genomic context while retaining nucleotide-level resolution? At fixed compute and data, how do second-stage long-context language modeling, direct long-context downstream fine-tuning, and a hierarchical local-to-global architecture compare? Which strategy best preserves what the short-context model learned while adding useful dependencies across tens to hundreds of kilobases?
+How should we turn a genomic language model pretrained on short windows—typically sized to model a single functional element—into a model that can use long-range genomic context while retaining nucleotide-level resolution?
+At fixed compute and data, how do second-stage long-context language modeling, direct long-context downstream fine-tuning, and a hierarchical local-to-global architecture compare?
+Which strategy best preserves what the short-context model learned while adding useful dependencies across tens to hundreds of kilobases?
 
 ## Current answer
 
-No MarinDNA experiment directly compares ways to add genuinely long-range context to a short-window model. A 256-versus-512 bp pretraining comparison found no clear VEP difference, so it does not decide behavior at tens or hundreds of kilobases.
+No MarinDNA experiment directly compares ways to add genuinely long-range context to a short-window model.
+A 256-versus-512 bp pretraining comparison found no clear VEP difference, so it does not decide behavior at tens or hundreds of kilobases.
 
-Three strategies remain viable. Continued long-context language modeling could produce a reusable base model but adds the most compute and risks diluting functional signal with abundant background sequence. Direct long-context downstream fine-tuning is the minimum-complexity baseline and aligns context learning with labels, but sparse labels may not teach reusable long-range structure. A local-to-global model reuses the short-context encoder and delegates cross-window interactions to a second model; full-resolution tiling preserves base-level outputs, while pooling is probably required at much longer contexts.
+Three strategies remain viable.
+Continued long-context language modeling could produce a reusable base model but adds the most compute and risks diluting functional signal with abundant background sequence.
+Direct long-context downstream fine-tuning is the minimum-complexity baseline and aligns context learning with labels, but sparse labels may not teach reusable long-range structure.
+A local-to-global model reuses the short-context encoder and delegates cross-window interactions to a second model; full-resolution tiling preserves base-level outputs, while pooling is probably required at much longer contexts.
 
-A short local encoder has improved a 2,114 bp supervised accessibility model in published work, which supports feasibility of local-to-global transfer. That setup freezes the local encoder, never lets it attend across chunk boundaries, and remains far below chromosome-scale context, so it does not establish long-context language understanding.
+A short local encoder has improved a 2,114 bp supervised accessibility model in published work, which supports feasibility of local-to-global transfer.
+That setup freezes the local encoder, never lets it attend across chunk boundaries, and remains far below chromosome-scale context, so it does not establish long-context language understanding.
 
-Confidence is low on a universal winner. Direct downstream extension should be the baseline; local-to-global modeling is the leading scalable option for nucleotide-resolution tasks; continued language modeling is justified only if gains transfer across several long-range tasks. Any comparison must match parameters, training tokens, and compute and must verify dependence on distant sequence.
+Confidence is low on a universal winner.
+Direct downstream extension should be the baseline; local-to-global modeling is the leading scalable option for nucleotide-resolution tasks; continued language modeling is justified only if gains transfer across several long-range tasks.
+Any comparison must match parameters, training tokens, and compute and must verify dependence on distant sequence.
 
 <details>
 <summary>Related work</summary>
 
-- [ARSENAL](https://www.biorxiv.org/content/10.64898/2026.02.05.703637v3) pretrains a 350 bp masked DNA model on ENCODE cCREs, tiles frozen per-base embeddings across a 2,114 bp input, and feeds them to a ChromBPNet-style dilated CNN. Across five cell lines it improves accessibility count prediction and caQTL/dsQTL scoring over a matched one-hot model. The [implementation](https://github.com/amanpatel101/arsenal-chrombpnet/blob/dcfa42b1786713e131bb113f4c6d20acc046185d/chrombpnet/chrombpnet.py#L188-L223) freezes the encoder by default, and its [center-out chunking](https://github.com/amanpatel101/arsenal-chrombpnet/blob/dcfa42b1786713e131bb113f4c6d20acc046185d/chrombpnet/chrombpnet.py#L391-L456) retains one embedding per base. This is direct evidence for full-resolution local-to-global transfer. It does not test long-context pretraining, cross-chunk attention in the gLM, pooling, or contexts beyond 2,114 bp.
-- [AlphaGenome](https://www.nature.com/articles/s41586-025-10014-0) predicts thousands of functional tracks from 1 Mb sequence using a multiscale supervised architecture. It demonstrates that long context and nucleotide-scale outputs can coexist through hierarchical computation. It does not test initialization from a short-context self-supervised gLM, so it is an architecture precedent rather than evidence for transfer.
-- [Can gLM pretraining improve human sequence-to-function modeling?](sequence-to-function.md) asks whether gLM pretraining improves sequence-to-function models. Its controlled scratch-versus-pretrained benchmark is a natural first consumer of any local-to-global design, but accessibility context is much shorter than the full long-range question.
-- [Which genomic regions to train on, and how to find them?](training-regions.md) asks how long-window background sequence should be selected, sampled, or weighted. This matters because uniformly weighted language modeling on long mammalian windows may devote most gradient mass to sequence outside the functional element of interest.
+- [ARSENAL](https://www.biorxiv.org/content/10.64898/2026.02.05.703637v3) pretrains a 350 bp masked DNA model on ENCODE cCREs, tiles frozen per-base embeddings across a 2,114 bp input, and feeds them to a ChromBPNet-style dilated CNN.
+  Across five cell lines it improves accessibility count prediction and caQTL/dsQTL scoring over a matched one-hot model.
+  The [implementation](https://github.com/amanpatel101/arsenal-chrombpnet/blob/dcfa42b1786713e131bb113f4c6d20acc046185d/chrombpnet/chrombpnet.py#L188-L223) freezes the encoder by default, and its [center-out chunking](https://github.com/amanpatel101/arsenal-chrombpnet/blob/dcfa42b1786713e131bb113f4c6d20acc046185d/chrombpnet/chrombpnet.py#L391-L456) retains one embedding per base.
+  This is direct evidence for full-resolution local-to-global transfer.
+  It does not test long-context pretraining, cross-chunk attention in the gLM, pooling, or contexts beyond 2,114 bp.
+- [AlphaGenome](https://www.nature.com/articles/s41586-025-10014-0) predicts thousands of functional tracks from 1 Mb sequence using a multiscale supervised architecture.
+  It demonstrates that long context and nucleotide-scale outputs can coexist through hierarchical computation.
+  It does not test initialization from a short-context self-supervised gLM, so it is an architecture precedent rather than evidence for transfer.
+- [Can gLM pretraining improve human sequence-to-function modeling?](sequence-to-function.md) asks whether gLM pretraining improves sequence-to-function models.
+  Its controlled scratch-versus-pretrained benchmark is a natural first consumer of any local-to-global design, but accessibility context is much shorter than the full long-range question.
+- [Which genomic regions to train on, and how to find them?](training-regions.md) asks how long-window background sequence should be selected, sampled, or weighted.
+  This matters because uniformly weighted language modeling on long mammalian windows may devote most gradient mass to sequence outside the functional element of interest.
 
 </details>
 
 <details>
 <summary>Related experiments</summary>
 
-- [#37](https://github.com/Open-Athena/marin-dna/issues/37) compared 256 bp and 512 bp pretraining contexts and found no clear VEP difference. It supports short windows as a workable local baseline and proposed downstream extension or hierarchy, but the tested lengths are too short to distinguish the three long-context strategies.
+- [#37](https://github.com/Open-Athena/marin-dna/issues/37) compared 256 bp and 512 bp pretraining contexts and found no clear VEP difference.
+  It supports short windows as a workable local baseline and proposed downstream extension or hierarchy, but the tested lengths are too short to distinguish the three long-context strategies.
 
 </details>
 
 ## Possible directions
 
-- **What long-range capability do we want first?** Candidate tests should require distant context by construction—for example enhancer–promoter interactions, gene-level expression, long-range splicing regulation, or another task where masking distant sequence should measurably hurt.
-- **What context lengths define the useful regime?** Compare a small ladder spanning the current local context through the expected biological scale, rather than testing only one large endpoint.
-- **How should a second-stage LM sample and weight sequence?** Compare uniform long windows, functional-element-centered windows, and functional or conservation-aware loss weights. How sensitive are the conclusions to incomplete and lineage-specific annotations?
-- **Does loss weighting damage likelihood interpretation?** If the long-context model is trained with nonuniform per-base weights, which language-modeling and zero-shot variant scores remain comparable to the short-context model?
-- **How do we avoid forgetting local sequence grammar?** Test freezing versus fine-tuning the local model, mixing short and long examples, and progressive context curricula.
-- **Should we preserve per-base embeddings or pool them?** ARSENAL-style concatenation supplies a no-pooling baseline. Compare it with mean/attention pooling, learned summary tokens, and multiple coarse tokens per chunk as context grows.
-- **How should local windows be tiled?** ARSENAL uses center-aligned, mostly non-overlapping 350 bp chunks with special handling for the two sequence ends. Compare overlap, stride, and blending schemes, and measure prediction or representation discontinuities at internal chunk boundaries explicitly.
-- **How does global information return to nucleotide resolution?** Compare broadcasting a global embedding, cross-attention from local positions to coarse tokens, and local decoding with skip connections.
-- **Does end-to-end fine-tuning matter?** ARSENAL’s released adapter freezes the local encoder by default. A frozen local encoder is cheaper and gives a clean test of representation reuse, but joint training may be necessary for local features to expose information useful at the global level.
-- **What is the fair compute-matched comparison?** Match parameter count where possible and report training tokens, FLOPs, peak memory, and wall time. A longer sequence at the same number of examples is not a compute-matched intervention.
-- **Is the model using distant context?** Evaluate with distance-stratified ablations: crop the input, mask or shuffle distal sequence, perturb the candidate interacting element, and measure performance as a function of distance.
-- **How should leakage controls change?** Longer overlapping windows increase the chance that homologous or shifted sequence crosses train/test boundaries; update the similarity and locus-holdout rules before interpreting small gains.
-- **What is the smallest decisive first experiment?** One option is a downstream task with known long-range dependence and five matched arms: short-context baseline, direct full-resolution extension, frozen ARSENAL-style per-base tiling, frozen-local pooled hierarchy, and jointly trained pooled hierarchy. A second-stage LM arm should follow once that comparison establishes that the task and evaluation can detect useful long-range context.
+- **What long-range capability do we want first?**
+  Candidate tests should require distant context by construction—for example enhancer–promoter interactions, gene-level expression, long-range splicing regulation, or another task where masking distant sequence should measurably hurt.
+- **What context lengths define the useful regime?**
+  Compare a small ladder spanning the current local context through the expected biological scale, rather than testing only one large endpoint.
+- **How should a second-stage LM sample and weight sequence?**
+  Compare uniform long windows, functional-element-centered windows, and functional or conservation-aware loss weights.
+  How sensitive are the conclusions to incomplete and lineage-specific annotations?
+- **Does loss weighting damage likelihood interpretation?**
+  If the long-context model is trained with nonuniform per-base weights, which language-modeling and zero-shot variant scores remain comparable to the short-context model?
+- **How do we avoid forgetting local sequence grammar?**
+  Test freezing versus fine-tuning the local model, mixing short and long examples, and progressive context curricula.
+- **Should we preserve per-base embeddings or pool them?**
+  ARSENAL-style concatenation supplies a no-pooling baseline.
+  Compare it with mean/attention pooling, learned summary tokens, and multiple coarse tokens per chunk as context grows.
+- **How should local windows be tiled?**
+  ARSENAL uses center-aligned, mostly non-overlapping 350 bp chunks with special handling for the two sequence ends.
+  Compare overlap, stride, and blending schemes, and measure prediction or representation discontinuities at internal chunk boundaries explicitly.
+- **How does global information return to nucleotide resolution?**
+  Compare broadcasting a global embedding, cross-attention from local positions to coarse tokens, and local decoding with skip connections.
+- **Does end-to-end fine-tuning matter?**
+  ARSENAL’s released adapter freezes the local encoder by default.
+  A frozen local encoder is cheaper and gives a clean test of representation reuse, but joint training may be necessary for local features to expose information useful at the global level.
+- **What is the fair compute-matched comparison?**
+  Match parameter count where possible and report training tokens, FLOPs, peak memory, and wall time.
+  A longer sequence at the same number of examples is not a compute-matched intervention.
+- **Is the model using distant context?**
+  Evaluate with distance-stratified ablations: crop the input, mask or shuffle distal sequence, perturb the candidate interacting element, and measure performance as a function of distance.
+- **How should leakage controls change?**
+  Longer overlapping windows increase the chance that homologous or shifted sequence crosses train/test boundaries; update the similarity and locus-holdout rules before interpreting small gains.
+- **What is the smallest decisive first experiment?**
+  One option is a downstream task with known long-range dependence and five matched arms: short-context baseline, direct full-resolution extension, frozen ARSENAL-style per-base tiling, frozen-local pooled hierarchy, and jointly trained pooled hierarchy.
+  A second-stage LM arm should follow once that comparison establishes that the task and evaluation can detect useful long-range context.

--- a/docs/research/questions/retrieval-augmented-models.md
+++ b/docs/research/questions/retrieval-augmented-models.md
@@ -2,61 +2,108 @@
 
 ## TL;DR
 
-A fixed-context mammalian-ortholog prototype produced promising VEP and representation results, but it lacks matched no-retrieval controls, online retrieval, and indel evaluation. Confidence is moderate that the model can use ortholog context and low that retrieval itself caused the gain or can be deployed efficiently.
+A fixed-context mammalian-ortholog prototype produced promising VEP and representation results, but it lacks matched no-retrieval controls, online retrieval, and indel evaluation.
+Confidence is moderate that the model can use ortholog context and low that retrieval itself caused the gain or can be deployed efficiently.
 
 ## Question
 
-Can an autoregressive retrieval-augmented genomic language model (gLM), trained to model sets of evolutionarily related but unaligned DNA sequences, improve variant effect prediction—especially for indels—and learned representations relative to both single-sequence autoregressive models and alignment-based models such as GPN-Star? Can it do so with a retrieval and inference system that is practical to deploy at genome scale, and how do model size, retrieval-corpus size, and the amount of retrieved context affect the accuracy–cost frontier?
+Can an autoregressive retrieval-augmented genomic language model (gLM), trained to model sets of evolutionarily related but unaligned DNA sequences, improve variant effect prediction—especially for indels—and learned representations relative to both single-sequence autoregressive models and alignment-based models such as GPN-Star?
+Can it do so with a retrieval and inference system that is practical to deploy at genome scale, and how do model size, retrieval-corpus size, and the amount of retrieved context affect the accuracy–cost frontier?
 
 ## Current answer
 
-Autoregressive retrieval-augmented genomic modeling is feasible, but neither its causal accuracy benefit nor its serving practicality is established. The only MarinDNA experiment used a fixed prefix of seven precomputed mammalian ortholog windows. Its 104M model produced promising zero-shot and frozen-probe point estimates and behaved as if it used ortholog context, but it lacked a matched human-only arm, online retrieval, species-order controls, and indel evaluation.
+Autoregressive retrieval-augmented genomic modeling is feasible, but neither its causal accuracy benefit nor its serving practicality is established.
+The only MarinDNA experiment used a fixed prefix of seven precomputed mammalian ortholog windows.
+Its 104M model produced promising zero-shot and frozen-probe point estimates and behaved as if it used ortholog context, but it lacked a matched human-only arm, online retrieval, species-order controls, and indel evaluation.
 
-External results make the hypothesis plausible. Alignment-based genomic models show that ortholog context is highly informative; autoregressive protein models improve substitutions and indels with unaligned homologs; a DNA enhancer model generates conditioned on homolog sets; and learned protein retrievers can serve approximate-neighbor context quickly. These setups differ from genome-wide DNA retrieval in corpus scale, repeats, ambiguous orthology, and query coordinates.
+External results make the hypothesis plausible.
+Alignment-based genomic models show that ortholog context is highly informative; autoregressive protein models improve substitutions and indels with unaligned homologs; a DNA enhancer model generates conditioned on homolog sets; and learned protein retrievers can serve approximate-neighbor context quickly.
+These setups differ from genome-wide DNA retrieval in corpus scale, repeats, ambiguous orthology, and query coordinates.
 
-The likely accuracy benefit is non-monotonic. More parameters, more training families, longer retrieved context, more homologs, and broader retrieval coverage are different scaling axes. Protein results show gains from some of these axes and saturation from others. A DNA model may benefit from a few informative orthologs while degrading when low-quality, repetitive, or redundant hits consume context.
+The likely accuracy benefit is non-monotonic.
+More parameters, more training families, longer retrieved context, more homologs, and broader retrieval coverage are different scaling axes.
+Protein results show gains from some of these axes and saturation from others.
+A DNA model may benefit from a few informative orthologs while degrading when low-quality, repetitive, or redundant hits consume context.
 
-Confidence is moderate that a reader can exploit curated ortholog context and low that retrieval itself caused the current MarinDNA gain or can be served economically genome-wide. The next decision gate is a matched human-only versus fixed-ortholog comparison with identical tokens and compute, followed by shuffled/wrong-species controls and indel scoring. Online retrieval and index-cost work should wait until the causal model benefit survives that gate.
+Confidence is moderate that a reader can exploit curated ortholog context and low that retrieval itself caused the current MarinDNA gain or can be served economically genome-wide.
+The next decision gate is a matched human-only versus fixed-ortholog comparison with identical tokens and compute, followed by shuffled/wrong-species controls and indel scoring.
+Online retrieval and index-cost work should wait until the causal model benefit survives that gate.
 
 <details>
 <summary>Related work</summary>
 
-- [GPN-Star](https://pmc.ncbi.nlm.nih.gov/articles/PMC12458161/) uses whole-genome alignments and an explicit species tree for coding and non-coding VEP and functional-region embeddings. It establishes the value of structured ortholog context and a strong accuracy baseline. Its reference-coordinate alignment input does not support arbitrary queries, general unaligned retrieval, or a standard likelihood-based indel scorer.
-- [PoET](https://papers.nips.cc/paper_files/paper/2023/hash/f4366126eba252699b280e8f93c0ab2f-Abstract-Conference.html) autoregressively models sets of unaligned protein homologs and improves substitution and indel fitness prediction. Its context ablation improves from 4K to 8K tokens and then saturates or worsens at 16K, suggesting that retrieval quantity is not monotonic. Protein families are cleaner and smaller than genome-wide DNA retrieval domains.
-- [Tranception](https://proceedings.mlr.press/v162/notin22a.html) mixes autoregressive likelihoods with statistics from retrieved homologs and improves substitutions, multiple mutants, and indels. It is a lightweight inference-time precedent; it does not learn a general retrieval-aware genomic representation.
-- [EnhancAR](https://www.biorxiv.org/content/10.64898/2026.04.13.718170v1) trains an autoregressive DNA model on 1.7 million sets of unaligned enhancer homologs from a 241-species alignment and preserves predicted activity, specificity, and motif properties in generation. It is the closest DNA precedent. Its homolog sets still come from an alignment, and it does not test general VEP, de novo retrieval, or serving cost.
-- [PoET-2](https://proceedings.neurips.cc/paper_files/paper/2025/hash/4d19160864e6a644496d61b21c7e015a-Abstract-Conference.html) combines retrieval-conditioned causal and masked objectives and improves protein VEP, indels, and supervised sequence-function embeddings. It suggests that retrieval can help representations as well as likelihoods. DNA transfer remains untested.
-- [RAG-ESM](https://openreview.net/forum?id=i4vevaqugi) adds homolog cross-attention to pretrained protein encoders, while [Profluent-E1](https://www.biorxiv.org/content/10.1101/2025.11.12.688125v1) trains native retrieval-aware encoders over unaligned homologs. Both improve selected protein prediction tasks and show alignment-like or retrieval-aware attention. Neither is autoregressive or genome-scale.
-- [Protriever](https://proceedings.mlr.press/v267/weitzman25a.html) jointly trains a protein retriever and autoregressive reader and reports approximately 4.6 ms retrieval with a 12.6 GB compressed UniRef50 index. This is evidence that learned dense retrieval can be practical in proteins. Genomes are larger, repetitive non-coding sequence is common, and local orthology can be ambiguous, so the speed and index size do not transfer directly.
-- The practical observables are retrieval recall for true orthologs, sensitivity to paralogs and repeats, accuracy versus homolog count and context length, per-query latency, index memory, preprocessing cost, and degradation under stale or incomplete corpora. None has been measured for MarinDNA.
+- [GPN-Star](https://pmc.ncbi.nlm.nih.gov/articles/PMC12458161/) uses whole-genome alignments and an explicit species tree for coding and non-coding VEP and functional-region embeddings.
+  It establishes the value of structured ortholog context and a strong accuracy baseline.
+  Its reference-coordinate alignment input does not support arbitrary queries, general unaligned retrieval, or a standard likelihood-based indel scorer.
+- [PoET](https://papers.nips.cc/paper_files/paper/2023/hash/f4366126eba252699b280e8f93c0ab2f-Abstract-Conference.html) autoregressively models sets of unaligned protein homologs and improves substitution and indel fitness prediction.
+  Its context ablation improves from 4K to 8K tokens and then saturates or worsens at 16K, suggesting that retrieval quantity is not monotonic.
+  Protein families are cleaner and smaller than genome-wide DNA retrieval domains.
+- [Tranception](https://proceedings.mlr.press/v162/notin22a.html) mixes autoregressive likelihoods with statistics from retrieved homologs and improves substitutions, multiple mutants, and indels.
+  It is a lightweight inference-time precedent; it does not learn a general retrieval-aware genomic representation.
+- [EnhancAR](https://www.biorxiv.org/content/10.64898/2026.04.13.718170v1) trains an autoregressive DNA model on 1.7 million sets of unaligned enhancer homologs from a 241-species alignment and preserves predicted activity, specificity, and motif properties in generation.
+  It is the closest DNA precedent.
+  Its homolog sets still come from an alignment, and it does not test general VEP, de novo retrieval, or serving cost.
+- [PoET-2](https://proceedings.neurips.cc/paper_files/paper/2025/hash/4d19160864e6a644496d61b21c7e015a-Abstract-Conference.html) combines retrieval-conditioned causal and masked objectives and improves protein VEP, indels, and supervised sequence-function embeddings.
+  It suggests that retrieval can help representations as well as likelihoods.
+  DNA transfer remains untested.
+- [RAG-ESM](https://openreview.net/forum?id=i4vevaqugi) adds homolog cross-attention to pretrained protein encoders, while [Profluent-E1](https://www.biorxiv.org/content/10.1101/2025.11.12.688125v1) trains native retrieval-aware encoders over unaligned homologs.
+  Both improve selected protein prediction tasks and show alignment-like or retrieval-aware attention.
+  Neither is autoregressive or genome-scale.
+- [Protriever](https://proceedings.mlr.press/v267/weitzman25a.html) jointly trains a protein retriever and autoregressive reader and reports approximately 4.6 ms retrieval with a 12.6 GB compressed UniRef50 index.
+  This is evidence that learned dense retrieval can be practical in proteins.
+  Genomes are larger, repetitive non-coding sequence is common, and local orthology can be ambiguous, so the speed and index size do not transfer directly.
+- The practical observables are retrieval recall for true orthologs, sensitivity to paralogs and repeats, accuracy versus homolog count and context length, per-query latency, index memory, preprocessing cost, and degradation under stale or incomplete corpora.
+  None has been measured for MarinDNA.
 
 </details>
 
 <details>
 <summary>Related experiments</summary>
 
-- [#402](https://github.com/Open-Athena/marin-dna/issues/402) trained 46M and 104M causal models on seven fixed HAL-projected mammalian windows followed by the human window. The 104M arm produced promising official train-cohort zero-shot and frozen-probe point estimates and showed ortholog-context use, but no matched human-only arm, online retrieval, order ablation, convergence study, or indel evaluation was included.
+- [#402](https://github.com/Open-Athena/marin-dna/issues/402) trained 46M and 104M causal models on seven fixed HAL-projected mammalian windows followed by the human window.
+  The 104M arm produced promising official train-cohort zero-shot and frozen-probe point estimates and showed ortholog-context use, but no matched human-only arm, online retrieval, order ablation, convergence study, or indel evaluation was included.
 
 </details>
 
 ## Possible directions
 
-- **Target and architecture.** Should the model directly generate a sequence of unaligned homologous sequences, as in PoET and EnhancAR, encode retrieved homologs separately and condition an autoregressive reader, or retrofit a strong pretrained single-sequence model with cross-attention, as in RAG-ESM? How should it represent species identity, phylogenetic distance, arbitrary homolog order, variable sequence length, and reverse complements?
+- **Target and architecture.**
+  Should the model directly generate a sequence of unaligned homologous sequences, as in PoET and EnhancAR, encode retrieved homologs separately and condition an autoregressive reader, or retrofit a strong pretrained single-sequence model with cross-attention, as in RAG-ESM?
+  How should it represent species identity, phylogenetic distance, arbitrary homolog order, variable sequence length, and reverse complements?
 
-- **What counts as useful retrieval?** Does the reader need strict orthologs, or can paralogs and more remote functional analogs help? How should we distinguish true evolutionary signal from repeats, low-complexity matches, assembly artifacts, and reference leakage?
+- **What counts as useful retrieval?**
+  Does the reader need strict orthologs, or can paralogs and more remote functional analogs help?
+  How should we distinguish true evolutionary signal from repeats, low-complexity matches, assembly artifacts, and reference leakage?
 
-- **Retrieval backend.** What is the best accuracy–cost tradeoff among direct lookup in a precomputed WGA, local sequence alignment against a genome corpus, dense embedding search, and a hybrid dense-retrieval-plus-alignment/reranking system? Can a retriever be trained jointly with the gLM, as in Protriever, and does task-aware retrieval outperform generic homology?
+- **Retrieval backend.**
+  What is the best accuracy–cost tradeoff among direct lookup in a precomputed WGA, local sequence alignment against a genome corpus, dense embedding search, and a hybrid dense-retrieval-plus-alignment/reranking system?
+  Can a retriever be trained jointly with the gLM, as in Protriever, and does task-aware retrieval outperform generic homology?
 
-- **Embedding retrieval.** What training objective and segment granularity would make a DNA embedding index recover local orthology across substitutions, indels, rearrangements, and large evolutionary distances? How much recall against trusted WGA/orthology sets is required before dense retrieval improves the downstream reader?
+- **Embedding retrieval.**
+  What training objective and segment granularity would make a DNA embedding index recover local orthology across substitutions, indels, rearrangements, and large evolutionary distances?
+  How much recall against trusted WGA/orthology sets is required before dense retrieval improves the downstream reader?
 
-- **VEP.** Does retrieval improve zero-shot performance on the existing Mendelian, complex-trait, saturation-genome-editing, and other SNV evaluations? More importantly, can full-sequence autoregressive likelihoods produce calibrated and length-robust scores for insertions and deletions that alignment-column models cannot naturally score?
+- **VEP.**
+  Does retrieval improve zero-shot performance on the existing Mendelian, complex-trait, saturation-genome-editing, and other SNV evaluations?
+  More importantly, can full-sequence autoregressive likelihoods produce calibrated and length-robust scores for insertions and deletions that alignment-column models cannot naturally score?
 
-- **Representations.** Do retrieval-conditioned embeddings improve functional-element separation, frozen-embedding linear probes, and other sequence-function tasks, as the protein results from E1, RAG-ESM, and PoET-2 suggest, or does retrieval mainly improve likelihood-based VEP in DNA? Which representation should be exported when the query is conditioned on a variable set of homologs, and is a causal objective sufficient or is a masked/dual objective needed?
+- **Representations.**
+  Do retrieval-conditioned embeddings improve functional-element separation, frozen-embedding linear probes, and other sequence-function tasks, as the protein results from E1, RAG-ESM, and PoET-2 suggest, or does retrieval mainly improve likelihood-based VEP in DNA?
+  Which representation should be exported when the query is conditioned on a variable set of homologs, and is a causal objective sufficient or is a masked/dual objective needed?
 
-- **Scaling.** Holding the retriever and data fixed, how does performance scale with model size? Holding the model fixed, how does it scale with training-family diversity, retrieval-corpus size, number and diversity of retrieved sequences, and total retrieved tokens? Where do these axes saturate, and which buys the most performance per unit of training and serving compute?
+- **Scaling.**
+  Holding the retriever and data fixed, how does performance scale with model size?
+  Holding the model fixed, how does it scale with training-family diversity, retrieval-corpus size, number and diversity of retrieved sequences, and total retrieved tokens?
+  Where do these axes saturate, and which buys the most performance per unit of training and serving compute?
 
-- **Deployment unit.** Is retrieval performed online per query window, amortized and cached per locus, or entirely offline for a fixed reference genome? The practical answer may differ for genome-wide precomputed VEP scores, interactive annotation of variants on a known reference, and scoring or generating arbitrary sequences.
+- **Deployment unit.**
+  Is retrieval performed online per query window, amortized and cached per locus, or entirely offline for a fixed reference genome?
+  The practical answer may differ for genome-wide precomputed VEP scores, interactive annotation of variants on a known reference, and scoring or generating arbitrary sequences.
 
-- **Practicality criteria.** What index-build time, index size, memory footprint, p50/p95 retrieval latency, end-to-end throughput, cache hit rate, and dollar cost are acceptable? Retrieval and reader inference should be profiled separately, with WGA lookup, local alignment, and dense retrieval compared at matched downstream accuracy.
+- **Practicality criteria.**
+  What index-build time, index size, memory footprint, p50/p95 retrieval latency, end-to-end throughput, cache hit rate, and dollar cost are acceptable?
+  Retrieval and reader inference should be profiled separately, with WGA lookup, local alignment, and dense retrieval compared at matched downstream accuracy.
 
-- **Evaluation hygiene.** How should genomes, loci, homolog families, and retrieval corpora be split to prevent near-duplicate or allele leakage? All comparisons need a no-retrieval ablation, matched reader capacity, fixed corpus versions, retrieval traces, and performance stratified by alignment depth, genomic region, repeat content, evolutionary distance, and indel length.
+- **Evaluation hygiene.**
+  How should genomes, loci, homolog families, and retrieval corpora be split to prevent near-duplicate or allele leakage?
+  All comparisons need a no-retrieval ablation, matched reader capacity, fixed corpus versions, retrieval traces, and performance stratified by alignment depth, genomic region, repeat content, evolutionary distance, and indel length.

--- a/docs/research/questions/sequence-to-function.md
+++ b/docs/research/questions/sequence-to-function.md
@@ -2,41 +2,66 @@
 
 ## TL;DR
 
-Self-supervised gLM pretraining has not shown a consistent advantage for human sequence-to-function modeling under matched architectures and evaluation. Positive results in other organisms and model families suggest the effect is regime-dependent; confidence is low, and the decisive gap is a scratch-versus-pretrained accessibility experiment with matched capacity and variant evaluation.
+Self-supervised gLM pretraining has not shown a consistent advantage for human sequence-to-function modeling under matched architectures and evaluation.
+Positive results in other organisms and model families suggest the effect is regime-dependent; confidence is low, and the decisive gap is a scratch-versus-pretrained accessibility experiment with matched capacity and variant evaluation.
 
 ## Question
 
-Can self-supervised genomic language model (gLM) pretraining improve human sequence-to-function models over the same downstream architecture trained from random initialization? In which regimes—chromatin accessibility first, then gene expression—and through which transfer strategy (frozen features, partial fine-tuning, or full fine-tuning) does pretraining improve functional-track prediction and downstream variant-effect prediction? All current positive precedents use bidirectional models; is bidirectionality important, and can it be obtained from existing causal MarinDNA checkpoints without retraining from scratch? How do directionality and movement from one human reference genome to homologous functional sequence across wider evolutionary timescales affect whether gLM initialization improves full-data accuracy, sample efficiency, optimization, or generalization to unseen cell types, loci, and variant distributions?
+Can self-supervised genomic language model (gLM) pretraining improve human sequence-to-function models over the same downstream architecture trained from random initialization?
+In which regimes—chromatin accessibility first, then gene expression—and through which transfer strategy (frozen features, partial fine-tuning, or full fine-tuning) does pretraining improve functional-track prediction and downstream variant-effect prediction?
+All current positive precedents use bidirectional models; is bidirectionality important, and can it be obtained from existing causal MarinDNA checkpoints without retraining from scratch?
+How do directionality and movement from one human reference genome to homologous functional sequence across wider evolutionary timescales affect whether gLM initialization improves full-data accuracy, sample efficiency, optimization, or generalization to unseen cell types, loci, and variant distributions?
 
 ## Current answer
 
-Self-supervised gLM pretraining has not shown a consistent, controlled advantage for human sequence-to-function modeling. Strong scratch-trained supervised models remain the main baseline, and the decisive MarinDNA frozen-versus-fine-tuned experiment has not been completed.
+Self-supervised gLM pretraining has not shown a consistent, controlled advantage for human sequence-to-function modeling.
+Strong scratch-trained supervised models remain the main baseline, and the decisive MarinDNA frozen-versus-fine-tuned experiment has not been completed.
 
-Published human evidence is mixed. A short, regulatory-targeted masked model gives modest gains when its frozen per-base embeddings replace one-hot input to an accessibility model, while broader human DNALM benchmarks do not show a general advantage over strong ab-initio models. Positive transfer is clearer in yeast and plants, where masked or bidirectional pretraining improves expression or functional-track prediction relative to random initialization.
+Published human evidence is mixed.
+A short, regulatory-targeted masked model gives modest gains when its frozen per-base embeddings replace one-hot input to an accessibility model, while broader human DNALM benchmarks do not show a general advantage over strong ab-initio models.
+Positive transfer is clearer in yeast and plants, where masked or bidirectional pretraining improves expression or functional-track prediction relative to random initialization.
 
-Every positive precedent uses bidirectional representations. MarinDNA’s causal checkpoints provide separate forward and reverse-complement views, but the two states do not interact inside the backbone. Directionality, objective, training corpus, and downstream architecture are therefore confounded.
+Every positive precedent uses bidirectional representations.
+MarinDNA’s causal checkpoints provide separate forward and reverse-complement views, but the two states do not interact inside the backbone.
+Directionality, objective, training corpus, and downstream architecture are therefore confounded.
 
-Confidence is low that generic causal pretraining will help without adaptation and moderate that a task-matched bidirectional or two-view representation can improve some accessibility settings. The first decision gate is a matched accessibility experiment with identical downstream capacity, chromosome splits, labels, and optimization: random encoder, frozen pretrained encoder, end-to-end fine-tuning, one-hot baseline, and a bidirectional reference. It should report full-data accuracy, label efficiency, unseen-cell/locus transfer, and caQTL/dsQTL effects separately. Gene expression is a later long-context question.
+Confidence is low that generic causal pretraining will help without adaptation and moderate that a task-matched bidirectional or two-view representation can improve some accessibility settings.
+The first decision gate is a matched accessibility experiment with identical downstream capacity, chromosome splits, labels, and optimization: random encoder, frozen pretrained encoder, end-to-end fine-tuning, one-hot baseline, and a bidirectional reference.
+It should report full-data accuracy, label efficiency, unseen-cell/locus transfer, and caQTL/dsQTL effects separately.
+Gene expression is a later long-context question.
 
 <details>
 <summary>Related work</summary>
 
-- [DART-Eval](https://proceedings.neurips.cc/paper_files/paper/2024/hash/71998bfc3217ffe1cca1ee084dfadadd-Abstract-Datasets_and_Benchmarks_Track.html) compares human DNALMs on regulatory tasks and finds inconsistent gains over strong supervised baselines. It establishes the need for matched ab-initio controls. It does not test the exact MarinDNA architecture or every end-to-end fine-tuning regime.
-- [AlphaGenome](https://www.nature.com/articles/s41586-025-10014-0) learns thousands of human and mouse functional tracks from 1 Mb sequence and performs strongly across track and variant tasks without reported self-supervised gLM initialization. It defines a high supervised baseline and a long-context architecture precedent. It does not isolate whether self-supervised initialization would improve the same model.
-- [ARSENAL](https://www.biorxiv.org/content/10.64898/2026.02.05.703637v3) pretrains a 350 bp masked model on human ENCODE cCREs and tiles frozen per-base embeddings into a ChromBPNet-style model. It reports accessibility gains across five cell lines and modest caQTL/dsQTL improvements. The setup is task-matched, human-only, short-context, and bidirectional, so corpus breadth and directionality remain confounded.
-- [Shorkie](https://pubmed.ncbi.nlm.nih.gov/41282136/) initializes a yeast sequence-to-function model from masked pretraining on 165 fungi and improves expression and regulatory-variant prediction over random initialization. This is direct evidence for evolutionary pretraining transfer outside humans; the gap is transfer to stronger human supervised baselines.
-- The [original GPN preprint](https://www.biorxiv.org/content/10.1101/2022.08.22.504706v1) fine-tunes a single-reference Arabidopsis model on 106 functional tracks and outperforms de novo DeepSEA and human-pretrained DNABERT controls. It shows that multispecies data are not required for transfer, while leaving the benefit of additional evolutionary breadth open.
-- A [PlantCaduceus sequence-to-expression study](https://www.biorxiv.org/content/10.64898/2026.02.27.708524v2) and [PlantCAD2](https://pmc.ncbi.nlm.nih.gov/articles/PMC12425018/) report transfer across plant expression, accessibility, and abundance tasks. These broaden the positive precedent but do not isolate the architecture, objective, or data property that enables transfer.
-- [#236](https://github.com/Open-Athena/marin-dna/issues/236) defines the ChromBPNet-on-gLM-embeddings evaluation harness. It is infrastructure rather than a completed experiment.
-- [How should a short-context gLM acquire long-range context?](long-context.md) covers connecting a short local encoder to longer sequence-to-function models; [Can causal gLMs become bidirectional representation and arbitrary-order generation models?](bidirectional-models.md) covers causal-to-bidirectional conversion; [Which genomic regions to train on, and how to find them?](training-regions.md) covers the pretraining footprint. These are coupled design axes that must be controlled rather than attributed to pretraining as one bundle.
+- [DART-Eval](https://proceedings.neurips.cc/paper_files/paper/2024/hash/71998bfc3217ffe1cca1ee084dfadadd-Abstract-Datasets_and_Benchmarks_Track.html) compares human DNALMs on regulatory tasks and finds inconsistent gains over strong supervised baselines.
+  It establishes the need for matched ab-initio controls.
+  It does not test the exact MarinDNA architecture or every end-to-end fine-tuning regime.
+- [AlphaGenome](https://www.nature.com/articles/s41586-025-10014-0) learns thousands of human and mouse functional tracks from 1 Mb sequence and performs strongly across track and variant tasks without reported self-supervised gLM initialization.
+  It defines a high supervised baseline and a long-context architecture precedent.
+  It does not isolate whether self-supervised initialization would improve the same model.
+- [ARSENAL](https://www.biorxiv.org/content/10.64898/2026.02.05.703637v3) pretrains a 350 bp masked model on human ENCODE cCREs and tiles frozen per-base embeddings into a ChromBPNet-style model.
+  It reports accessibility gains across five cell lines and modest caQTL/dsQTL improvements.
+  The setup is task-matched, human-only, short-context, and bidirectional, so corpus breadth and directionality remain confounded.
+- [Shorkie](https://pubmed.ncbi.nlm.nih.gov/41282136/) initializes a yeast sequence-to-function model from masked pretraining on 165 fungi and improves expression and regulatory-variant prediction over random initialization.
+  This is direct evidence for evolutionary pretraining transfer outside humans; the gap is transfer to stronger human supervised baselines.
+- The [original GPN preprint](https://www.biorxiv.org/content/10.1101/2022.08.22.504706v1) fine-tunes a single-reference Arabidopsis model on 106 functional tracks and outperforms de novo DeepSEA and human-pretrained DNABERT controls.
+  It shows that multispecies data are not required for transfer, while leaving the benefit of additional evolutionary breadth open.
+- A [PlantCaduceus sequence-to-expression study](https://www.biorxiv.org/content/10.64898/2026.02.27.708524v2) and [PlantCAD2](https://pmc.ncbi.nlm.nih.gov/articles/PMC12425018/) report transfer across plant expression, accessibility, and abundance tasks.
+  These broaden the positive precedent but do not isolate the architecture, objective, or data property that enables transfer.
+- [#236](https://github.com/Open-Athena/marin-dna/issues/236) defines the ChromBPNet-on-gLM-embeddings evaluation harness.
+  It is infrastructure rather than a completed experiment.
+- [How should a short-context gLM acquire long-range context?](long-context.md) covers connecting a short local encoder to longer sequence-to-function models; [Can causal gLMs become bidirectional representation and arbitrary-order generation models?](bidirectional-models.md) covers causal-to-bidirectional conversion; [Which genomic regions to train on, and how to find them?](training-regions.md) covers the pretraining footprint.
+  These are coupled design axes that must be controlled rather than attributed to pretraining as one bundle.
 
 </details>
 
 <details>
 <summary>Related experiments</summary>
 
-- [#243](https://github.com/Open-Athena/marin-dna/issues/243) scopes the direct ChromBPNet-on-MarinDNA comparison with frozen and fine-tuned encoders. Its body does not record a completed controlled result, so the main human transfer question remains open.
-- [#314](https://github.com/Open-Athena/marin-dna/issues/314) evaluated frozen gLM embeddings for VEP across representation designs. Accessibility-QTL signal was weak, with best dsQTL AUPRC around 0.063; this argues against a shallow probe on generic frozen causal embeddings but does not test spatial heads, end-to-end fine-tuning, or bidirectional conversion.
+- [#243](https://github.com/Open-Athena/marin-dna/issues/243) scopes the direct ChromBPNet-on-MarinDNA comparison with frozen and fine-tuned encoders.
+  Its body does not record a completed controlled result, so the main human transfer question remains open.
+- [#314](https://github.com/Open-Athena/marin-dna/issues/314) evaluated frozen gLM embeddings for VEP across representation designs.
+  Accessibility-QTL signal was weak, with best dsQTL AUPRC around 0.063; this argues against a shallow probe on generic frozen causal embeddings but does not test spatial heads, end-to-end fine-tuning, or bidirectional conversion.
 
 </details>
 
@@ -53,44 +78,60 @@ On identical chromosome splits and GM12878 functional data, compare at minimum:
 5. ARSENAL under the same evaluation protocol.
 
 - Is one-hot ChromBPNet the only relevant scratch baseline, or do we also need the exact gLM-plus-head architecture from random initialization to separate initialization from added capacity?
-- Does pretraining improve held-out accessibility profiles, caQTL/dsQTL variant effects, or both? These are related but distinct outcomes and should not be collapsed into one verdict.
+- Does pretraining improve held-out accessibility profiles, caQTL/dsQTL variant effects, or both?
+  These are related but distinct outcomes and should not be collapsed into one verdict.
 - Are gains consistent across cell types and assays, or restricted to GM12878 DNase data that closely matches the pretraining and benchmark distributions?
 
 ### When and why does transfer help?
 
 - How does the pretrained-versus-random-init gap change with 1%, 10%, and 100% of the functional training data?
 - Does pretraining primarily improve early optimization and convergence speed, or does it improve the final attainable solution after both arms are trained to convergence?
-- Which layers should be frozen, gradually unfrozen, or fully fine-tuned? How much task-specific adaptation is needed before the original gLM representation is overwritten?
-- Does the benefit come from self-supervised learning itself, from enrichment of the pretraining corpus for regulatory sequence, from multispecies evolutionary signal, or from the motif-scale inductive bias? Matched ablations should separate these factors rather than treating “pretraining” as one intervention.
+- Which layers should be frozen, gradually unfrozen, or fully fine-tuned?
+  How much task-specific adaptation is needed before the original gLM representation is overwritten?
+- Does the benefit come from self-supervised learning itself, from enrichment of the pretraining corpus for regulatory sequence, from multispecies evolutionary signal, or from the motif-scale inductive bias?
+  Matched ablations should separate these factors rather than treating “pretraining” as one intervention.
 - Are per-nucleotide embeddings necessary, or can a cheaper pooled or hierarchical interface preserve the benefit?
 
 ### Is bidirectionality important, and can we obtain it?
 
-- Within the ChromBPNet experiment, compare causal-only embeddings, FWD+RC concatenation, and a genuinely bidirectional conversion of the same MarinDNA checkpoint. Keep the downstream head, functional labels, adaptation data, and compute matched.
+- Within the ChromBPNet experiment, compare causal-only embeddings, FWD+RC concatenation, and a genuinely bidirectional conversion of the same MarinDNA checkpoint.
+  Keep the downstream head, functional labels, adaptation data, and compute matched.
 - Is FWD+RC concatenation sufficient because the ChromBPNet head can learn cross-flank interactions, or does integration within every gLM layer provide additional signal?
 - Can a causal checkpoint be converted by removing its attention mask and continuing with masked-token training, as proposed in [Can causal gLMs become bidirectional representation and arbitrary-order generation models?](bidirectional-models.md), or is bidirectional training from random initialization ultimately better?
-- How much masked adaptation is required before the converted model behaves bidirectionally? Compare no adaptation, parameter-efficient adaptation, and full continued pretraining.
-- Separate bidirectional information flow from the masked objective and from extra optimization. Include a causal continued-pretraining arm and, if possible, a matched bidirectional architecture trained under alternative objectives.
+- How much masked adaptation is required before the converted model behaves bidirectionally?
+  Compare no adaptation, parameter-efficient adaptation, and full continued pretraining.
+- Separate bidirectional information flow from the masked objective and from extra optimization.
+  Include a causal continued-pretraining arm and, if possible, a matched bidirectional architecture trained under alternative objectives.
 - Does bidirectionality help accessibility-track prediction, caQTL/dsQTL effects, gene-expression prediction, and representation probes equally, or only tasks where a position's interpretation strongly depends on both flanks?
-- What is lost during conversion? Measure causal likelihood and left-to-right generation alongside downstream transfer; decide whether one dual-mode checkpoint or separate causal and bidirectional forks is preferable.
-- Test directionality and evolutionary breadth factorially. A human-only bidirectional model versus a multispecies causal model cannot reveal which ingredient caused a gain.
+- What is lost during conversion?
+  Measure causal likelihood and left-to-right generation alongside downstream transfer; decide whether one dual-mode checkpoint or separate causal and bidirectional forks is preferable.
+- Test directionality and evolutionary breadth factorially.
+  A human-only bidirectional model versus a multispecies causal model cannot reveal which ingredient caused a gain.
 
 ### How much evolutionary breadth is useful?
 
-- Compare ARSENAL-style human-reference-only pretraining with human population variation and progressively broader primate, mammal, vertebrate, and animal corpora. Which evolutionary timescale gives the strongest transfer to human accessibility and expression?
-- Hold the number of training tokens, functional-region composition, model size, and compute fixed. Otherwise, a multispecies advantage could merely reflect more data or a denser functional training distribution.
-- Should the comparison use orthologous projections of the same human regulatory elements, each species' native annotations, whole-genome sequence, or matched mixtures? These expose different biological information and should not be conflated.
-- Do closer species provide the best balance between alignable regulatory grammar and informative variation, while distant species dilute lineage-specific human regulation? Is the optimal timescale different for promoters, enhancers, splice regions, and coding sequence?
+- Compare ARSENAL-style human-reference-only pretraining with human population variation and progressively broader primate, mammal, vertebrate, and animal corpora.
+  Which evolutionary timescale gives the strongest transfer to human accessibility and expression?
+- Hold the number of training tokens, functional-region composition, model size, and compute fixed.
+  Otherwise, a multispecies advantage could merely reflect more data or a denser functional training distribution.
+- Should the comparison use orthologous projections of the same human regulatory elements, each species' native annotations, whole-genome sequence, or matched mixtures?
+  These expose different biological information and should not be conflated.
+- Do closer species provide the best balance between alignable regulatory grammar and informative variation, while distant species dilute lineage-specific human regulation?
+  Is the optimal timescale different for promoters, enhancers, splice regions, and coding sequence?
 - Does explicit alignment or conservation information add value beyond training a single-sequence gLM on the same multispecies corpus?
-- Does evolutionary breadth improve full-data performance, label efficiency, cross-cell-type transfer, or variant-effect prediction most strongly? A benefit confined to one regime is still useful but should be stated narrowly.
+- Does evolutionary breadth improve full-data performance, label efficiency, cross-cell-type transfer, or variant-effect prediction most strongly?
+  A benefit confined to one regime is still useful but should be stated narrowly.
 
 ### What constitutes fair evidence?
 
-- Hold downstream architecture, labels, chromosome splits, optimizer search, stopping rule, and augmentation fixed. Train all arms to comparable convergence rather than giving the pretrained arm a privileged recipe.
-- Report both downstream-only compute and total compute including gLM pretraining. The former measures amortized reuse; the latter measures whether pretraining is worthwhile for a single task.
+- Hold downstream architecture, labels, chromosome splits, optimizer search, stopping rule, and augmentation fixed.
+  Train all arms to comparable convergence rather than giving the pretrained arm a privileged recipe.
+- Report both downstream-only compute and total compute including gLM pretraining.
+  The former measures amortized reuse; the latter measures whether pretraining is worthwhile for a single task.
 - Match parameter count where possible and report trainable versus frozen parameters, examples seen, FLOPs, peak memory, and wall time.
 - Test for sequence-similarity and locus leakage, especially when regulatory elements used for self-supervised pretraining overlap the genomic universe used for downstream supervision.
-- Predefine whether success means higher full-data accuracy, improved label efficiency, better out-of-distribution transfer, lower compute, or some combination. A small gain on one metric should not silently become a general claim about transfer learning.
+- Predefine whether success means higher full-data accuracy, improved label efficiency, better out-of-distribution transfer, lower compute, or some combination.
+  A small gain on one metric should not silently become a general claim about transfer learning.
 
 ### How should we progress from accessibility to gene expression?
 
@@ -98,4 +139,5 @@ On identical chromosome splits and GM12878 functional data, compare at minimum:
 - Should the gLM replace the local convolutional encoder in an AlphaGenome- or Borzoi-style model, feed a hierarchical long-context model, or first undergo long-context language-model adaptation?
 - Does accessibility pretraining provide an intermediate supervised stage between self-supervised gLM training and expression prediction, and if so, how do we distinguish the value of gLM initialization from ordinary supervised multitask transfer?
 - Does one gLM initialization improve accessibility, histone marks, TF binding, and expression together, or are task-specific pretrained models more effective?
-- For expression, should the primary readout be track correlation, gene-level expression, eQTL direction/causality, or perturbation response? Improvements in average coverage prediction may not translate to better variant effects.
+- For expression, should the primary readout be track correlation, gene-level expression, eQTL direction/causality, or perturbation response?
+  Improvements in average coverage prediction may not translate to better variant effects.

--- a/docs/research/questions/species-conditioning.md
+++ b/docs/research/questions/species-conditioning.md
@@ -2,26 +2,43 @@
 
 ## TL;DR
 
-No matched MarinDNA ablation has tested taxon conditioning. Carbon directly ablates species and gene-type tags: overall sequence recovery is unchanged, while a correct species tag helps low-resource eukaryote groups; it does not report the conditioning effect on VEP. Other published gains remain small or task-specific. Confidence is low, and the cheapest next test is a frozen-Carbon tagged, untagged, and wrong-tag VEP comparison before matched retraining.
+No matched MarinDNA ablation has tested taxon conditioning.
+Carbon directly ablates species and gene-type tags: overall sequence recovery is unchanged, while a correct species tag helps low-resource eukaryote groups; it does not report the conditioning effect on VEP.
+Other published gains remain small or task-specific.
+Confidence is low, and the cheapest next test is a frozen-Carbon tagged, untagged, and wrong-tag VEP comparison before matched retraining.
 
 ## Question
 
-Does explicitly conditioning a multi-species genomic language model on the source species or clade improve what it learns, relative to an otherwise identical sequence-only model that must infer taxonomic context from the DNA window? The taxon is known for our reference-genome training and evaluation data; the question is whether exposing it improves conditional language modeling, zero-shot variant-effect prediction, or learned representations—not merely whether the model can classify species. If conditioning helps, what taxonomic granularity and representation share information across related organisms while still generalizing to unseen species? Can taxon-tag dropout preserve a useful unconditional mode?
+Does explicitly conditioning a multi-species genomic language model on the source species or clade improve what it learns, relative to an otherwise identical sequence-only model that must infer taxonomic context from the DNA window?
+The taxon is known for our reference-genome training and evaluation data; the question is whether exposing it improves conditional language modeling, zero-shot variant-effect prediction, or learned representations—not merely whether the model can classify species.
+If conditioning helps, what taxonomic granularity and representation share information across related organisms while still generalizing to unseen species?
+Can taxon-tag dropout preserve a useful unconditional mode?
 
 ## Current answer
 
-No MarinDNA experiment has compared identical examples with and without an explicit taxon input. The current model-facing path retains sequence but does not expose species identity, so every multispecies model must infer organismal context from the DNA window.
+No MarinDNA experiment has compared identical examples with and without an explicit taxon input.
+The current model-facing path retains sequence but does not expose species identity, so every multispecies model must infer organismal context from the DNA window.
 
-[Carbon](https://www.biorxiv.org/content/10.64898/2026.05.22.727119v1) supplies the most direct published evidence so far. Its released 3B and 8B autoregressive models see species- and gene-type-tagged prompts on 50% of pretraining examples. The reported tag ablation leaves overall sequence recovery essentially unchanged, while a correct species tag improves recovery for fungi, protozoa, and invertebrates and leaves high-resource groups unchanged. Carbon evaluates ClinVar, BRCA2, and TraitGym VEP separately, but does not report how those results change with conditioning. The released checkpoints support both conditional and unconditional prompts, enabling a same-checkpoint VEP intervention now; this measures inference-time use of metadata, not the causal effect of metadata-conditioned pretraining.
+[Carbon](https://www.biorxiv.org/content/10.64898/2026.05.22.727119v1) supplies the most direct published evidence so far.
+Its released 3B and 8B autoregressive models see species- and gene-type-tagged prompts on 50% of pretraining examples.
+The reported tag ablation leaves overall sequence recovery essentially unchanged, while a correct species tag improves recovery for fungi, protozoa, and invertebrates and leaves high-resource groups unchanged.
+Carbon evaluates ClinVar, BRCA2, and TraitGym VEP separately, but does not report how those results change with conditioning.
+The released checkpoints support both conditional and unconditional prompts, enabling a same-checkpoint VEP intervention now; this measures inference-time use of metadata, not the causal effect of metadata-conditioned pretraining.
 
-The evidence supports a conditional hypothesis with low confidence. Taxon labels are most likely to help when the sequence window is too short to identify the relevant organismal regime and when the target feature varies across clades. The benefit may shrink with longer context or larger models, and a label may expose compositional shortcuts instead of functional biology.
+The evidence supports a conditional hypothesis with low confidence.
+Taxon labels are most likely to help when the sequence window is too short to identify the relevant organismal regime and when the target feature varies across clades.
+The benefit may shrink with longer context or larger models, and a label may expose compositional shortcuts instead of functional biology.
 
-A leaf-species token is the simplest ablation, but a hierarchy could share information across related organisms and remain usable for unseen species. Any positive result must survive shuffled-label controls, wrong-tag sensitivity, fixed data and compute, and downstream evaluation. Validation-loss improvement alone would not show that conditioning learned useful biology.
+A leaf-species token is the simplest ablation, but a hierarchy could share information across related organisms and remain usable for unseen species.
+Any positive result must survive shuffled-label controls, wrong-tag sensitivity, fixed data and compute, and downstream evaluation.
+Validation-loss improvement alone would not show that conditioning learned useful biology.
 
 <details>
 <summary>Related work</summary>
 
-- The [current MarinDNA preprocessor](https://github.com/Open-Athena/marin-dna/blob/cbb127b53b3d52421fae65cebedf2194c4ec84a3/src/marin_dna/levanter/batch_tokenizer.py#L63-L76) reads the sequence field and emits nucleotide IDs and loss weights without a taxon input. This establishes the sequence-only baseline. It does not determine whether a taxon input would improve representations or VEP.
+- The [current MarinDNA preprocessor](https://github.com/Open-Athena/marin-dna/blob/cbb127b53b3d52421fae65cebedf2194c4ec84a3/src/marin_dna/levanter/batch_tokenizer.py#L63-L76) reads the sequence field and emits nucleotide IDs and loss weights without a taxon input.
+  This establishes the sequence-only baseline.
+  It does not determine whether a taxon input would improve representations or VEP.
 
 | Work | Setup and finding | Implication and remaining gap |
 |---|---|---|
@@ -39,21 +56,47 @@ A leaf-species token is the simplest ablation, but a hierarchy could share infor
 <details>
 <summary>Related experiments</summary>
 
-- [#55](https://github.com/Open-Athena/marin-dna/issues/55) compared promoter training across human, primate, mammal, vertebrate, and animal corpora. Mammalian data learned human Mendelian VEP faster, but phylogenetic breadth, unique-data quantity, and epoch count changed together; the experiment motivates conditioning without testing it.
-- [#58](https://github.com/Open-Athena/marin-dna/issues/58) repeated the timescale comparison for CDS and found a different trajectory: shallower arms led early, while the animal arm later became stronger for missense VEP. This suggests that useful taxonomic context depends on feature class and training stage.
-- [#255](https://github.com/Open-Athena/marin-dna/issues/255) reduced the mammalian cohort from 108 family representatives to 19 order representatives at matched compute. Coding, 3′ UTR, and enhancer VEP were similar, while ncRNA and 5′ UTR/TSS VEP worsened, showing region-dependent value from species diversity.
-- [#353](https://github.com/Open-Athena/marin-dna/issues/353) compared animal- and vertebrate-scale CDS corpora constructed by native annotation and human-anchored projection. The preferred breadth depended on evaluation and construction method, and nucleotide projection recovered little invertebrate sequence; nominal taxonomy and effective training context can differ.
+- [#55](https://github.com/Open-Athena/marin-dna/issues/55) compared promoter training across human, primate, mammal, vertebrate, and animal corpora.
+  Mammalian data learned human Mendelian VEP faster, but phylogenetic breadth, unique-data quantity, and epoch count changed together; the experiment motivates conditioning without testing it.
+- [#58](https://github.com/Open-Athena/marin-dna/issues/58) repeated the timescale comparison for CDS and found a different trajectory: shallower arms led early, while the animal arm later became stronger for missense VEP.
+  This suggests that useful taxonomic context depends on feature class and training stage.
+- [#255](https://github.com/Open-Athena/marin-dna/issues/255) reduced the mammalian cohort from 108 family representatives to 19 order representatives at matched compute.
+  Coding, 3′ UTR, and enhancer VEP were similar, while ncRNA and 5′ UTR/TSS VEP worsened, showing region-dependent value from species diversity.
+- [#353](https://github.com/Open-Athena/marin-dna/issues/353) compared animal- and vertebrate-scale CDS corpora constructed by native annotation and human-anchored projection.
+  The preferred breadth depended on evaluation and construction method, and nucleotide projection recovered little invertebrate sequence; nominal taxonomy and effective training context can differ.
 
 </details>
 
 ## Possible directions
 
-- **Does it help at fixed compute and data?** Compare models trained on the same examples, order, optimizer, seed, and token budget. The primary contrast should be sequence-only versus correctly conditioned; a shuffled-label control can test whether any extra token/parameters alone explain the result.
-- **Can the released Carbon checkpoints test inference-time VEP sensitivity now?** Start with Carbon-500M, then replicate any signal on 3B and 8B. Score the same development-safe human variants from odd-numbered autosomes and X under `<dna>` (untagged), `<vertebrate_mammalian><dna>` (correct), and equal-length wrong or shuffled taxon tags; optionally cross gene-type tags. Keep the checkpoint, window, strand handling, and scorer fixed. Compare paired per-variant score changes and consequence-stratified or macro AUPRC. Correct-versus-wrong tags control the semantics of the prefix more cleanly than correct-versus-untagged alone. This tests whether a trained Carbon model's VEP scores use metadata, not whether metadata-conditioned pretraining caused better VEP.
-- **Species, clade, or hierarchy?** Compare a leaf-species token with hierarchical rank tokens (for example class/order/family/genus/species) or a shared phylogenetic embedding. A hierarchy may capture both universal and lineage-specific rules more efficiently than unrelated leaf embeddings.
-- **How should unseen species work?** Candidate policies include an explicit unknown-taxon token, the nearest known clade, only the known prefix of the taxonomy path, or an embedding derived from phylogenetic distance. SpeciesLM's proxy-token workaround should not be assumed to generalize.
-- **How redundant is the tag with sequence context?** Measure the conditioning gain across context lengths and genomic regions. Correct, null, and deliberately wrong tags at evaluation time would quantify how much the model actually uses the metadata.
-- **Can one model remain unconditional?** Replace taxon tokens with fixed-position null tokens with probability $q$ during training, following the control-tag dropout idea used by LOL-EVE. Sweep $q$; evaluate both correct-tag and null-tag inference. Keeping fixed slots avoids conflating dropout with a positional shift.
-- **Is the model learning useful biology or a shortcut?** Stratify language-modeling gains by coding/regulatory/background regions and by GC/repeat content. Test whether conditioning improves conserved-versus-background likelihood gaps and human VEP after controlling for simple composition.
-- **Which outcomes decide the question?** At minimum: held-out language-model loss on seen and unseen taxa, region-relevant LL gaps, zero-shot Mendelian/complex-trait VEP AUPRC, and frozen-embedding probes. Correct-versus-wrong-tag sensitivity is a diagnostic, not the primary success metric.
-- **Where should the first experiment live?** A short-window specialist with a known multi-species cohort is the cleanest first test; it avoids changing the data distribution and targets the regime in which taxon cannot always be inferred from long genomic context.
+- **Does it help at fixed compute and data?**
+  Compare models trained on the same examples, order, optimizer, seed, and token budget.
+  The primary contrast should be sequence-only versus correctly conditioned; a shuffled-label control can test whether any extra token/parameters alone explain the result.
+- **Can the released Carbon checkpoints test inference-time VEP sensitivity now?**
+  Start with Carbon-500M, then replicate any signal on 3B and 8B.
+  Score the same development-safe human variants from odd-numbered autosomes and X under `<dna>` (untagged), `<vertebrate_mammalian><dna>` (correct), and equal-length wrong or shuffled taxon tags; optionally cross gene-type tags.
+  Keep the checkpoint, window, strand handling, and scorer fixed.
+  Compare paired per-variant score changes and consequence-stratified or macro AUPRC.
+  Correct-versus-wrong tags control the semantics of the prefix more cleanly than correct-versus-untagged alone.
+  This tests whether a trained Carbon model's VEP scores use metadata, not whether metadata-conditioned pretraining caused better VEP.
+- **Species, clade, or hierarchy?**
+  Compare a leaf-species token with hierarchical rank tokens (for example class/order/family/genus/species) or a shared phylogenetic embedding.
+  A hierarchy may capture both universal and lineage-specific rules more efficiently than unrelated leaf embeddings.
+- **How should unseen species work?**
+  Candidate policies include an explicit unknown-taxon token, the nearest known clade, only the known prefix of the taxonomy path, or an embedding derived from phylogenetic distance.
+  SpeciesLM's proxy-token workaround should not be assumed to generalize.
+- **How redundant is the tag with sequence context?**
+  Measure the conditioning gain across context lengths and genomic regions.
+  Correct, null, and deliberately wrong tags at evaluation time would quantify how much the model actually uses the metadata.
+- **Can one model remain unconditional?**
+  Replace taxon tokens with fixed-position null tokens with probability $q$ during training, following the control-tag dropout idea used by LOL-EVE.
+  Sweep $q$; evaluate both correct-tag and null-tag inference.
+  Keeping fixed slots avoids conflating dropout with a positional shift.
+- **Is the model learning useful biology or a shortcut?**
+  Stratify language-modeling gains by coding/regulatory/background regions and by GC/repeat content.
+  Test whether conditioning improves conserved-versus-background likelihood gaps and human VEP after controlling for simple composition.
+- **Which outcomes decide the question?**
+  At minimum: held-out language-model loss on seen and unseen taxa, region-relevant LL gaps, zero-shot Mendelian/complex-trait VEP AUPRC, and frozen-embedding probes.
+  Correct-versus-wrong-tag sensitivity is a diagnostic, not the primary success metric.
+- **Where should the first experiment live?**
+  A short-window specialist with a known multi-species cohort is the cleanest first test; it avoids changing the data distribution and targets the regime in which taxon cannot always be inferred from long genomic context.

--- a/docs/research/questions/tokenization.md
+++ b/docs/research/questions/tokenization.md
@@ -2,49 +2,83 @@
 
 ## TL;DR
 
-Single-nucleotide tokenization remains the MarinDNA default and current recommendation. It preserves base-level prediction and evaluation, and our only internal comparison found worse Mendelian VEP as fixed k-mer size increased, although that experiment had a repeat-weighting confound. Confidence is moderate: we have enough evidence to require a strong case for moving away from single bases, but not enough to claim they are optimal. The main gap is a matched comparison of single-base, fixed-block, and learned semantic tokenizers under ordinary causal next-token prediction. The most interesting alternative is a learned discrete tokenizer that spends fewer model steps on weakly constrained or noisy sequence while preserving useful biological signal.
+Single-nucleotide tokenization remains the MarinDNA default and current recommendation.
+It preserves base-level prediction and evaluation, and our only internal comparison found worse Mendelian VEP as fixed k-mer size increased, although that experiment had a repeat-weighting confound.
+Confidence is moderate: we have enough evidence to require a strong case for moving away from single bases, but not enough to claim they are optimal.
+The main gap is a matched comparison of single-base, fixed-block, and learned semantic tokenizers under ordinary causal next-token prediction.
+The most interesting alternative is a learned discrete tokenizer that spends fewer model steps on weakly constrained or noisy sequence while preserving useful biological signal.
 
 ## Question
 
 Which tokenizer, if any, should MarinDNA use for causal next-token pretraining?
 
-Single-nucleotide tokens with a beginning-of-sequence token are the baseline. They make the prediction target and genomic coordinate explicit, preserve single-base sensitivity, and avoid segmentation assumptions. Moving away from them requires strong matched evidence.
+Single-nucleotide tokens with a beginning-of-sequence token are the baseline.
+They make the prediction target and genomic coordinate explicit, preserve single-base sensitivity, and avoid segmentation assumptions.
+Moving away from them requires strong matched evidence.
 
 Two motivations for alternative tokenization should be kept separate:
 
 1. **Efficiency and context:** represent more base pairs with fewer model tokens, reducing attention and decoding cost or increasing the genomic span visible at a fixed token context.
 2. **Biological abstraction:** learn discrete units that align with reusable sequence patterns and compress weakly constrained or unpredictable background sequence, so less model capacity is spent predicting base-level noise.
 
-This question is restricted to tokenizers that produce a finite sequence of discrete IDs that the current decoder-only Marin model can train on with standard causal next-token cross-entropy. A tokenizer may be trained separately, including with a VQ-VAE-style reconstruction objective, and may emit fixed- or variable-span codes. The Marin language-model objective must remain ordinary next-token prediction. Factorized nucleotide supervision, masked or diffusion language modeling, auxiliary per-base losses, and tokenization schemes that require a different backbone are out of scope.
+This question is restricted to tokenizers that produce a finite sequence of discrete IDs that the current decoder-only Marin model can train on with standard causal next-token cross-entropy.
+A tokenizer may be trained separately, including with a VQ-VAE-style reconstruction objective, and may emit fixed- or variable-span codes.
+The Marin language-model objective must remain ordinary next-token prediction.
+Factorized nucleotide supervision, masked or diffusion language modeling, auxiliary per-base losses, and tokenization schemes that require a different backbone are out of scope.
 
 ## Current answer
 
-Keep single-nucleotide tokenization as the default. The current evidence does not justify changing it.
+Keep single-nucleotide tokenization as the default.
+The current evidence does not justify changing it.
 
-MarinDNA's current preprocessing contract is explicitly character-level and target-aligned. This gives every nucleotide its own autoregressive prediction step and keeps likelihood-based variant scoring straightforward. The cost is a long token sequence and substantial compute spent on bases that may be weakly constrained or intrinsically hard to predict.
+MarinDNA's current preprocessing contract is explicitly character-level and target-aligned.
+This gives every nucleotide its own autoregressive prediction step and keeps likelihood-based variant scoring straightforward.
+The cost is a long token sequence and substantial compute spent on bases that may be weakly constrained or intrinsically hard to predict.
 
-The only direct internal experiment, [#64](https://github.com/Open-Athena/marin-dna/issues/64), compared character, non-overlapping 4-mer, and non-overlapping 8-mer promoter models. TraitGym Mendelian validation performance on odd chromosomes degraded as k increased. The character baseline used repeat downweighting while the k-mer arms did not, so the character-versus-k-mer difference is not fully isolated; the 4-mer-versus-8-mer ordering is cleaner. This is evidence against adopting coarse fixed k-mers by default, not a definitive tokenizer sweep.
+The only direct internal experiment, [#64](https://github.com/Open-Athena/marin-dna/issues/64), compared character, non-overlapping 4-mer, and non-overlapping 8-mer promoter models.
+TraitGym Mendelian validation performance on odd chromosomes degraded as k increased.
+The character baseline used repeat downweighting while the k-mer arms did not, so the character-versus-k-mer difference is not fully isolated; the 4-mer-versus-8-mer ordering is cleaner.
+This is evidence against adopting coarse fixed k-mers by default, not a definitive tokenizer sweep.
 
-External evidence is objective- and setup-dependent. Carbon reports that fixed 6-mers substantially outperform learned BPE under its autoregressive ablation and provide a six-fold sequence-length reduction, but its final recipe later changes the language-model objective with Factorized Nucleotide Supervision. VQDNA shows that a VQ-VAE can learn discrete, pattern-aware genomic codes, but it evaluates those codes with masked-code modeling and supervised downstream tasks rather than causal next-token pretraining. Neither result establishes that an alternative tokenizer improves MarinDNA under the constraint here.
+External evidence is objective- and setup-dependent.
+Carbon reports that fixed 6-mers substantially outperform learned BPE under its autoregressive ablation and provide a six-fold sequence-length reduction, but its final recipe later changes the language-model objective with Factorized Nucleotide Supervision.
+VQDNA shows that a VQ-VAE can learn discrete, pattern-aware genomic codes, but it evaluates those codes with masked-code modeling and supervised downstream tasks rather than causal next-token pretraining.
+Neither result establishes that an alternative tokenizer improves MarinDNA under the constraint here.
 
-The highest-value direction is therefore a semantic learned tokenizer, especially one derived from representations of an existing MarinDNA model. A frozen character-level model could supply span representations; a separately trained quantizer and decoder could turn them into discrete codes; and a new Marin model could then train on those codes with unchanged next-token cross-entropy. This is an untested hypothesis. It must beat simple compression controls and show that its codes capture useful biology rather than GC content, repeat identity, phase, or tokenizer-boundary artifacts.
+The highest-value direction is therefore a semantic learned tokenizer, especially one derived from representations of an existing MarinDNA model.
+A frozen character-level model could supply span representations; a separately trained quantizer and decoder could turn them into discrete codes; and a new Marin model could then train on those codes with unchanged next-token cross-entropy.
+This is an untested hypothesis.
+It must beat simple compression controls and show that its codes capture useful biology rather than GC content, repeat identity, phase, or tokenizer-boundary artifacts.
 
-Confidence is moderate that single-nucleotide tokenization is the right default today and low that it is globally optimal. We have no internal learned-tokenizer result and no evidence that a semantic codebook can safely compress weakly constrained sequence while retaining base-sensitive VEP and generation.
+Confidence is moderate that single-nucleotide tokenization is the right default today and low that it is globally optimal.
+We have no internal learned-tokenizer result and no evidence that a semantic codebook can safely compress weakly constrained sequence while retaining base-sensitive VEP and generation.
 
 <details>
 <summary>Related work</summary>
 
-- The current [MarinDNA batch tokenizer](https://github.com/Open-Athena/marin-dna/blob/c3021ec6926b9f8f329c06679fec1d10539d0389/snakemake/analysis/evals_v2/src/marin_dna_evals/levanter/batch_tokenizer.py#L19-L92) requires a one-to-one character/token mapping and aligns case-based weights to next-token targets. This defines the operational baseline and exposes an implementation gap: compressed or variable-span tokenizers need a different preprocessing path even if the model loss remains unchanged.
-- [Carbon: Decoding the Language of Life](https://www.biorxiv.org/content/10.64898/2026.05.22.727119v1) surveys single-nucleotide, fixed k-mer, BPE, and vector-quantized approaches. In its matched 3B, 50B-token ablation, fixed 6-mers reached 43.25% sequence recovery versus 21.68% and 23.48% for 32k- and 50k-vocabulary BPE, and BRCA2 AUROC of 75.04% versus 63.40% and 66.51%. Its interpretation is that variable BPE boundaries are poorly aligned with causal DNA generation, while fixed 6-mers are neutral compression units. The result supports testing fixed blocks before BPE in an autoregressive model. It does not compare 6-mers against MarinDNA's single-base baseline under matched data, model, and compute, and Carbon's later FNS loss and nucleotide-marginal inference are outside this question.
-- [DNABERT-2](https://openreview.net/forum?id=oMLQB4EZE1) uses learned BPE with masked language modeling and reports strong multispecies downstream results. It shows that BPE can be useful for genomic representation learning, but it does not resolve Carbon's causal-boundary objection or provide evidence for BPE under MarinDNA next-token training.
-- [VQDNA](https://proceedings.mlr.press/v235/li24bm.html) learns a vector-quantized genome vocabulary with a VQ-VAE reconstruction stage, then freezes the vocabulary for masked-code pretraining and downstream fine-tuning. It reports parameter-efficient results across 32 datasets and biologically associated code patterns. This is the closest precedent for model-learned semantic tokens. Its masked encoder setup, hierarchical residual quantization, and downstream evaluation do not show that the same codes are effective causal prediction targets. It also does not test initializing the tokenizer from representations of an already trained causal genomic model.
+- The current [MarinDNA batch tokenizer](https://github.com/Open-Athena/marin-dna/blob/c3021ec6926b9f8f329c06679fec1d10539d0389/snakemake/analysis/evals_v2/src/marin_dna_evals/levanter/batch_tokenizer.py#L19-L92) requires a one-to-one character/token mapping and aligns case-based weights to next-token targets.
+  This defines the operational baseline and exposes an implementation gap: compressed or variable-span tokenizers need a different preprocessing path even if the model loss remains unchanged.
+- [Carbon: Decoding the Language of Life](https://www.biorxiv.org/content/10.64898/2026.05.22.727119v1) surveys single-nucleotide, fixed k-mer, BPE, and vector-quantized approaches.
+  In its matched 3B, 50B-token ablation, fixed 6-mers reached 43.25% sequence recovery versus 21.68% and 23.48% for 32k- and 50k-vocabulary BPE, and BRCA2 AUROC of 75.04% versus 63.40% and 66.51%.
+  Its interpretation is that variable BPE boundaries are poorly aligned with causal DNA generation, while fixed 6-mers are neutral compression units.
+  The result supports testing fixed blocks before BPE in an autoregressive model.
+  It does not compare 6-mers against MarinDNA's single-base baseline under matched data, model, and compute, and Carbon's later FNS loss and nucleotide-marginal inference are outside this question.
+- [DNABERT-2](https://openreview.net/forum?id=oMLQB4EZE1) uses learned BPE with masked language modeling and reports strong multispecies downstream results.
+  It shows that BPE can be useful for genomic representation learning, but it does not resolve Carbon's causal-boundary objection or provide evidence for BPE under MarinDNA next-token training.
+- [VQDNA](https://proceedings.mlr.press/v235/li24bm.html) learns a vector-quantized genome vocabulary with a VQ-VAE reconstruction stage, then freezes the vocabulary for masked-code pretraining and downstream fine-tuning.
+  It reports parameter-efficient results across 32 datasets and biologically associated code patterns.
+  This is the closest precedent for model-learned semantic tokens.
+  Its masked encoder setup, hierarchical residual quantization, and downstream evaluation do not show that the same codes are effective causal prediction targets.
+  It also does not test initializing the tokenizer from representations of an already trained causal genomic model.
 
 </details>
 
 <details>
 <summary>Related experiments</summary>
 
-- [#64](https://github.com/Open-Athena/marin-dna/issues/64) compared character, non-overlapping 4-mer, and non-overlapping 8-mer tokenization on the mammalian promoter training setup. Odd-chromosome TraitGym Mendelian validation performance worsened with larger k. The character arm's repeat downweighting was not applied to the k-mer arms, so a clean replication should hold the data and loss weighting fixed.
+- [#64](https://github.com/Open-Athena/marin-dna/issues/64) compared character, non-overlapping 4-mer, and non-overlapping 8-mer tokenization on the mammalian promoter training setup.
+  Odd-chromosome TraitGym Mendelian validation performance worsened with larger k.
+  The character arm's repeat downweighting was not applied to the k-mer arms, so a clean replication should hold the data and loss weighting fixed.
 
 </details>
 
@@ -53,15 +87,22 @@ Confidence is moderate that single-nucleotide tokenization is the right default 
 ### Evidence required to leave the baseline
 
 - What improvement would justify moving away from single nucleotides: downstream quality at matched training FLOPs, throughput at matched quality, longer useful context, or some combination?
-- How should comparisons account for both token budget and nucleotide exposure? Report model tokens, raw bases, realized epochs, training FLOPs, peak memory, and wall-clock throughput. Use bits per base rather than raw token cross-entropy when vocabulary size and bases per token differ.
-- Which base-sensitive capabilities are non-negotiable? At minimum, compare likelihood-based VEP on permitted development chromosomes, generation/reconstruction fidelity, reverse-complement behavior, and sensitivity to substitutions and indels near token boundaries.
+- How should comparisons account for both token budget and nucleotide exposure?
+  Report model tokens, raw bases, realized epochs, training FLOPs, peak memory, and wall-clock throughput.
+  Use bits per base rather than raw token cross-entropy when vocabulary size and bases per token differ.
+- Which base-sensitive capabilities are non-negotiable?
+  At minimum, compare likelihood-based VEP on permitted development chromosomes, generation/reconstruction fidelity, reverse-complement behavior, and sensitivity to substitutions and indels near token boundaries.
 
 ### Semantic and noise-aware tokens
 
 - Can a tokenizer allocate short or specific codes to constrained sequence and coarser codes to weakly constrained background without using downstream labels at inference time?
-- How should "semantic" be measured? Candidate observables include association with motifs and genomic annotations, stability across species and reverse complements, code reuse across sequence variants, and improved downstream performance after controlling for GC, repeats, and span length.
-- Does compressing unpredictable sequence remove genuine but unannotated biology? Reconstruction error, code entropy, and downstream failures should be stratified by conservation, repeat class, and genomic region.
-- If a token such as a generic background code is lossy, what sequence does it decode to? Lossy semantic codes still permit next-token training, but they change the modeled object and may make exact generation or nucleotide likelihoods unavailable. This tradeoff must be explicit.
+- How should "semantic" be measured?
+  Candidate observables include association with motifs and genomic annotations, stability across species and reverse complements, code reuse across sequence variants, and improved downstream performance after controlling for GC, repeats, and span length.
+- Does compressing unpredictable sequence remove genuine but unannotated biology?
+  Reconstruction error, code entropy, and downstream failures should be stratified by conservation, repeat class, and genomic region.
+- If a token such as a generic background code is lossy, what sequence does it decode to?
+  Lossy semantic codes still permit next-token training, but they change the modeled object and may make exact generation or nucleotide likelihoods unavailable.
+  This tradeoff must be explicit.
 
 ### Using MarinDNA to build a tokenizer
 
@@ -73,9 +114,18 @@ Confidence is moderate that single-nucleotide tokenization is the right default 
 
 ### Candidate experiment ladder
 
-1. **Clean fixed-token replication.** Compare character, 4-mer, 6-mer, and 8-mer tokenization on one fixed corpus with the same examples, uniform loss weighting, model family, optimizer, training FLOPs, and development evaluations. Report both matched-compute and matched-base-exposure views. This settles whether [#64](https://github.com/Open-Athena/marin-dna/issues/64) reproduces without the repeat-weighting confound.
-2. **Frozen-model VQ pilot.** Use span representations from one released MarinDNA checkpoint to train a small VQ encoder-decoder, materialize discrete code sequences, and train a small causal model over those codes with ordinary next-token cross-entropy. Include one-hot VQ and fixed-k-mer controls.
-3. **Semantic audit.** Measure compression ratio, bits per base, reconstruction, code usage, annotation and motif enrichment, conservation, repeat/GC confounding, reverse-complement consistency, and boundary sensitivity before scaling the language model.
-4. **Matched downstream gate.** Compare the best learned tokenizer with the single-base baseline at matched FLOPs on odd autosomes plus chromosome X for development. Do not use even-autosome or chromosome-Y VEP labels during tokenizer selection. Advance only if the tokenizer improves a preregistered downstream or efficiency target without a material loss in base-sensitive scoring.
+1. **Clean fixed-token replication.**
+   Compare character, 4-mer, 6-mer, and 8-mer tokenization on one fixed corpus with the same examples, uniform loss weighting, model family, optimizer, training FLOPs, and development evaluations.
+   Report both matched-compute and matched-base-exposure views.
+   This settles whether [#64](https://github.com/Open-Athena/marin-dna/issues/64) reproduces without the repeat-weighting confound.
+2. **Frozen-model VQ pilot.**
+   Use span representations from one released MarinDNA checkpoint to train a small VQ encoder-decoder, materialize discrete code sequences, and train a small causal model over those codes with ordinary next-token cross-entropy.
+   Include one-hot VQ and fixed-k-mer controls.
+3. **Semantic audit.**
+   Measure compression ratio, bits per base, reconstruction, code usage, annotation and motif enrichment, conservation, repeat/GC confounding, reverse-complement consistency, and boundary sensitivity before scaling the language model.
+4. **Matched downstream gate.**
+   Compare the best learned tokenizer with the single-base baseline at matched FLOPs on odd autosomes plus chromosome X for development.
+   Do not use even-autosome or chromosome-Y VEP labels during tokenizer selection.
+   Advance only if the tokenizer improves a preregistered downstream or efficiency target without a material loss in base-sensitive scoring.
 
 The learned-tokenizer direction should stop if codes mainly reproduce simple composition or repeat labels, if reconstruction failures concentrate in constrained bases, if codebooks are unstable, or if gains disappear against fixed-block controls at matched compute.

--- a/docs/research/questions/training-regions.md
+++ b/docs/research/questions/training-regions.md
@@ -2,46 +2,78 @@
 
 ## TL;DR
 
-Training-footprint choice materially affects functional prediction, and targeted or conservation-selected corpora often beat naive whole-genome sampling at current scales. No experiment establishes a universal region-selection rule across scale and tasks; confidence is moderate that task-aware enrichment helps current models. We do not know whether repeat downweighting improves performance or how its effect changes with scale.
+Training-footprint choice materially affects functional prediction, and targeted or conservation-selected corpora often beat naive whole-genome sampling at current scales.
+No experiment establishes a universal region-selection rule across scale and tasks; confidence is moderate that task-aware enrichment helps current models.
+We do not know whether repeat downweighting improves performance or how its effect changes with scale.
 
 ## Question
 
-Which regions of a genome should a gLM use for pretraining, and how should we obtain those regions when high-quality annotations or whole-genome alignments are unavailable? For functional tasks such as variant-effect prediction, does enriching for constrained or annotated functional sequence outperform whole-genome training, or does that advantage disappear at sufficient model/data scale or with a different loss weighting or training objective? Can cheap local alignments or a learned single-sequence predictor recover useful functional sequence without a full multiple-genome alignment? Does repeat downweighting help, and how does its value change with model and data scale? The answer may be task-dependent: sequence evolving approximately neutrally may be low-value for functional-constraint prediction but central to phylogenetic or mutation-process questions.
+Which regions of a genome should a gLM use for pretraining, and how should we obtain those regions when high-quality annotations or whole-genome alignments are unavailable?
+For functional tasks such as variant-effect prediction, does enriching for constrained or annotated functional sequence outperform whole-genome training, or does that advantage disappear at sufficient model/data scale or with a different loss weighting or training objective?
+Can cheap local alignments or a learned single-sequence predictor recover useful functional sequence without a full multiple-genome alignment?
+Does repeat downweighting help, and how does its value change with model and data scale?
+The answer may be task-dependent: sequence evolving approximately neutrally may be low-value for functional-constraint prediction but central to phylogenetic or mutation-process questions.
 
 ## Current answer
 
-No experiment identifies one universally optimal genomic training footprint. Current MarinDNA results and external ablations support task-aware enrichment at modest scale: region specialists beat mismatched specialists, clean enhancer curation fixes a large VEP failure, and the conservation-filtered footprint covers Mendelian positives much better than complex-trait positives.
+No experiment identifies one universally optimal genomic training footprint.
+Current MarinDNA results and external ablations support task-aware enrichment at modest scale: region specialists beat mismatched specialists, clean enhancer curation fixes a large VEP failure, and the conservation-filtered footprint covers Mendelian positives much better than complex-trait positives.
 
-The design has three separable controls. Locus selection decides which sequence is present; sampling decides exposure frequency; per-base loss weights decide which observations shape the fitted distribution. A hard filter, importance sampling, and loss weighting should not be treated as interchangeable because they change coverage, repetition, and likelihood semantics differently.
+The design has three separable controls.
+Locus selection decides which sequence is present; sampling decides exposure frequency; per-base loss weights decide which observations shape the fitted distribution.
+A hard filter, importance sampling, and loss weighting should not be treated as interchangeable because they change coverage, repetition, and likelihood semantics differently.
 
-The current 100-fold repeat downweighting has not been ablated across scales. We do not know whether it improves language modeling or downstream performance, or whether any benefit shrinks or grows with scale. Uniform loss is the simpler prior. If removing repeat-specific weights preserves performance at the scales and tasks we care about, we should remove them. This would eliminate a special-case training heuristic and make likelihoods easier to interpret.
+The current 100-fold repeat downweighting has not been ablated across scales.
+We do not know whether it improves language modeling or downstream performance, or whether any benefit shrinks or grows with scale.
+Uniform loss is the simpler prior.
+If removing repeat-specific weights preserves performance at the scales and tasks we care about, we should remove them.
+This would eliminate a special-case training heuristic and make likelihoods easier to interpret.
 
-The leading hypothesis is that increasing the density of constrained or correctly annotated sequence improves functional-VEP sample efficiency at fixed compute. Whole-genome data may become more useful at larger scale, under weighting that prevents easy background from dominating, or for mutation-process, repeat, phylogeny, and regional-context tasks. Confidence is moderate for functional enrichment at current scales and low on how the optimum moves with model size and task.
+The leading hypothesis is that increasing the density of constrained or correctly annotated sequence improves functional-VEP sample efficiency at fixed compute.
+Whole-genome data may become more useful at larger scale, under weighting that prevents easy background from dominating, or for mutation-process, repeat, phylogeny, and regional-context tasks.
+Confidence is moderate for functional enrichment at current scales and low on how the optimum moves with model size and task.
 
-The next decisive comparison should cross footprint choice with scale while matching training tokens and reporting unique loci, realized repetitions, contamination, and leakage. It should retain a background arm so gains on functional VEP can be weighed against losses on outcomes that need neutral or repetitive sequence.
+The next decisive comparison should cross footprint choice with scale while matching training tokens and reporting unique loci, realized repetitions, contamination, and leakage.
+It should retain a background arm so gains on functional VEP can be weighed against losses on outcomes that need neutral or repetitive sequence.
 
 <details>
 <summary>Related work</summary>
 
-- [GPN-MSA](https://pmc.ncbi.nlm.nih.gov/articles/PMC10592768/) selected the top 5% of 128 bp windows by conservation, retained a small random background sample, upweighted conserved positions, and downweighted repeats. Its matched ablation favored conserved-region training for VEP. This supports functional enrichment at that model size and objective. It does not prove that neutral sequence is useless or determine how the result changes with scale.
-- Conservation is a proxy for purifying constraint rather than a complete definition of function. It misses lineage-specific and hard-to-align elements, while annotations miss unknown constrained sequence. A useful observable is the joint coverage of evaluation loci, annotated classes, conservation tiers, and repeats under each proposed footprint.
-- [Why do MarinDNA models lag on complex-trait VEP?](complex-trait-vep.md) synthesizes evidence that the current conservation-filtered footprint undercovers complex-trait positives, especially distal variants. This motivates weakly conserved/background arms but does not show that adding them improves VEP.
-- [How should a short-context gLM acquire long-range context?](long-context.md) identifies a long-context version of the same problem: uniformly weighted long windows contain much more background sequence than focal functional sequence. Any long-context pretraining study should report whether selection or weighting changes the distant-context result.
+- [GPN-MSA](https://pmc.ncbi.nlm.nih.gov/articles/PMC10592768/) selected the top 5% of 128 bp windows by conservation, retained a small random background sample, upweighted conserved positions, and downweighted repeats.
+  Its matched ablation favored conserved-region training for VEP.
+  This supports functional enrichment at that model size and objective.
+  It does not prove that neutral sequence is useless or determine how the result changes with scale.
+- Conservation is a proxy for purifying constraint rather than a complete definition of function.
+  It misses lineage-specific and hard-to-align elements, while annotations miss unknown constrained sequence.
+  A useful observable is the joint coverage of evaluation loci, annotated classes, conservation tiers, and repeats under each proposed footprint.
+- [Why do MarinDNA models lag on complex-trait VEP?](complex-trait-vep.md) synthesizes evidence that the current conservation-filtered footprint undercovers complex-trait positives, especially distal variants.
+  This motivates weakly conserved/background arms but does not show that adding them improves VEP.
+- [How should a short-context gLM acquire long-range context?](long-context.md) identifies a long-context version of the same problem: uniformly weighted long windows contain much more background sequence than focal functional sequence.
+  Any long-context pretraining study should report whether selection or weighting changes the distant-context result.
 
 </details>
 
 <details>
 <summary>Related experiments</summary>
 
-- [#8](https://github.com/Open-Athena/marin-dna/issues/8) established functional-versus-background likelihood gaps as a training diagnostic. It provides a readout for footprint experiments but also shows that likelihood gaps need not track VEP under contamination.
-- [#87](https://github.com/Open-Athena/marin-dna/issues/87) scopes repeat and loss-weighting ablations across FLOP budgets. It is the direct scale-dependent weighting experiment, but no completed result is recorded.
-- [#120](https://github.com/Open-Athena/marin-dna/issues/120) compared cheap pairwise methods for recovering cross-species enhancer sequence. It showed that local similarity search can acquire useful functional candidates at lower compute than sensitive whole-genome alignment, with a measurable recall frontier.
-- [#177](https://github.com/Open-Athena/marin-dna/issues/177) audited N stretches and repeat masking in the Zoonomia corpus. Major corruption was not found, and the existing 100-fold repeat downweighting was documented; the biological value of repeat classes remains unresolved.
-- [#213](https://github.com/Open-Athena/marin-dna/issues/213) measured conservation-footprint coverage. The production cutoff covers 83.9% of Mendelian positives and 42.6% of complex-trait positives, with especially low distal complex-trait coverage.
-- [#232](https://github.com/Open-Athena/marin-dna/issues/232) trained matched region specialists and a background control. Every specialist won its home Mendelian class and the background model won none, showing that region-matched distributions matter at this scale.
-- [#326](https://github.com/Open-Athena/marin-dna/issues/326) removed exon overlap and mixed cCRE classes from the enhancer arm. Distal AUPRC rose from 0.127 to about 0.30 while splicing leakage disappeared, showing that broad functional labels are insufficient without contamination control.
-- [#351](https://github.com/Open-Athena/marin-dna/issues/351) compared enhancer-centered and clean tiled windows. Centering was suggestively better for distal VEP, but unequal epoch counts and non-converged curves confounded functional-base density, placement, and repetition.
-- [#353](https://github.com/Open-Athena/marin-dna/issues/353) compared human-anchored CDS projection with native per-species annotation across vertebrate and animal scopes. Projection produced useful conserved-CDS data but lost distant species and did not dominate annotation on every endpoint.
+- [#8](https://github.com/Open-Athena/marin-dna/issues/8) established functional-versus-background likelihood gaps as a training diagnostic.
+  It provides a readout for footprint experiments but also shows that likelihood gaps need not track VEP under contamination.
+- [#87](https://github.com/Open-Athena/marin-dna/issues/87) scopes repeat and loss-weighting ablations across FLOP budgets.
+  It is the direct scale-dependent weighting experiment, but no completed result is recorded.
+- [#120](https://github.com/Open-Athena/marin-dna/issues/120) compared cheap pairwise methods for recovering cross-species enhancer sequence.
+  It showed that local similarity search can acquire useful functional candidates at lower compute than sensitive whole-genome alignment, with a measurable recall frontier.
+- [#177](https://github.com/Open-Athena/marin-dna/issues/177) audited N stretches and repeat masking in the Zoonomia corpus.
+  Major corruption was not found, and the existing 100-fold repeat downweighting was documented; the biological value of repeat classes remains unresolved.
+- [#213](https://github.com/Open-Athena/marin-dna/issues/213) measured conservation-footprint coverage.
+  The production cutoff covers 83.9% of Mendelian positives and 42.6% of complex-trait positives, with especially low distal complex-trait coverage.
+- [#232](https://github.com/Open-Athena/marin-dna/issues/232) trained matched region specialists and a background control.
+  Every specialist won its home Mendelian class and the background model won none, showing that region-matched distributions matter at this scale.
+- [#326](https://github.com/Open-Athena/marin-dna/issues/326) removed exon overlap and mixed cCRE classes from the enhancer arm.
+  Distal AUPRC rose from 0.127 to about 0.30 while splicing leakage disappeared, showing that broad functional labels are insufficient without contamination control.
+- [#351](https://github.com/Open-Athena/marin-dna/issues/351) compared enhancer-centered and clean tiled windows.
+  Centering was suggestively better for distal VEP, but unequal epoch counts and non-converged curves confounded functional-base density, placement, and repetition.
+- [#353](https://github.com/Open-Athena/marin-dna/issues/353) compared human-anchored CDS projection with native per-species annotation across vertebrate and animal scopes.
+  Projection produced useful conserved-CDS data but lost distant species and did not dominate annotation on every endpoint.
 
 </details>
 
@@ -50,34 +82,45 @@ The next decisive comparison should cross footprint choice with scale while matc
 ### What outcome are we optimizing?
 
 - Is there one corpus that transfers well across VEP, functional-region representations, sequence generation, genome annotation, and phylogenetic inference, or should MarinDNA maintain task-specific mixtures?
-- For VEP, should the primary decision metric be zero-shot AUPRC, frozen-embedding probes, functional/non-functional likelihood gaps, or a combination? Improvements should be reported separately for Mendelian, complex-trait, coding, regulatory, conserved, and weakly conserved variants.
-- What evaluation would expose the cost of removing neutral sequence? Candidate outcomes include phylogeny/species inference, mutation-spectrum prediction, regional composition, and held-out whole-genome likelihood, but these should not silently displace functional VEP as the primary task.
+- For VEP, should the primary decision metric be zero-shot AUPRC, frozen-embedding probes, functional/non-functional likelihood gaps, or a combination?
+  Improvements should be reported separately for Mendelian, complex-trait, coding, regulatory, conserved, and weakly conserved variants.
+- What evaluation would expose the cost of removing neutral sequence?
+  Candidate outcomes include phylogeny/species inference, mutation-spectrum prediction, regional composition, and held-out whole-genome likelihood, but these should not silently displace functional VEP as the primary task.
 
 ### What should count as functional training sequence?
 
-- **Direct annotation:** genes, UTRs, ncRNAs, cCREs, experimentally measured regulatory elements. How should incomplete, tissue-specific, and species-biased annotations be combined without letting well-annotated organisms dominate?
-- **Evolutionary constraint:** phyloP, phastCons, GERP, alignment depth, or a learned evolutionary-rate score. Which phylogenetic timescale and window statistic best match each downstream task? How much low-conservation sequence must remain to cover recent or rapidly evolving function?
-- **Cheap local alignment:** can `mmseqs2` hits be converted into robust local statistics—hit depth, taxonomic breadth, identity/coverage profiles, or deviations from a neutral model—that select functional windows without a precomputed WGA? How should paralogs, synteny loss, fragmented hits, and repeats be handled?
-- **Learned single-sequence selection:** once a strong model exists, can a classifier or probe trained on annotations and/or evolutionary labels identify functional windows in a new genome from sequence alone? What orthogonal evaluation prevents the selector from merely reproducing conservation or annotation bias?
+- **Direct annotation:** genes, UTRs, ncRNAs, cCREs, experimentally measured regulatory elements.
+  How should incomplete, tissue-specific, and species-biased annotations be combined without letting well-annotated organisms dominate?
+- **Evolutionary constraint:** phyloP, phastCons, GERP, alignment depth, or a learned evolutionary-rate score.
+  Which phylogenetic timescale and window statistic best match each downstream task?
+  How much low-conservation sequence must remain to cover recent or rapidly evolving function?
+- **Cheap local alignment:** can `mmseqs2` hits be converted into robust local statistics—hit depth, taxonomic breadth, identity/coverage profiles, or deviations from a neutral model—that select functional windows without a precomputed WGA?
+  How should paralogs, synteny loss, fragmented hits, and repeats be handled?
+- **Learned single-sequence selection:** once a strong model exists, can a classifier or probe trained on annotations and/or evolutionary labels identify functional windows in a new genome from sequence alone?
+  What orthogonal evaluation prevents the selector from merely reproducing conservation or annotation bias?
 - Should these sources be used as a union, an intersection, separate sampling strata, or continuous weights?
 
 ### Filter, sample, or weight?
 
 - At equal training FLOPs, how do hard filtering, score-proportional sampling, per-base loss weighting, and a curriculum from enriched to whole-genome data compare?
-- Can the whole genome remain in the corpus while constrained/annotated bases receive most of the gradient? Does this retain rare functional classes and useful neutral context without letting background dominate?
-- Should a window be selected because it contains some functional sequence, while the loss is applied only or preferentially to the functional bases? How much flanking sequence is beneficial context rather than wasted loss?
+- Can the whole genome remain in the corpus while constrained/annotated bases receive most of the gradient?
+  Does this retain rare functional classes and useful neutral context without letting background dominate?
+- Should a window be selected because it contains some functional sequence, while the loss is applied only or preferentially to the functional bases?
+  How much flanking sequence is beneficial context rather than wasted loss?
 - Does causal next-token prediction, masked modeling, or another objective change the optimal sampling/weighting policy?
 
 ### How do scale and data quantity change the answer?
 
 - Does the benefit of enrichment shrink with parameter count, token budget, or context length?
-- When a filtered corpus is smaller, are gains caused by better loci or simply by seeing the same loci for more epochs? Both compute-matched and exposure/epoch-matched comparisons are needed.
+- When a filtered corpus is smaller, are gains caused by better loci or simply by seeing the same loci for more epochs?
+  Both compute-matched and exposure/epoch-matched comparisons are needed.
 - Is there a curriculum in which constrained sequence is best early, but adding progressively broader genome sequence later improves generalization or prevents overfitting?
 - What is the minimum useful amount of low-conservation/background data at each scale?
 
 ### How should repetitive elements be handled?
 
-- At several matched FLOP budgets, compare uniform loss with the current 100-fold repeat downweighting while holding footprint and sampling fixed. This should measure whether repeat downweighting helps and how its effect changes with scale.
+- At several matched FLOP budgets, compare uniform loss with the current 100-fold repeat downweighting while holding footprint and sampling fixed.
+  This should measure whether repeat downweighting helps and how its effect changes with scale.
 - If uniform loss preserves language-modeling and downstream performance, remove repeat-specific loss weights.
 - Compare exclusion, deduplication, soft masking, family/age-aware sampling, and per-base loss downweighting rather than treating “repeat filtering” as one intervention.
 - Which repeat classes mostly create redundant or ambiguous alignment signal, and which carry regulatory, structural, or lineage-specific information?
@@ -86,20 +129,31 @@ The next decisive comparison should cross footprint choice with scale while matc
 
 ### Candidate experiment ladder
 
-1. **Small controlled baseline.** At one small MarinDNA scale and fixed context, compare:
+1. **Small controlled baseline.**
+   At one small MarinDNA scale and fixed context, compare:
    - uniform whole-genome sampling with uniform loss;
    - the current conservation-filtered footprint;
    - whole-genome sampling with conservation/annotation-aware loss weights; and
    - a matched mixture of annotated functional classes plus background.
 
-   Hold architecture, optimizer, number of training tokens, splits, and evaluation fixed. Report unique loci, effective epochs, repeat content, region composition, and gradient/loss mass by stratum.
+   Hold architecture, optimizer, number of training tokens, splits, and evaluation fixed.
+   Report unique loci, effective epochs, repeat content, region composition, and gradient/loss mass by stratum.
 
-2. **Disentangle selection from repetition.** Add a data-size-matched whole-genome subset and an epoch/exposure-matched rerun of the enriched arm. This separates “better sequence” from “more passes over less sequence.”
+2. **Disentangle selection from repetition.**
+   Add a data-size-matched whole-genome subset and an epoch/exposure-matched rerun of the enriched arm.
+   This separates “better sequence” from “more passes over less sequence.”
 
-3. **Task-stratified readout.** Evaluate Mendelian and complex-trait VEP by consequence and conservation stratum, region-matched likelihood gaps, frozen-embedding probes, and at least one outcome expected to benefit from neutral/background sequence.
+3. **Task-stratified readout.**
+   Evaluate Mendelian and complex-trait VEP by consequence and conservation stratum, region-matched likelihood gaps, frozen-embedding probes, and at least one outcome expected to benefit from neutral/background sequence.
 
-4. **Scale and repeat-weighting interaction.** Compare uniform loss with the current repeat downweighting at several model/token budgets while holding footprint, sampling, and objective fixed. If uniform loss preserves likelihood and downstream performance, remove repeat-specific weighting. [#87](https://github.com/Open-Athena/marin-dna/issues/87) first scoped this ablation.
+4. **Scale and repeat-weighting interaction.**
+   Compare uniform loss with the current repeat downweighting at several model/token budgets while holding footprint, sampling, and objective fixed.
+   If uniform loss preserves likelihood and downstream performance, remove repeat-specific weighting.
+   [#87](https://github.com/Open-Athena/marin-dna/issues/87) first scoped this ablation.
 
-5. **Acquisition-method comparison.** Once the target training distribution is clearer, compare WGA/conservation selection against direct annotation, `mmseqs2`-derived local evolutionary statistics, and a learned single-sequence selector on the same genomes and matched window budget.
+5. **Acquisition-method comparison.**
+   Once the target training distribution is clearer, compare WGA/conservation selection against direct annotation, `mmseqs2`-derived local evolutionary statistics, and a learned single-sequence selector on the same genomes and matched window budget.
 
-6. **Mixture frontier.** Sweep the fraction of constrained/annotated, weakly conserved, neutral/background, and repetitive sequence rather than comparing only the endpoints. The useful output is a task-by-scale Pareto frontier and a reproducible default mixture, not a universal declaration that one class of sequence “matters.”
+6. **Mixture frontier.**
+   Sweep the fraction of constrained/annotated, weakly conserved, neutral/background, and repetitive sequence rather than comparing only the endpoints.
+   The useful output is a task-by-scale Pareto frontier and a reproducible default mixture, not a universal declaration that one class of sequence “matters.”


### PR DESCRIPTION
Put each prose sentence in `docs/research/questions/` on its own source line so future edits produce smaller diffs. Markdown table rows remain intact because splitting them would break table syntax.

The reflow changes whitespace only. Non-whitespace content hashes match the prior files, GitHub's repository-Markdown renderer produces equivalent HTML, and the repository pre-commit hooks pass on all 12 documents.