### PR TITLE
Require additive changes to S3-backed Snakemake pipelines

### DIFF
--- a/.agents/skills/develop-snakemake-pipelines/SKILL.md
+++ b/.agents/skills/develop-snakemake-pipelines/SKILL.md
@@ -28,6 +28,13 @@ Use the targets intended for the task. Put pipeline-wide defaults such as cores,
 - Expose maintained command-line tools through package entry points.
 - Add tests for Python behavior and assert output contracts where silent corruption is possible.
 
+## Extend Existing S3-Backed Pipelines Additively
+
+- Treat existing rules and the shared Python code paths they invoke as immutable when their artifacts share underlying data or storage on S3.
+- Add task-specific rules, modules, tests, configuration, targets, and output namespaces instead of editing an existing path. Copy code when that is the clearest way to keep the new execution path isolated.
+- Preserve existing rule names, inputs, outputs, parameters, and transitive behavior. Do not rely on producer-keyed paths alone to make an in-place change safe.
+- If the requested outcome cannot be implemented additively, stop and obtain explicit user approval before modifying a legacy rule or shared execution path.
+
 ## Inspect Before Executing
 
 1. Run the owning project's tests.


### PR DESCRIPTION
## Summary

Add a guardrail to the Snakemake development skill: preserve existing rules and shared execution paths when they use common S3-backed data, and implement experiments through additive rules, modules, tests, configuration, targets, and output namespaces.

This makes copy-pasting explicit when it is needed to isolate new behavior and requires user approval before a legacy path is changed.

## Validation

- `uv run /home/ubuntu/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/develop-snakemake-pipelines`
- `git diff --check origin/main...HEAD`