### PR TITLE
Simplify research index link names

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,27 +9,27 @@
 - **2026-08-03** — *Blog post* — [A 1B standard Transformer rivals Evo 2 40B on variant effect prediction](https://openathena.ai/blog/marin-dna/).
 - **2026-05-26** — *Poster* — [Data curation strategies for genomic language models](https://github.com/Open-Athena/marin-dna/blob/190999b89b573b07026eff58c2c0a8cc8fa74458/docs/posters/cshl26/poster.pdf).
 
-## Research questions
+## Research
 
 These documents synthesize MarinDNA's current answers and help organize future experiments.
 
 ### Current priorities
 
-- [Can autoregressive RAG gLMs be accurate and practical?](docs/research/questions/retrieval-augmented-models.md)
-- [Can causal gLMs become bidirectional representation and arbitrary-order generation models?](docs/research/questions/bidirectional-models.md)
-- [How should genomic anchors be selected and projected across species?](docs/research/questions/genomic-anchors.md)
-- [Why do MarinDNA models lag on complex-trait VEP?](docs/research/questions/complex-trait-vep.md)
+- [Bidirectionality](docs/research/questions/bidirectional-models.md)
+- [Complex-trait VEP](docs/research/questions/complex-trait-vep.md)
+- [Genomic anchor projection](docs/research/questions/genomic-anchors.md)
+- [RAG](docs/research/questions/retrieval-augmented-models.md)
 
 ### Other active questions
 
-- [Can gLM pretraining improve human sequence-to-function modeling?](docs/research/questions/sequence-to-function.md)
-- [Does conditioning on species/clade help?](docs/research/questions/species-conditioning.md)
-- [How should a short-context gLM acquire long-range context?](docs/research/questions/long-context.md)
-- [How should evolutionary timescale shape training?](docs/research/questions/evolutionary-timescale.md)
-- [How to optimize pretraining data mixtures?](docs/research/questions/data-mixtures.md)
+- [Data mixing](docs/research/questions/data-mixtures.md)
+- [Evolutionary timescales](docs/research/questions/evolutionary-timescale.md)
+- [Latent biological features](docs/research/questions/latent-features.md)
+- [Long-range context](docs/research/questions/long-context.md)
+- [Sequence-to-function modeling](docs/research/questions/sequence-to-function.md)
+- [Species conditioning](docs/research/questions/species-conditioning.md)
 - [Tokenization](docs/research/questions/tokenization.md)
-- [What latent biological features do gLMs learn?](docs/research/questions/latent-features.md)
-- [Which genomic regions to train on, and how to find them?](docs/research/questions/training-regions.md)
+- [Training regions](docs/research/questions/training-regions.md)
 
 ## Resources
 


### PR DESCRIPTION
Present the README section as `Research` and shorten each link to a topic name. Keep `Other active questions` and alphabetize both lists. This makes the index easier to scan.

The documentation-only change passes `git diff --check`.