### PR TITLE
Standardize research-question summaries and directions

### DIFF
--- a/.agents/skills/maintain-research-question/SKILL.md
+++ b/.agents/skills/maintain-research-question/SKILL.md
@@ -23,9 +23,8 @@ Keep this structure:
 ```markdown
 # <Question title>
 
-## TL;DR
-
-<Short current answer.>
+> [!NOTE]
+> **TL;DR:** <Concise current answer on exactly one source line.>
 
 ## Question
 
@@ -49,14 +48,19 @@ Keep this structure:
 
 </details>
 
-## Possible directions
+<details>
+<summary>Possible directions</summary>
 
 <Curated promising ways to reduce the important uncertainty.>
+
+</details>
 ```
+
+Write the TL;DR as exactly one source line after the callout marker. Keep the answer concise enough to scan as a summary; do not move evidence or extended caveats into the callout.
 
 Keep `Related work` curated. Include counterevidence when it materially affects the answer. Keep `Related experiments` exhaustive: include experiments created for the question and experiments later found to materially inform it. Use explicit clickable MarinDNA issue links.
 
-Treat `Possible directions` as suggestions, not commitments or a chronological backlog.
+Keep `Related work`, `Related experiments`, and `Possible directions` collapsed. Treat `Possible directions` as suggestions, not commitments or a chronological backlog.
 
 ## Create Or Revise A Question
 
@@ -64,7 +68,7 @@ Treat `Possible directions` as suggestions, not commitments or a chronological b
 2. Search the active documents and Git history for overlapping scope.
 3. Read the accepted document, open synthesis pull requests, linked experiments and comments, relevant logbooks and branches, source ledgers, and material external work.
 4. Preserve the existing format and human-authored content unless the evidence requires a change.
-5. Update the TL;DR, current answer, related work, related experiments, and possible directions together when needed.
+5. Update the one-line TL;DR, current answer, related work, related experiments, and possible directions together when needed.
 6. Update the root README and open a pull request.
 
 Agents may independently open a synthesis pull request when evidence materially changes the answer, an important caveat, or the most promising directions. Keep routine progress, dense results, and failures in experiment issues and logbooks.

--- a/docs/research/questions/bidirectional-models.md
+++ b/docs/research/questions/bidirectional-models.md
@@ -1,12 +1,7 @@
 # Can causal gLM checkpoints be cheaply adapted into bidirectional representation models?
 
-## TL;DR
-
-Probably, but this has not been tested in MarinDNA.
-The intended route is to keep the large-scale Marin run entirely causal, preserve that autoregressive checkpoint, and make a separate bidirectional fork with a small amount of post-training outside Marin.
-[Training Compute-Optimal Protein Language Models](https://arxiv.org/abs/2411.02142) is the closest biological precedent for sequential CLM-to-MLM transfer, but its transfer run spent only 20% of its tokens on CLM and 80% on MLM, so it does not show that a mature causal checkpoint needs only a small adaptation budget.
-[LLM2Vec](https://arxiv.org/abs/2404.05961) suggests that masked next-token prediction (MNTP), rather than ordinary same-position MLM, is a natural first objective when adapting a causal decoder.
-Confidence is moderate that the conversion is feasible and low that a cheap conversion will improve genomic representations or variant-effect prediction.
+> [!NOTE]
+> **TL;DR:** Sequential causal-to-masked-objective transfer is feasible in protein models, while full-attention masked next-token prediction is the leading untested hypothesis for cheap MarinDNA adaptation; confidence is moderate that conversion is feasible and low that a small adaptation budget will improve representations or variant-effect prediction.
 
 ## Question
 
@@ -63,7 +58,8 @@ The current hypothesis is therefore:
 
 </details>
 
-## Possible directions
+<details>
+<summary>Possible directions</summary>
 
 ### How much sidecar adaptation is enough?
 
@@ -110,3 +106,5 @@ For a fair comparison with the existing MarinDNA protocol, score both forward an
    Report the incremental FLOPs and tokens relative to the original CLM run.
 4. **Representation gate.**
    Run the broader [#246](https://github.com/Open-Athena/marin-dna/issues/246) and [#314](https://github.com/Open-Athena/marin-dna/issues/314) evaluations only if the smoke test shows a useful gain at an acceptably small budget.
+
+</details>

--- a/docs/research/questions/complex-trait-vep.md
+++ b/docs/research/questions/complex-trait-vep.md
@@ -1,9 +1,7 @@
 # Why do MarinDNA models lag on complex-trait VEP?
 
-## TL;DR
-
-MarinDNA's complex-trait VEP gap is real but has not been causally attributed.
-Training-footprint undercoverage has direct supporting evidence, while shallower evolutionary timescales and retrieval remain plausible; confidence is moderate on undercoverage as one contributor and low on which intervention will close the gap.
+> [!NOTE]
+> **TL;DR:** MarinDNA's complex-trait VEP gap is real but has not been causally attributed; training-footprint undercoverage is the best-supported hypothesis, while shallower evolutionary timescales and retrieval remain plausible, and confidence is low on which intervention will close the gap.
 
 ## Question
 
@@ -68,7 +66,8 @@ The decisive next evidence is a fixed-compute footprint ablation, followed by ma
 
 </details>
 
-## Possible directions
+<details>
+<summary>Possible directions</summary>
 
 1. **Does training-footprint coverage explain the gap?**
    Stratify current predictions by [#213](https://github.com/Open-Athena/marin-dna/issues/213)'s variant-centered conserved fraction, kept-window membership, and consequence group.
@@ -95,3 +94,5 @@ The decisive next evidence is a fixed-compute footprint ablation, followed by ma
    - Improvement from a controlled mammal/primate arm, without merely adding tokens or loci, supports hypothesis 2.
    - Improvement from retrieval, largest on weakly conserved variants, supports hypothesis 3.
    - If none helps, benchmark noise or missing tissue/cell-state information becomes the leading explanation.
+
+</details>

--- a/docs/research/questions/data-mixtures.md
+++ b/docs/research/questions/data-mixtures.md
@@ -1,9 +1,7 @@
 # How to optimize pretraining data mixtures?
 
-## TL;DR
-
-No validated genomic mixture-optimization method exists yet.
-Proxy-swarm regression is promising but depends on small-to-large-scale rank transfer, objective signal, finite-data repetition, and leakage controls; confidence is low, and the next gap is a bounded proxy study before any broad or paid sweep.
+> [!NOTE]
+> **TL;DR:** No validated genomic mixture-optimization method exists yet; proxy-swarm regression is promising but depends on rank transfer, objective signal, finite-data repetition, and leakage controls, so confidence is low and the next step is a bounded proxy study.
 
 ## Question
 
@@ -60,7 +58,8 @@ A broad swarm or target-scale launch is not justified until rank stability, repe
 
 </details>
 
-## Possible directions
+<details>
+<summary>Possible directions</summary>
 
 ### Core questions
 
@@ -443,3 +442,5 @@ This draft makes the following non-blocking interpretations of the transcription
 6. Evolutionary scale is an optional follow-up axis.
    If included, nested taxonomic groups must be converted to disjoint buckets or modeled hierarchically so the same data are not counted under multiple weights.
 7. Phase-specific mixing means separate weight vectors over the same semantic cells for broad pretraining and cooldown or midtraining; phase is not an additional biological bucket axis.
+
+</details>

--- a/docs/research/questions/evolutionary-timescale.md
+++ b/docs/research/questions/evolutionary-timescale.md
@@ -1,9 +1,7 @@
 # How should evolutionary timescale shape training?
 
-## TL;DR
-
-Existing MarinDNA experiments show that useful evolutionary breadth depends on genomic region: promoter and CDS specialists prefer different timescales, and reducing mammalian species diversity hurts some regions more than others.
-Confidence is moderate that there is no universal best clade depth; the main gap is a matched factorial test of breadth, quantity, and downstream task.
+> [!NOTE]
+> **TL;DR:** Useful evolutionary breadth depends on genomic region: promoter and CDS specialists prefer different timescales, and reducing mammalian species diversity hurts some regions more than others; confidence is moderate that there is no universal best clade depth, with a matched factorial test of breadth, quantity, and downstream task still needed.
 
 ## Question
 
@@ -61,7 +59,8 @@ This would separate early sample efficiency from final endpoint quality and test
 
 </details>
 
-## Possible directions
+<details>
+<summary>Possible directions</summary>
 
 1. **What exactly should “evolutionary timescale” mean experimentally?**
    Phylogenetic breadth (primates versus mammals versus vertebrates versus animals), species density within a clade, total unique bases, and distance from the target organism are separate axes and should not be collapsed into one variable.
@@ -90,3 +89,5 @@ This would separate early sample efficiency from final endpoint quality and test
    - Target-clade-only winning would support evolutionary relevance and efficient use of the token budget.
    - Broad-to-narrow beating both endpoints and the static mixture would support a curriculum in which general biological features transfer before lineage-specific adaptation.
    - Strong region-by-timescale interactions would support region-specific mixtures or curricula rather than one universal phylogenetic scope.
+
+</details>

--- a/docs/research/questions/genomic-anchors.md
+++ b/docs/research/questions/genomic-anchors.md
@@ -1,9 +1,7 @@
 # How should genomic anchors be selected and projected across species?
 
-## TL;DR
-
-The current full-window projection contract is operational and has supported viable training datasets, but its anchor criterion, fragment semantics, and homology-versus-yield tradeoff remain unsettled.
-Confidence is high in the documented baseline behavior and low in its optimality; the main gap is a matched projection-policy comparison tied to downstream performance.
+> [!NOTE]
+> **TL;DR:** The current full-window projection contract supports viable training datasets, but its anchor criterion, fragment semantics, and homology-versus-yield tradeoff remain unsettled; confidence is high in the baseline behavior and low in its optimality, with a matched downstream comparison still needed.
 
 ## Question
 
@@ -83,7 +81,8 @@ Projection yield alone is insufficient.
 
 </details>
 
-## Possible directions
+<details>
+<summary>Possible directions</summary>
 
 - Which projection semantics best balance species recovery with confidence that the extracted target window is homologous to the human anchor: full-window projection, center-seeded projection, multiple projected landmarks, or fragment/locus-based alternatives?
 - Within full-window projection, should tiny fragments be removed before locus checks, should one fragment be selected as canonical, or should all compatible fragments define the target span?
@@ -93,3 +92,5 @@ Projection yield alone is insufficient.
   CDS-centered and cCRE-enhancer-centered windows are useful contrasting initial probes, rather than the scope of the research question itself.
 - Which projection diagnostics are needed beyond overall yield, including unique versus multiple mappings, aligned coverage around center-seeded windows, and per-species, per-clade, and per-region recovery?
 - How should controlled training comparisons separate sequence quality and evolutionary breadth from dataset quantity, and which independent coding, regulatory, and genome-wide evaluations should determine success?
+
+</details>

--- a/docs/research/questions/latent-features.md
+++ b/docs/research/questions/latent-features.md
@@ -1,9 +1,7 @@
 # What latent biological features do gLMs learn?
 
-## TL;DR
-
-Sparse-autoencoder analyses identify reproducible splice, stop-codon, accessibility, and coding-context feature responses across layers and dictionaries, while several broader semantic claims failed to replicate.
-The program is paused indefinitely; confidence is moderate for the local causal features and low for a complete biological inventory, with reference-annotation and broader variant tiers still unfinished.
+> [!NOTE]
+> **TL;DR:** Sparse-autoencoder analyses identify reproducible splice, stop-codon, accessibility, and coding-context responses, while several broader semantic claims failed to replicate; the program is paused indefinitely, with moderate confidence in local causal features and low confidence in a complete biological inventory.
 
 ## Question
 
@@ -99,7 +97,8 @@ The next useful biological tiers are UTR, promoter/TSS-proximal, and annotated n
 
 </details>
 
-## Possible directions
+<details>
+<summary>Possible directions</summary>
 
 ### 1. Paired-variant protocol: current answer and extensions
 
@@ -206,3 +205,5 @@ Applied follow-ups:
 - **Curriculum and generalization:** Which features appeared or sharpened during the three-way to five-way continuation, and do they generalize across held-out human loci and homologous mammalian loci?
 - **Causality:** For a small preregistered set of robust features, do in-distribution ablation or clamping change downstream predictions in the biologically expected direction?
 - **Efficiency:** What is the cheapest correctness-equivalent extraction and SAE training recipe that preserves the scientific conclusions?
+
+</details>

--- a/docs/research/questions/long-context.md
+++ b/docs/research/questions/long-context.md
@@ -1,9 +1,7 @@
 # How should a short-context gLM acquire long-range context?
 
-## TL;DR
-
-No MarinDNA experiment directly compares long-context strategies.
-Existing work favors reusing short-context representations through staged, hierarchical, or downstream adaptation, but the best choice depends on required output resolution and compute; confidence is low, and a matched comparison is the main gap.
+> [!NOTE]
+> **TL;DR:** No MarinDNA experiment directly compares long-context strategies; existing work favors reusing short-context representations through staged, hierarchical, or downstream adaptation, but the best choice depends on output resolution and compute, so confidence is low pending a matched comparison.
 
 ## Question
 
@@ -54,7 +52,8 @@ Any comparison must match parameters, training tokens, and compute and must veri
 
 </details>
 
-## Possible directions
+<details>
+<summary>Possible directions</summary>
 
 - **What long-range capability do we want first?**
   Candidate tests should require distant context by construction—for example enhancer–promoter interactions, gene-level expression, long-range splicing regulation, or another task where masking distant sequence should measurably hurt.
@@ -88,3 +87,5 @@ Any comparison must match parameters, training tokens, and compute and must veri
 - **What is the smallest decisive first experiment?**
   One option is a downstream task with known long-range dependence and five matched arms: short-context baseline, direct full-resolution extension, frozen ARSENAL-style per-base tiling, frozen-local pooled hierarchy, and jointly trained pooled hierarchy.
   A second-stage LM arm should follow once that comparison establishes that the task and evaluation can detect useful long-range context.
+
+</details>

--- a/docs/research/questions/retrieval-augmented-models.md
+++ b/docs/research/questions/retrieval-augmented-models.md
@@ -1,9 +1,7 @@
 # Can autoregressive RAG gLMs be accurate and practical?
 
-## TL;DR
-
-A fixed-context mammalian-ortholog prototype produced promising VEP and representation results, but it lacks matched no-retrieval controls, online retrieval, and indel evaluation.
-Confidence is moderate that the model can use ortholog context and low that retrieval itself caused the gain or can be deployed efficiently.
+> [!NOTE]
+> **TL;DR:** A fixed-context mammalian-ortholog prototype produced promising VEP and representation results, but without matched no-retrieval controls, online retrieval, or indel evaluation; confidence is moderate that the model uses ortholog context and low that retrieval caused the gain or can be deployed efficiently.
 
 ## Question
 
@@ -65,7 +63,8 @@ Online retrieval and index-cost work should wait until the causal model benefit 
 
 </details>
 
-## Possible directions
+<details>
+<summary>Possible directions</summary>
 
 - **Target and architecture.**
   Should the model directly generate a sequence of unaligned homologous sequences, as in PoET and EnhancAR, encode retrieved homologs separately and condition an autoregressive reader, or retrofit a strong pretrained single-sequence model with cross-attention, as in RAG-ESM?
@@ -107,3 +106,5 @@ Online retrieval and index-cost work should wait until the causal model benefit 
 - **Evaluation hygiene.**
   How should genomes, loci, homolog families, and retrieval corpora be split to prevent near-duplicate or allele leakage?
   All comparisons need a no-retrieval ablation, matched reader capacity, fixed corpus versions, retrieval traces, and performance stratified by alignment depth, genomic region, repeat content, evolutionary distance, and indel length.
+
+</details>

--- a/docs/research/questions/sequence-to-function.md
+++ b/docs/research/questions/sequence-to-function.md
@@ -1,9 +1,7 @@
 # Can gLM pretraining improve human sequence-to-function modeling?
 
-## TL;DR
-
-Self-supervised gLM pretraining has not shown a consistent advantage for human sequence-to-function modeling under matched architectures and evaluation.
-Positive results in other organisms and model families suggest the effect is regime-dependent; confidence is low, and the decisive gap is a scratch-versus-pretrained accessibility experiment with matched capacity and variant evaluation.
+> [!NOTE]
+> **TL;DR:** Self-supervised gLM pretraining has not shown a consistent advantage for human sequence-to-function modeling under matched architectures and evaluation; positive results elsewhere suggest the effect is regime-dependent, so confidence is low pending a scratch-versus-pretrained accessibility experiment with matched capacity and variant evaluation.
 
 ## Question
 
@@ -65,7 +63,8 @@ Gene expression is a later long-context question.
 
 </details>
 
-## Possible directions
+<details>
+<summary>Possible directions</summary>
 
 ### What is the decisive accessibility experiment?
 
@@ -141,3 +140,5 @@ On identical chromosome splits and GM12878 functional data, compare at minimum:
 - Does one gLM initialization improve accessibility, histone marks, TF binding, and expression together, or are task-specific pretrained models more effective?
 - For expression, should the primary readout be track correlation, gene-level expression, eQTL direction/causality, or perturbation response?
   Improvements in average coverage prediction may not translate to better variant effects.
+
+</details>

--- a/docs/research/questions/species-conditioning.md
+++ b/docs/research/questions/species-conditioning.md
@@ -1,11 +1,7 @@
 # Does conditioning on species/clade help?
 
-## TL;DR
-
-No matched MarinDNA ablation has tested taxon conditioning.
-Carbon directly ablates species and gene-type tags: overall sequence recovery is unchanged, while a correct species tag helps low-resource eukaryote groups; it does not report the conditioning effect on VEP.
-Other published gains remain small or task-specific.
-Confidence is low, and the cheapest next test is a frozen-Carbon tagged, untagged, and wrong-tag VEP comparison before matched retraining.
+> [!NOTE]
+> **TL;DR:** No matched MarinDNA ablation has tested taxon conditioning; Carbon finds unchanged overall sequence recovery and gains only for low-resource eukaryote groups, without VEP evidence, so confidence is low and the cheapest next test is a frozen-Carbon tagged, untagged, and wrong-tag VEP comparison.
 
 ## Question
 
@@ -67,7 +63,8 @@ Validation-loss improvement alone would not show that conditioning learned usefu
 
 </details>
 
-## Possible directions
+<details>
+<summary>Possible directions</summary>
 
 - **Does it help at fixed compute and data?**
   Compare models trained on the same examples, order, optimizer, seed, and token budget.
@@ -100,3 +97,5 @@ Validation-loss improvement alone would not show that conditioning learned usefu
   Correct-versus-wrong-tag sensitivity is a diagnostic, not the primary success metric.
 - **Where should the first experiment live?**
   A short-window specialist with a known multi-species cohort is the cleanest first test; it avoids changing the data distribution and targets the regime in which taxon cannot always be inferred from long genomic context.
+
+</details>

--- a/docs/research/questions/tokenization.md
+++ b/docs/research/questions/tokenization.md
@@ -1,12 +1,7 @@
 # Tokenization
 
-## TL;DR
-
-Single-nucleotide tokenization remains the MarinDNA default and current recommendation.
-It preserves base-level prediction and evaluation, and our only internal comparison found worse Mendelian VEP as fixed k-mer size increased, although that experiment had a repeat-weighting confound.
-Confidence is moderate: we have enough evidence to require a strong case for moving away from single bases, but not enough to claim they are optimal.
-The main gap is a matched comparison of single-base, fixed-block, and learned semantic tokenizers under ordinary causal next-token prediction.
-The most interesting alternative is a learned discrete tokenizer that spends fewer model steps on weakly constrained or noisy sequence while preserving useful biological signal.
+> [!NOTE]
+> **TL;DR:** Single-nucleotide tokenization remains the MarinDNA default because it preserves base-level prediction and the only internal comparison worsened Mendelian VEP as fixed k-mer size increased, although repeat weighting was confounded; confidence is moderate pending a matched causal-next-token comparison with fixed-block and learned semantic tokenizers.
 
 ## Question
 
@@ -82,7 +77,8 @@ We have no internal learned-tokenizer result and no evidence that a semantic cod
 
 </details>
 
-## Possible directions
+<details>
+<summary>Possible directions</summary>
 
 ### Evidence required to leave the baseline
 
@@ -129,3 +125,5 @@ We have no internal learned-tokenizer result and no evidence that a semantic cod
    Advance only if the tokenizer improves a preregistered downstream or efficiency target without a material loss in base-sensitive scoring.
 
 The learned-tokenizer direction should stop if codes mainly reproduce simple composition or repeat labels, if reconstruction failures concentrate in constrained bases, if codebooks are unstable, or if gains disappear against fixed-block controls at matched compute.
+
+</details>

--- a/docs/research/questions/training-regions.md
+++ b/docs/research/questions/training-regions.md
@@ -1,10 +1,7 @@
 # Which genomic regions to train on, and how to find them?
 
-## TL;DR
-
-Training-footprint choice materially affects functional prediction, and targeted or conservation-selected corpora often beat naive whole-genome sampling at current scales.
-No experiment establishes a universal region-selection rule across scale and tasks; confidence is moderate that task-aware enrichment helps current models.
-We do not know whether repeat downweighting improves performance or how its effect changes with scale.
+> [!NOTE]
+> **TL;DR:** Training-footprint choice materially affects functional prediction, and targeted or conservation-selected corpora often beat naive whole-genome sampling at current scales; confidence is moderate that task-aware enrichment helps, while no universal selection rule or repeat-downweighting benefit has been established.
 
 ## Question
 
@@ -77,7 +74,8 @@ It should retain a background arm so gains on functional VEP can be weighed agai
 
 </details>
 
-## Possible directions
+<details>
+<summary>Possible directions</summary>
 
 ### What outcome are we optimizing?
 
@@ -157,3 +155,5 @@ It should retain a background arm so gains on functional VEP can be weighed agai
 6. **Mixture frontier.**
    Sweep the fraction of constrained/annotated, weakly conserved, neutral/background, and repetitive sequence rather than comparing only the endpoints.
    The useful output is a task-by-scale Pareto frontier and a reproducible default mixture, not a universal declaration that one class of sequence “matters.”
+
+</details>


### PR DESCRIPTION
Render each active research question's TL;DR as a one-line GitHub note alert and collapse Possible directions with the existing Related work and Related experiments sections. The summaries retain the accepted answer, confidence, and main evidence gap while reducing top-level visual weight.

Update the maintain-research-question skill so future revisions use the same structure and keep extended evidence and caveats in the body.

Validated all 12 documents for one alert, one single-line summary, three balanced details blocks, and no legacy headings. The skill passes `quick_validate.py`, and `git diff --check` passes.