### PR TITLE
[evals_v2] Pin Sky GPU runtime for PyTorch 2.13

### DIFF
--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -160,6 +160,55 @@ be skipped with no embedding columns.) Name targeted targets rather than
 
 ## Setup
 
+### Supported Sky GPU runtime
+
+The standard AWS GPU task pins the complete runtime instead of inheriting SkyPilot's changing default image.
+
+| Component | Standard runtime | PyTorch 2.8 baseline |
+| --- | --- | --- |
+| Sky image | AWS `ami-0324f0ad73bdcd087`, Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 24.04) 20260721 | SkyPilot default GPU image used by issue #459 |
+| OS | Ubuntu 24.04.4 LTS | Ubuntu 22.04 |
+| NVIDIA driver | 595.71.05 | 535.216.01 |
+| PyTorch | 2.13.0 | 2.8.0 |
+| Compiled CUDA | 13.0 | 12.8 |
+| Accelerator | NVIDIA A10G | NVIDIA A10G |
+
+The AWS image is immutable and its release notes list A10G support, driver 595.71.05, and CUDA 13.0 in the installed stack.
+CUDA 13.x requires an R580-or-newer driver, so the R595 image satisfies the major-version compatibility boundary.
+The exact contract and the fixed parity cell live in [`config/gpu_runtime_validation.yaml`](config/gpu_runtime_validation.yaml).
+The locked environment pins `torch==2.13.0`, whose Linux wheel reports `torch.version.cuda == "13.0"`.
+
+Every `sky/run.yaml` setup executes `evals-gpu-runtime-check smoke` after the locked environment is installed.
+The smoke gate requires `torch.cuda.is_available()`, the exact image runtime metadata, A10G bf16 support, and a finite bf16 CUDA matrix multiplication.
+
+The numerical gate re-scores the full 16,140-row `exp351-centered-step-1000` × `mendelian_traits@4aed58e` train cell without writing pipeline outputs.
+It checks the four raw score atoms against the checksummed PyTorch 2.8 parquet, using `rtol=1e-4, atol=0.15` for LLR and `rtol=1e-3, atol=1e-4` for mean JSD.
+The LLR tolerance covers the accumulated bf16 kernel differences observed when moving the fixed cell to the new driver, CUDA, and PyTorch stack.
+Run the gate on a fresh one-GPU cluster with:
+
+```bash
+sky launch snakemake/analysis/evals_v2/sky/run.yaml \
+  -c evals-v2-gpu-runtime-462 \
+  --env GPU_RUNTIME_PARITY=true \
+  --down
+```
+
+The gate passed on 2026-08-20 on a fresh AWS `g5.xlarge` spot instance.
+The focused runtime-validation suite available for the live run passed, the runtime metadata matched exactly, and the scorer read only the pinned `train.parquet` file.
+Two failure-path regression tests were added after the live run and will be exercised by CI.
+All 16,140 rows passed for both strands:
+
+| Score atom | Mean absolute difference | 95th percentile | Maximum | Outside tolerance |
+| --- | ---: | ---: | ---: | ---: |
+| `llr_fwd` | 0.0179263 | 0.0450959 | 0.130265 | 0 |
+| `llr_rc` | 0.0176735 | 0.0443012 | 0.100058 | 0 |
+| `mean_jsd_fwd` | 1.23838e-6 | 3.62520e-6 | 1.92486e-5 | 0 |
+| `mean_jsd_rc` | 1.21606e-6 | 3.61578e-6 | 1.49733e-5 | 0 |
+
+The validation writes no persistent score outputs and does not access held-out labels.
+
+The pinned image is documented by the [AWS DLAMI release index](https://docs.aws.amazon.com/dlami/latest/devguide/aws-deep-learning-x86-base-gpu-ami-ubuntu-24-04.html), and the driver boundary comes from the [NVIDIA CUDA compatibility guide](https://docs.nvidia.com/deploy/cuda-compatibility/minor-version-compatibility.html).
+
 On a GPU node (a small EC2 GPU is sufficient for the approximately 0.6B-parameter models):
 
 ```bash

--- a/snakemake/analysis/evals_v2/config/gpu_runtime_validation.yaml
+++ b/snakemake/analysis/evals_v2/config/gpu_runtime_validation.yaml
@@ -1,0 +1,41 @@
+# The standard evals_v2 Sky GPU runtime selected for issue #462.
+runtime:
+  image_id: ami-0324f0ad73bdcd087
+  image_name: Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 24.04) 20260721
+  operating_system: Ubuntu 24.04.4 LTS
+  driver_version: "595.71.05"
+  pytorch_version: "2.13.0"
+  compiled_cuda_version: "13.0"
+  device_name: NVIDIA A10G
+
+# Full development-split parity against an output written after the issue-459
+# PyTorch 2.8.0 pin. The checksum prevents a later S3 overwrite from silently
+# changing the baseline used by this gate.
+parity:
+  baseline:
+    scores_uri: s3://oa-bolinas/snakemake/analysis/evals_v2/results/scores/exp351-centered-step-1000/mendelian_traits.parquet
+    sha256: 7f5ccf50a48aa50494c208a454abbb1ff3fb69e27fb8daf6d57d0af3d503222f
+    pytorch_version: "2.8.0"
+    compiled_cuda_version: "12.8"
+    driver_version: "535.216.01"
+  checkpoint:
+    name: exp351-centered-step-1000
+    gcs_path: gs://marin-us-east5/checkpoints/dna-exp351-zoonomia-v1-0p25b-centered-v0.1-8adcec/hf/step-1000
+    context_size: 255
+  dataset:
+    repo: bolinas-dna/evals_mendelian_traits
+    revision: 4aed58e50c5dea0b878a665007af2ef9e5108e9f
+    filename: train.parquet
+    split: train
+  inference:
+    batch_size: 128
+    num_workers: 4
+    data_transform_on_the_fly: true
+    torch_compile: true
+    rc: true
+  identity_columns: [chrom, pos, ref, alt]
+  tolerances:
+    llr_fwd: {rtol: 0.0001, atol: 0.15}
+    llr_rc: {rtol: 0.0001, atol: 0.15}
+    jsd_fwd: {rtol: 0.001, atol: 0.0001}
+    jsd_rc: {rtol: 0.001, atol: 0.0001}

--- a/snakemake/analysis/evals_v2/pyproject.toml
+++ b/snakemake/analysis/evals_v2/pyproject.toml
@@ -26,10 +26,13 @@ dependencies = [
     "seaborn",
     "snakemake",
     "snakemake-storage-plugin-s3>=0.3.6",
-    "torch",
+    "torch==2.13.0",
     "transformers[torch]<5",
     "zstandard",
 ]
+
+[project.scripts]
+evals-gpu-runtime-check = "marin_dna_evals.gpu_runtime_validation:main"
 
 [dependency-groups]
 dev = [

--- a/snakemake/analysis/evals_v2/sky/run.yaml
+++ b/snakemake/analysis/evals_v2/sky/run.yaml
@@ -19,6 +19,9 @@ name: evals-v2
 
 resources:
     infra: aws/us-east-2
+    # AWS DLAMI 20260721: Ubuntu 24.04.4, NVIDIA driver 595.71.05.
+    # Pinned for the PyTorch 2.13.0 / CUDA 13.0 runtime in issue #462.
+    image_id: ami-0324f0ad73bdcd087
     accelerators: A10G:1        # 24 GB Ampere — bf16-capable. L4 (g6.xlarge) is
                                 # ~$0.21/hr cheaper and would also work; keeping A10G
                                 # because that's what we benchmarked batch_size=64 on.
@@ -37,6 +40,7 @@ workdir: .
 
 envs:
     SNAKEMAKE_ARGS: ""           # extra snakemake args (e.g. --forcerun compute_scores)
+    GPU_RUNTIME_PARITY: "false"  # true runs the issue-462 fixed-cell parity gate only.
     EXTRA_UV_GROUPS: ""          # extra `uv` groups for this run, e.g. "--group umap"
                                  # for the embedding-UMAP target (#246). Default
                                  # empty so metrics/nuc_dep runs stay lean (the
@@ -52,6 +56,9 @@ setup: |
 
     if ! command -v uv >/dev/null 2>&1; then
         curl -LsSf https://astral.sh/uv/install.sh | sh
+    fi
+    if [[ "$(uv --version)" != "uv 0.11.31" ]]; then
+        uv self update 0.11.31
     fi
 
     # gcloud CLI for the pipeline's `download_model` shell rule.
@@ -73,6 +80,13 @@ setup: |
     # $EXTRA_UV_GROUPS adds per-target groups (e.g. `--group umap` for #246).
     uv sync --project snakemake/analysis/evals_v2 --locked --group genome-s3 $EXTRA_UV_GROUPS
 
+    # Fail setup before scoring if the image, driver, torch, compiled CUDA,
+    # A10G, CUDA availability, or bf16 execution differs from the pinned tuple.
+    uv run --project snakemake/analysis/evals_v2 --locked --group genome-s3 \
+        $EXTRA_UV_GROUPS evals-gpu-runtime-check \
+        --config snakemake/analysis/evals_v2/config/gpu_runtime_validation.yaml \
+        smoke
+
     # Smoke-test GCS access so a bad ADC fails fast in setup, not in a rule.
     gcloud storage ls gs://marin-us-central1/checkpoints/ | head -3 >/dev/null
 
@@ -88,6 +102,18 @@ run: |
     export WANDB_DISABLED=true
 
     cd snakemake/analysis/evals_v2
+
+    if [[ "$GPU_RUNTIME_PARITY" == "true" ]]; then
+        # Re-score the fixed train-split cell in memory and compare it with the
+        # checksummed PyTorch 2.8 baseline. This writes no pipeline artifacts.
+        uv run --locked --group genome-s3 $EXTRA_UV_GROUPS \
+            pytest tests/evals/test_gpu_runtime_validation.py
+        uv run --locked --group genome-s3 $EXTRA_UV_GROUPS \
+            evals-gpu-runtime-check \
+            --config config/gpu_runtime_validation.yaml \
+            parity
+        exit 0
+    fi
 
     # $SNAKEMAKE_ARGS goes last so it can include `-- target1 target2 ...`
     # without breaking the parser (everything after `--` is positional, so

--- a/snakemake/analysis/evals_v2/sky/run.yaml
+++ b/snakemake/analysis/evals_v2/sky/run.yaml
@@ -54,6 +54,8 @@ file_mounts:
 setup: |
     set -euxo pipefail
 
+    export PATH="$HOME/google-cloud-sdk/bin:$HOME/.local/bin:$PATH"
+
     if ! command -v uv >/dev/null 2>&1; then
         curl -LsSf https://astral.sh/uv/install.sh | sh
     fi
@@ -69,8 +71,6 @@ setup: |
 
     grep -q 'google-cloud-sdk/bin' "$HOME/.bashrc" || \
         echo 'export PATH="$HOME/google-cloud-sdk/bin:$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
-
-    export PATH="$HOME/google-cloud-sdk/bin:$HOME/.local/bin:$PATH"
 
     # Pin to the ADC we mounted; gcloud picks this up automatically.
     export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/application_default_credentials.json"

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/gpu_runtime_validation.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/gpu_runtime_validation.py
@@ -1,0 +1,469 @@
+"""Validate the pinned evals_v2 Sky GPU runtime and its inference parity."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import fsspec
+import numpy as np
+import pandas as pd
+import torch
+import yaml
+from datasets import load_dataset
+from huggingface_hub import hf_hub_download
+
+from marin_dna_evals.inference import compute_variant_scores
+
+
+@dataclass(frozen=True)
+class RuntimeSpec:
+    """Exact software and hardware contract for the standard Sky GPU task."""
+
+    image_id: str
+    image_name: str
+    operating_system: str
+    driver_version: str
+    pytorch_version: str
+    compiled_cuda_version: str
+    device_name: str
+
+
+@dataclass(frozen=True)
+class Tolerance:
+    """Elementwise numerical tolerance for one score atom."""
+
+    rtol: float
+    atol: float
+
+
+@dataclass(frozen=True)
+class ParitySpec:
+    """Fixed development inference cell and its PyTorch 2.8 baseline."""
+
+    baseline_scores_uri: str
+    baseline_sha256: str
+    baseline_pytorch_version: str
+    baseline_compiled_cuda_version: str
+    baseline_driver_version: str
+    checkpoint_name: str
+    checkpoint_gcs_path: str
+    context_size: int
+    dataset_repo: str
+    dataset_revision: str
+    dataset_filename: str
+    split: str
+    batch_size: int
+    num_workers: int
+    data_transform_on_the_fly: bool
+    torch_compile: bool
+    rc: bool
+    identity_columns: tuple[str, ...]
+    tolerances: dict[str, Tolerance]
+
+
+@dataclass(frozen=True)
+class ValidationSpec:
+    """Complete runtime smoke-test and inference-parity contract."""
+
+    runtime: RuntimeSpec
+    parity: ParitySpec
+
+
+def _require(condition: bool, message: str) -> None:
+    """Raise even when Python assertions are disabled with ``-O``."""
+    if not condition:
+        raise AssertionError(message)
+
+
+def load_validation_spec(path: str | Path) -> ValidationSpec:
+    """Load and validate the checked-in GPU runtime contract."""
+    with Path(path).open(encoding="utf-8") as handle:
+        raw = yaml.safe_load(handle)
+    _require(isinstance(raw, dict), "GPU runtime config must be a mapping")
+    runtime_raw = raw["runtime"]
+    parity_raw = raw["parity"]
+    baseline_raw = parity_raw["baseline"]
+    checkpoint_raw = parity_raw["checkpoint"]
+    dataset_raw = parity_raw["dataset"]
+    inference_raw = parity_raw["inference"]
+    tolerance_raw = parity_raw["tolerances"]
+
+    tolerances = {
+        str(column): Tolerance(rtol=float(values["rtol"]), atol=float(values["atol"]))
+        for column, values in tolerance_raw.items()
+    }
+    _require(bool(tolerances), "at least one score-column tolerance is required")
+    _require(
+        all(t.rtol >= 0 and t.atol >= 0 for t in tolerances.values()),
+        "score tolerances must be non-negative",
+    )
+
+    runtime = RuntimeSpec(
+        image_id=str(runtime_raw["image_id"]),
+        image_name=str(runtime_raw["image_name"]),
+        operating_system=str(runtime_raw["operating_system"]),
+        driver_version=str(runtime_raw["driver_version"]),
+        pytorch_version=str(runtime_raw["pytorch_version"]),
+        compiled_cuda_version=str(runtime_raw["compiled_cuda_version"]),
+        device_name=str(runtime_raw["device_name"]),
+    )
+    parity = ParitySpec(
+        baseline_scores_uri=str(baseline_raw["scores_uri"]),
+        baseline_sha256=str(baseline_raw["sha256"]),
+        baseline_pytorch_version=str(baseline_raw["pytorch_version"]),
+        baseline_compiled_cuda_version=str(baseline_raw["compiled_cuda_version"]),
+        baseline_driver_version=str(baseline_raw["driver_version"]),
+        checkpoint_name=str(checkpoint_raw["name"]),
+        checkpoint_gcs_path=str(checkpoint_raw["gcs_path"]),
+        context_size=int(checkpoint_raw["context_size"]),
+        dataset_repo=str(dataset_raw["repo"]),
+        dataset_revision=str(dataset_raw["revision"]),
+        dataset_filename=str(dataset_raw["filename"]),
+        split=str(dataset_raw["split"]),
+        batch_size=int(inference_raw["batch_size"]),
+        num_workers=int(inference_raw["num_workers"]),
+        data_transform_on_the_fly=bool(inference_raw["data_transform_on_the_fly"]),
+        torch_compile=bool(inference_raw["torch_compile"]),
+        rc=bool(inference_raw["rc"]),
+        identity_columns=tuple(str(c) for c in parity_raw["identity_columns"]),
+        tolerances=tolerances,
+    )
+    _require(
+        len(parity.baseline_sha256) == 64,
+        "baseline SHA-256 must have 64 hex digits",
+    )
+    _require(
+        parity.batch_size > 0 and parity.num_workers >= 0,
+        "batch size must be positive and worker count must be non-negative",
+    )
+    _require(
+        parity.split == "train",
+        "GPU parity must not access the held-out test split",
+    )
+    _require(
+        parity.dataset_filename == f"{parity.split}.parquet",
+        "GPU parity must load the development split's parquet file directly",
+    )
+    _require(parity.rc, "the production parity cell must score both strands")
+    return ValidationSpec(runtime=runtime, parity=parity)
+
+
+def validate_runtime_metadata(
+    spec: RuntimeSpec,
+    *,
+    pytorch_version: str,
+    compiled_cuda_version: str | None,
+    driver_version: str,
+    device_name: str,
+) -> dict[str, str]:
+    """Assert that observed runtime metadata matches the checked-in tuple."""
+    observed_torch = pytorch_version.partition("+")[0]
+    expected = {
+        "pytorch_version": spec.pytorch_version,
+        "compiled_cuda_version": spec.compiled_cuda_version,
+        "driver_version": spec.driver_version,
+        "device_name": spec.device_name,
+    }
+    observed = {
+        "pytorch_version": observed_torch,
+        "compiled_cuda_version": str(compiled_cuda_version),
+        "driver_version": driver_version,
+        "device_name": device_name,
+    }
+    _require(
+        observed == expected,
+        f"GPU runtime mismatch: observed={observed}, expected={expected}",
+    )
+    return observed
+
+
+def _nvidia_smi_metadata() -> tuple[str, str]:
+    result = subprocess.run(
+        [
+            "nvidia-smi",
+            "--query-gpu=driver_version,name",
+            "--format=csv,noheader,nounits",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    rows = [row.strip() for row in result.stdout.splitlines() if row.strip()]
+    _require(len(rows) == 1, f"expected exactly one GPU, found {rows}")
+    driver_version, device_name = (part.strip() for part in rows[0].split(",", 1))
+    return driver_version, device_name
+
+
+def run_cuda_smoke(spec: RuntimeSpec) -> dict[str, Any]:
+    """Exercise CUDA initialization and a finite bf16 matrix multiplication."""
+    _require(torch.cuda.is_available(), "torch.cuda.is_available() is false")
+    _require(
+        torch.cuda.device_count() == 1,
+        "the standard Sky task requires one GPU",
+    )
+    _require(torch.cuda.is_bf16_supported(), "CUDA device does not support bf16")
+
+    driver_version, smi_device_name = _nvidia_smi_metadata()
+    metadata = validate_runtime_metadata(
+        spec,
+        pytorch_version=torch.__version__,
+        compiled_cuda_version=torch.version.cuda,
+        driver_version=driver_version,
+        device_name=smi_device_name,
+    )
+    _require(
+        torch.cuda.get_device_name(0) == spec.device_name,
+        f"torch CUDA device is not {spec.device_name}",
+    )
+
+    values = torch.arange(64, device="cuda", dtype=torch.float32).reshape(8, 8)
+    values = (values / 64).to(torch.bfloat16)
+    product = values @ values.T
+    torch.cuda.synchronize()
+    _require(
+        product.dtype == torch.bfloat16,
+        f"bf16 matmul returned {product.dtype}",
+    )
+    _require(
+        bool(torch.isfinite(product).all().item()),
+        "bf16 matmul returned non-finite values",
+    )
+
+    return {
+        **metadata,
+        "image_id": spec.image_id,
+        "bf16_supported": True,
+        "bf16_matmul_checksum": float(product.float().sum().item()),
+    }
+
+
+def read_verified_parquet(uri: str, expected_sha256: str) -> pd.DataFrame:
+    """Read a parquet only after verifying its complete byte-level identity."""
+    with fsspec.open(uri, "rb") as handle:
+        payload = handle.read()
+    actual_sha256 = hashlib.sha256(payload).hexdigest()
+    _require(
+        actual_sha256 == expected_sha256,
+        f"baseline checksum mismatch for {uri}: "
+        f"observed={actual_sha256}, expected={expected_sha256}",
+    )
+    return pd.read_parquet(io.BytesIO(payload))
+
+
+def compare_score_frames(
+    candidate: pd.DataFrame,
+    baseline: pd.DataFrame,
+    *,
+    identity_columns: tuple[str, ...],
+    tolerances: dict[str, Tolerance],
+) -> dict[str, dict[str, float | int]]:
+    """Require identical variants and tolerance-bounded finite score atoms."""
+    _require(
+        len(candidate) == len(baseline),
+        f"row-count mismatch: candidate={len(candidate)}, baseline={len(baseline)}",
+    )
+    for column in (*identity_columns, *tolerances):
+        _require(column in candidate, f"candidate missing column {column!r}")
+        _require(column in baseline, f"baseline missing column {column!r}")
+
+    candidate_identity = candidate.loc[:, list(identity_columns)].reset_index(drop=True)
+    baseline_identity = baseline.loc[:, list(identity_columns)].reset_index(drop=True)
+    try:
+        pd.testing.assert_frame_equal(
+            candidate_identity,
+            baseline_identity,
+            check_dtype=False,
+            check_exact=True,
+        )
+    except AssertionError as error:
+        raise AssertionError(
+            "candidate variants do not match the pinned baseline"
+        ) from error
+
+    report: dict[str, dict[str, float | int]] = {}
+    failed_columns: list[str] = []
+    for column, tolerance in tolerances.items():
+        candidate_values = candidate[column].to_numpy(dtype=np.float64)
+        baseline_values = baseline[column].to_numpy(dtype=np.float64)
+        _require(
+            bool(np.isfinite(candidate_values).all()),
+            f"candidate {column} contains non-finite values",
+        )
+        _require(
+            bool(np.isfinite(baseline_values).all()),
+            f"baseline {column} contains non-finite values",
+        )
+
+        absolute_difference = np.abs(candidate_values - baseline_values)
+        close = np.isclose(
+            candidate_values,
+            baseline_values,
+            rtol=tolerance.rtol,
+            atol=tolerance.atol,
+        )
+        bad_rows = np.flatnonzero(~close)
+        nonzero = np.abs(baseline_values) > 0
+        max_relative_difference = (
+            float(
+                np.max(absolute_difference[nonzero] / np.abs(baseline_values[nonzero]))
+            )
+            if nonzero.any()
+            else 0.0
+        )
+        report[column] = {
+            "n_rows": len(candidate_values),
+            "n_outside_tolerance": len(bad_rows),
+            "mean_absolute_difference": float(absolute_difference.mean()),
+            "median_absolute_difference": float(np.median(absolute_difference)),
+            "p95_absolute_difference": float(np.quantile(absolute_difference, 0.95)),
+            "p99_absolute_difference": float(np.quantile(absolute_difference, 0.99)),
+            "max_absolute_difference": float(absolute_difference.max(initial=0.0)),
+            "max_relative_difference": max_relative_difference,
+            "rtol": tolerance.rtol,
+            "atol": tolerance.atol,
+        }
+        if len(bad_rows) > 0:
+            failed_columns.append(column)
+
+    _require(
+        not failed_columns,
+        f"score parity failed for {failed_columns}:\n"
+        f"{json.dumps(report, indent=2, sort_keys=True)}",
+    )
+    return report
+
+
+def _download_checkpoint(gcs_path: str, destination: Path) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "gcloud",
+            "storage",
+            "cp",
+            "-r",
+            f"{gcs_path.rstrip('/')}/*",
+            f"{destination}/",
+        ],
+        check=True,
+    )
+
+
+def run_inference_parity(
+    spec: ParitySpec,
+    *,
+    checkpoint_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Re-score the fixed train cell and compare it to the PyTorch 2.8 output."""
+    dataset_path = hf_hub_download(
+        repo_id=spec.dataset_repo,
+        filename=spec.dataset_filename,
+        repo_type="dataset",
+        revision=spec.dataset_revision,
+    )
+    dataset = load_dataset(
+        "parquet",
+        data_files={spec.split: dataset_path},
+        split=spec.split,
+    ).to_pandas()
+
+    def compute(checkpoint: Path) -> pd.DataFrame:
+        scores = compute_variant_scores(
+            checkpoint_path=checkpoint,
+            dataset=dataset,
+            genome_path=(
+                "s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/"
+                "ensembl-release-115/Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
+            ),
+            context_size=spec.context_size,
+            batch_size=spec.batch_size,
+            num_workers=spec.num_workers,
+            data_transform_on_the_fly=spec.data_transform_on_the_fly,
+            torch_compile=spec.torch_compile,
+            rc=spec.rc,
+        )
+        return pd.concat(
+            [
+                dataset.loc[:, list(spec.identity_columns)].reset_index(drop=True),
+                scores,
+            ],
+            axis=1,
+        )
+
+    if checkpoint_path is None:
+        with tempfile.TemporaryDirectory(prefix="marin-dna-evals-gpu-parity-") as tmp:
+            local_checkpoint = Path(tmp) / spec.checkpoint_name
+            _download_checkpoint(spec.checkpoint_gcs_path, local_checkpoint)
+            candidate = compute(local_checkpoint)
+    else:
+        candidate = compute(Path(checkpoint_path))
+
+    # Open the S3 baseline only after worker-backed inference completes.
+    # fsspec owns an asyncio thread; opening S3 before PyTorch forks data-loader
+    # workers leaves the children waiting forever on the inherited event loop.
+    baseline = read_verified_parquet(spec.baseline_scores_uri, spec.baseline_sha256)
+    comparison = compare_score_frames(
+        candidate,
+        baseline,
+        identity_columns=spec.identity_columns,
+        tolerances=spec.tolerances,
+    )
+    return {
+        "checkpoint": spec.checkpoint_name,
+        "dataset": spec.dataset_repo,
+        "dataset_revision": spec.dataset_revision,
+        "dataset_filename": spec.dataset_filename,
+        "split": spec.split,
+        "n_rows": len(candidate),
+        "baseline_scores_uri": spec.baseline_scores_uri,
+        "baseline_sha256": spec.baseline_sha256,
+        "baseline_pytorch_version": spec.baseline_pytorch_version,
+        "baseline_compiled_cuda_version": spec.baseline_compiled_cuda_version,
+        "baseline_driver_version": spec.baseline_driver_version,
+        "score_comparison": comparison,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        default="config/gpu_runtime_validation.yaml",
+        help="Path to the checked-in GPU runtime validation contract.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("smoke", help="Validate CUDA metadata and a bf16 operation.")
+    parity = subparsers.add_parser(
+        "parity", help="Run the full fixed inference cell and compare its score atoms."
+    )
+    parity.add_argument(
+        "--checkpoint-path",
+        help="Use an existing local checkpoint instead of downloading the pinned GCS path.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the selected validation and print a machine-readable result."""
+    args = _build_parser().parse_args(argv)
+    spec = load_validation_spec(args.config)
+    runtime = run_cuda_smoke(spec.runtime)
+    result: dict[str, Any] = {"runtime": runtime}
+    if args.command == "parity":
+        result["parity"] = run_inference_parity(
+            spec.parity,
+            checkpoint_path=args.checkpoint_path,
+        )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/snakemake/analysis/evals_v2/tests/evals/test_gpu_runtime_validation.py
+++ b/snakemake/analysis/evals_v2/tests/evals/test_gpu_runtime_validation.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import pandas as pd
 import pytest
 import yaml
-
 from marin_dna_evals import gpu_runtime_validation
 from marin_dna_evals.gpu_runtime_validation import (
     RuntimeSpec,
@@ -48,6 +47,12 @@ def test_runtime_contract_matches_project_and_sky_configuration() -> None:
     assert sky["resources"]["image_id"] == spec.runtime.image_id
     setup = sky["setup"].replace("\\\n", " ")
     run = sky["run"].replace("\\\n", " ")
+    path_export = setup.index(
+        'export PATH="$HOME/google-cloud-sdk/bin:$HOME/.local/bin:$PATH"'
+    )
+    uv_install = setup.index("if ! command -v uv")
+    uv_version = setup.index('if [[ "$(uv --version)"')
+    assert path_export < uv_install < uv_version
     assert re.search(r"\bevals-gpu-runtime-check\b[^\n]*\bsmoke\b", setup)
     assert re.search(r"\bevals-gpu-runtime-check\b[^\n]*\bparity\b", run)
     assert spec.parity.split == "train"

--- a/snakemake/analysis/evals_v2/tests/evals/test_gpu_runtime_validation.py
+++ b/snakemake/analysis/evals_v2/tests/evals/test_gpu_runtime_validation.py
@@ -1,0 +1,200 @@
+"""Contracts for the pinned evals_v2 Sky GPU runtime and parity gate."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import re
+import tomllib
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import yaml
+
+from marin_dna_evals import gpu_runtime_validation
+from marin_dna_evals.gpu_runtime_validation import (
+    RuntimeSpec,
+    Tolerance,
+    compare_score_frames,
+    load_validation_spec,
+    read_verified_parquet,
+    validate_runtime_metadata,
+)
+
+PROJECT_ROOT = Path(__file__).parents[2]
+VALIDATION_CONFIG = PROJECT_ROOT / "config" / "gpu_runtime_validation.yaml"
+
+
+def test_runtime_gate_has_no_optimization_removable_assertions() -> None:
+    source_path = Path(gpu_runtime_validation.__file__)
+    module = ast.parse(source_path.read_text(encoding="utf-8"))
+    assertion_lines = [
+        node.lineno for node in ast.walk(module) if isinstance(node, ast.Assert)
+    ]
+    assert assertion_lines == []
+
+
+def test_runtime_contract_matches_project_and_sky_configuration() -> None:
+    spec = load_validation_spec(VALIDATION_CONFIG)
+    with (PROJECT_ROOT / "pyproject.toml").open("rb") as handle:
+        project = tomllib.load(handle)
+    with (PROJECT_ROOT / "sky" / "run.yaml").open(encoding="utf-8") as handle:
+        sky = yaml.safe_load(handle)
+
+    assert (
+        f"torch=={spec.runtime.pytorch_version}" in project["project"]["dependencies"]
+    )
+    assert sky["resources"]["image_id"] == spec.runtime.image_id
+    setup = sky["setup"].replace("\\\n", " ")
+    run = sky["run"].replace("\\\n", " ")
+    assert re.search(r"\bevals-gpu-runtime-check\b[^\n]*\bsmoke\b", setup)
+    assert re.search(r"\bevals-gpu-runtime-check\b[^\n]*\bparity\b", run)
+    assert spec.parity.split == "train"
+    assert spec.parity.dataset_filename == "train.parquet"
+
+
+def test_validate_runtime_metadata_strips_local_torch_suffix() -> None:
+    spec = RuntimeSpec(
+        image_id="ami-test",
+        image_name="test",
+        operating_system="Ubuntu",
+        driver_version="595.71.05",
+        pytorch_version="2.13.0",
+        compiled_cuda_version="13.0",
+        device_name="NVIDIA A10G",
+    )
+    observed = validate_runtime_metadata(
+        spec,
+        pytorch_version="2.13.0+cu130",
+        compiled_cuda_version="13.0",
+        driver_version="595.71.05",
+        device_name="NVIDIA A10G",
+    )
+    assert observed["pytorch_version"] == "2.13.0"
+
+
+def test_validate_runtime_metadata_rejects_implicit_cuda_change() -> None:
+    spec = load_validation_spec(VALIDATION_CONFIG).runtime
+    with pytest.raises(AssertionError, match="GPU runtime mismatch"):
+        validate_runtime_metadata(
+            spec,
+            pytorch_version=spec.pytorch_version,
+            compiled_cuda_version="13.1",
+            driver_version=spec.driver_version,
+            device_name=spec.device_name,
+        )
+
+
+def _score_frame(offset: float = 0.0) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "chrom": ["1", "3"],
+            "pos": [100, 200],
+            "ref": ["A", "C"],
+            "alt": ["G", "T"],
+            "llr_fwd": [0.1 + offset, -0.2],
+            "jsd_fwd": [0.01, 0.02],
+        }
+    )
+
+
+def test_compare_score_frames_reports_tolerance_bounded_differences() -> None:
+    tolerances = {
+        "llr_fwd": Tolerance(rtol=0.0, atol=0.005),
+        "jsd_fwd": Tolerance(rtol=0.0, atol=0.0001),
+    }
+    report = compare_score_frames(
+        _score_frame(offset=0.004),
+        _score_frame(),
+        identity_columns=("chrom", "pos", "ref", "alt"),
+        tolerances=tolerances,
+    )
+    assert report["llr_fwd"]["max_absolute_difference"] == pytest.approx(0.004)
+    assert report["llr_fwd"]["n_outside_tolerance"] == 0
+
+
+def test_compare_score_frames_rejects_out_of_tolerance_difference() -> None:
+    with pytest.raises(AssertionError, match="score parity failed"):
+        compare_score_frames(
+            _score_frame(offset=0.006),
+            _score_frame(),
+            identity_columns=("chrom", "pos", "ref", "alt"),
+            tolerances={"llr_fwd": Tolerance(rtol=0.0, atol=0.005)},
+        )
+
+
+def test_compare_score_frames_rejects_variant_misalignment() -> None:
+    candidate = _score_frame()
+    candidate.loc[0, "pos"] = 101
+    with pytest.raises(AssertionError, match="variants do not match"):
+        compare_score_frames(
+            candidate,
+            _score_frame(),
+            identity_columns=("chrom", "pos", "ref", "alt"),
+            tolerances={"llr_fwd": Tolerance(rtol=0.0, atol=0.005)},
+        )
+
+
+def test_read_verified_parquet_rejects_changed_baseline(tmp_path: Path) -> None:
+    path = tmp_path / "baseline.parquet"
+    _score_frame().to_parquet(path, index=False)
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    pd.testing.assert_frame_equal(
+        read_verified_parquet(str(path), digest), _score_frame()
+    )
+    with pytest.raises(AssertionError, match="baseline checksum mismatch"):
+        read_verified_parquet(str(path), "0" * 64)
+
+
+def test_inference_scores_before_opening_s3_baseline(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    spec = load_validation_spec(VALIDATION_CONFIG).parity
+    variants = _score_frame().loc[:, list(spec.identity_columns)]
+    events: list[str] = []
+
+    class DatasetStub:
+        def to_pandas(self) -> pd.DataFrame:
+            return variants
+
+    def fake_hf_hub_download(**kwargs: object) -> str:
+        assert kwargs["repo_id"] == spec.dataset_repo
+        assert kwargs["filename"] == "train.parquet"
+        assert kwargs["repo_type"] == "dataset"
+        assert kwargs["revision"] == spec.dataset_revision
+        return str(tmp_path / "train.parquet")
+
+    def fake_load_dataset(*args: object, **kwargs: object) -> DatasetStub:
+        assert args == ("parquet",)
+        assert kwargs["data_files"] == {"train": str(tmp_path / "train.parquet")}
+        return DatasetStub()
+
+    def fake_compute_variant_scores(**kwargs: object) -> pd.DataFrame:
+        events.append("score")
+        return pd.DataFrame(
+            {column: [0.0, 0.0] for column in spec.tolerances},
+        )
+
+    def fake_read_verified_parquet(uri: str, sha256: str) -> pd.DataFrame:
+        events.append("baseline")
+        return pd.DataFrame()
+
+    monkeypatch.setattr(gpu_runtime_validation, "hf_hub_download", fake_hf_hub_download)
+    monkeypatch.setattr(gpu_runtime_validation, "load_dataset", fake_load_dataset)
+    monkeypatch.setattr(
+        gpu_runtime_validation, "compute_variant_scores", fake_compute_variant_scores
+    )
+    monkeypatch.setattr(
+        gpu_runtime_validation, "read_verified_parquet", fake_read_verified_parquet
+    )
+    monkeypatch.setattr(
+        gpu_runtime_validation,
+        "compare_score_frames",
+        lambda *args, **kwargs: {},
+    )
+
+    report = gpu_runtime_validation.run_inference_parity(spec, checkpoint_path=tmp_path)
+
+    assert events == ["score", "baseline"]
+    assert report["n_rows"] == len(variants)

--- a/snakemake/analysis/evals_v2/uv.lock
+++ b/snakemake/analysis/evals_v2/uv.lock
@@ -849,7 +849,7 @@ requires-dist = [
     { name = "seaborn" },
     { name = "snakemake" },
     { name = "snakemake-storage-plugin-s3", specifier = ">=0.3.6" },
-    { name = "torch" },
+    { name = "torch", specifier = "==2.13.0" },
     { name = "transformers", extras = ["torch"], specifier = "<5" },
     { name = "zstandard" },
 ]


### PR DESCRIPTION
Pin the standard `evals_v2` AWS GPU task to the 20260721 Ubuntu 24.04 DLAMI and PyTorch 2.13.0 with compiled CUDA 13.0.
Sky setup now fails before scoring unless the A10G, NVIDIA 595.71.05 driver, PyTorch/CUDA tuple, CUDA availability, bf16 support, and a bf16 matrix multiplication match the [checked-in runtime contract](https://github.com/Open-Athena/marin-dna/blob/e94e9a0ea21d1e08ac0d4d7c2d8f9431596db84c/snakemake/analysis/evals_v2/config/gpu_runtime_validation.yaml).

The 2026-08-20 validation ran on a fresh AWS `g5.xlarge` spot instance and scored all 16,140 rows of the pinned train split on both strands against the checksummed PyTorch 2.8 baseline.
No score values exceeded `rtol=1e-4, atol=0.15` for LLR or `rtol=1e-3, atol=1e-4` for mean JSD.
Maximum absolute differences were 0.130265 for forward LLR, 0.100058 for reverse-complement LLR, 1.92486e-5 for forward mean JSD, and 1.49733e-5 for reverse-complement mean JSD.
The gate downloads only the commit-pinned `train.parquet`, validates exact variant identity, and writes no pipeline outputs.
Reproduce from [commit e94e9a0e](https://github.com/Open-Athena/marin-dna/tree/e94e9a0ea21d1e08ac0d4d7c2d8f9431596db84c) with:

```bash
sky launch snakemake/analysis/evals_v2/sky/run.yaml \
  -c evals-v2-gpu-runtime-462 \
  --env GPU_RUNTIME_PARITY=true \
  --down
```

The focused runtime-validation suite available during the live run passed.
Two failure-path regressions were added after that run to keep validation active under `PYTHONOPTIMIZE=1` and reject out-of-tolerance scores.
Ruff formatting and lint, lockfile consistency, and diff-integrity checks pass.
The broader `evals_v2` suite has not run because the local worktree has no project environment and a broader paid GPU launch was outside the approved validation scope.
Independent review found the optimization issue; re-review confirmed the fix and found no remaining blocking issues.

Fixes #462
