### PR TITLE
[agents] Refine research plotting defaults

### DIFF
--- a/.agents/skills/plot-research-results/SKILL.md
+++ b/.agents/skills/plot-research-results/SKILL.md
@@ -5,14 +5,16 @@ description: Create or revise MarinDNA plots and figures for experiment analysis
 
 # Plot Research Results
 
+Apply the guidance in this skill before first presenting a figure to a human. Explicit human direction and an established figure-family or publication style override it.
+
+Prefer plotting-library defaults, including Seaborn's default color palette, when they express the intended comparison cleanly. Customize only for a specific semantic, legibility, accessibility, or publication constraint.
+
 Build the figure around the scientific comparison it must support.
 
-## Apply The First-Review Defaults
+## Compose The Figure
 
-- Apply the defaults in this skill before first presenting a figure to a human. Explicit human direction and an established figure-family or publication style override them.
 - Present one scientific comparison at a time. Start with the primary contrast, then add modifiers or interactions only when they answer the next question.
 - Use one single-line overall figure title. Give each subplot or facet one single-line title that identifies only its panel distinction. Do not stack subtitles, narrative blocks, or sample counts into the figure header.
-- Use the [published MarinDNA blog](https://openathena.ai/blog/marin-dna/) and its [merged figure assets](https://github.com/Open-Athena/open-athena.github.io/tree/d61d7c68f073ce2e923e1132a29dcccc7556b0e4/static/assets/images/blog/marin-dna) as the visual reference for these defaults.
 
 ## Choose The Highest-Level Suitable Interface
 

--- a/.agents/skills/plot-research-results/SKILL.md
+++ b/.agents/skills/plot-research-results/SKILL.md
@@ -7,24 +7,41 @@ description: Create or revise MarinDNA plots and figures for experiment analysis
 
 Build the figure around the scientific comparison it must support.
 
+## Apply The First-Review Defaults
+
+- Apply the defaults in this skill before first presenting a figure to a human. Explicit human direction and an established figure-family or publication style override them.
+- Present one scientific comparison at a time. Start with the primary contrast, then add modifiers or interactions only when they answer the next question.
+- Use one single-line overall figure title. Give each subplot or facet one single-line title that identifies only its panel distinction. Do not stack subtitles, narrative blocks, or sample counts into the figure header.
+- Use the [published MarinDNA blog](https://openathena.ai/blog/marin-dna/) and its [merged figure assets](https://github.com/Open-Athena/open-athena.github.io/tree/d61d7c68f073ce2e923e1132a29dcccc7556b0e4/static/assets/images/blog/marin-dna) as the visual reference for these defaults.
+
 ## Choose The Highest-Level Suitable Interface
 
 - Prefer the highest-level plotting interface that expresses the intended figure cleanly. Favor declarative or figure-level APIs that own faceting, labels, legends, scales, and layout.
 - Use axes-level or low-level drawing when the higher-level interface cannot express the figure without distorting the comparison or requiring brittle workarounds.
 - With seaborn, prefer figure-level functions such as `relplot`, `catplot`, and `displot` when they fit. Use axes-level seaborn or matplotlib for genuinely custom composition.
 
+## Size Typography And Layout
+
+- Keep the plotting theme's typography consistent. Improve legibility by changing the figure, facet, or intended display size rather than manually setting individual font sizes.
+- Write concise, sentence-case axis labels and legend titles with an initial capital, such as `Parameters` and `Loss`. Put longer definitions in the caption or prose.
+- Prefer square axes for quantitative subplots. Deviate when the data or plot form benefits materially from another aspect ratio.
+- Keep spacing between subplots compact. Size the canvas so square axes fill their allotted cells without large empty gaps.
+- Preserve a semantic legend title. Place the legend where it does not overlap data or create excessive whitespace.
+- Map a variable to one visual channel by default. Do not vary color and line style or marker shape for the same variable unless accessibility, monochrome output, or explicit human direction requires redundant encoding.
+
 ## Preserve The Meaning
 
-- Label metrics, units, aggregation, sample definition, transformations, and uncertainty explicitly.
-- State the uncertainty quantity, such as standard error, confidence interval, standard deviation, or range. Choose its rendering to match that meaning.
-- Do not imply level comparisons between quantities that are not comparable by construction. Use facets, normalization, independent axes, or another labeled encoding appropriate to the task.
+- Label metrics, units, aggregation, sample definition, transformations, and any displayed uncertainty explicitly in the caption or surrounding prose when they do not fit cleanly in the figure.
+- Keep sample counts out of the plotting area by default. Include `n` only when it is needed to interpret the statistic, and state exactly what it counts.
+- Do not add bootstrap intervals or another uncertainty overlay by habit. If uncertainty is negligible at the intended display scale, omit the overlay; when uncertainty is shown, name the quantity, such as standard error, confidence interval, standard deviation, or range.
+- Share an axis only when the common scale supports the intended comparison without obscuring variation. Otherwise use clearly labeled independent axes, especially for panels that are not comparable by construction or have materially different useful ranges.
 - Preserve negative results and relevant variation. Do not tune axis limits, smoothing, filtering, or color scales to exaggerate an effect.
-- Use accessible colors and ensure the figure remains interpretable without relying on color alone when practical.
+- Use accessible colors. Add a redundant visual channel only when the output context requires it.
 
 ## Produce And Inspect The Artifact
 
 - Emit SVG by default for a static figure. Add PNG, PDF, or another format only when a downstream consumer requires it.
-- Inspect the rendered artifact before publishing it. Check labels, clipping, legend order, facet consistency, numeric scales, and whether the visual supports the stated takeaway.
+- Inspect the rendered artifact before publishing it. Check title length, label capitalization, typography, axis aspect, subplot spacing, legend title and order, clipping, numeric scales, and whether the visual supports the stated takeaway.
 - Commit every SVG referenced by a knowledge-base experiment page under `docs/research/experiments/figures/<issue>/` on `main`.
 - Store other small figures under `.agents/artifacts/<topic>/` on the permanent task or research branch.
 - Use a raw commit-pinned repository URL when a branch figure must render on GitHub.

--- a/.agents/skills/plot-research-results/SKILL.md
+++ b/.agents/skills/plot-research-results/SKILL.md
@@ -14,7 +14,7 @@ Build the figure around the scientific comparison it must support.
 ## Compose The Figure
 
 - Present one scientific comparison at a time. Start with the primary contrast, then add modifiers or interactions only when they answer the next question.
-- Use one single-line overall figure title. Give each subplot or facet one single-line title that identifies only its panel distinction. Do not stack subtitles, narrative blocks, or sample counts into the figure header.
+- Keep the overall figure title, each subplot or facet title, and each axis label on one line within its allotted area. Shorten them or move detail to the caption before they wrap, clip, or overflow.
 
 ## Choose The Highest-Level Suitable Interface
 
@@ -33,9 +33,8 @@ Build the figure around the scientific comparison it must support.
 
 ## Preserve The Meaning
 
-- Label metrics, units, aggregation, sample definition, transformations, and any displayed uncertainty explicitly in the caption or surrounding prose when they do not fit cleanly in the figure.
-- Keep sample counts out of the plotting area by default. Include `n` only when it is needed to interpret the statistic, and state exactly what it counts.
-- Do not add bootstrap intervals or another uncertainty overlay by habit. If uncertainty is negligible at the intended display scale, omit the overlay; when uncertainty is shown, name the quantity, such as standard error, confidence interval, standard deviation, or range.
+- Label metrics, units, aggregation, sample definition, and transformations explicitly in the caption or surrounding prose when they do not fit cleanly in the figure.
+- Show uncertainty by default when it can be estimated. Name the quantity, such as standard error, confidence interval, standard deviation, or range. Omit it only when uncertainty is not meaningful for the statistic or explicit human direction calls for another presentation.
 - Share an axis only when the common scale supports the intended comparison without obscuring variation. Otherwise use clearly labeled independent axes, especially for panels that are not comparable by construction or have materially different useful ranges.
 - Preserve negative results and relevant variation. Do not tune axis limits, smoothing, filtering, or color scales to exaggerate an effect.
 - Use accessible colors. Add a redundant visual channel only when the output context requires it.

--- a/.agents/skills/plot-research-results/SKILL.md
+++ b/.agents/skills/plot-research-results/SKILL.md
@@ -52,7 +52,6 @@ Build the figure around the scientific comparison it must support.
 
 - Label metrics, units, aggregation, sample definition, and transformations explicitly in the caption or surrounding prose when they do not fit cleanly in the figure.
 - Choose the estimator, aggregation, unit of independence, uncertainty method, confidence level when applicable, and resampling unit explicitly.
-  Account for dependence among repeated observations or nearby genomic positions.
 - Show uncertainty by default when it can be estimated.
   Name the quantity, such as standard error, confidence interval, standard deviation, or range.
   Omit it only when uncertainty is not meaningful for the statistic or explicit human direction calls for another presentation.

--- a/.agents/skills/plot-research-results/SKILL.md
+++ b/.agents/skills/plot-research-results/SKILL.md
@@ -37,7 +37,6 @@ Build the figure around the scientific comparison it must support.
 - Show uncertainty by default when it can be estimated. Name the quantity, such as standard error, confidence interval, standard deviation, or range. Omit it only when uncertainty is not meaningful for the statistic or explicit human direction calls for another presentation.
 - Share an axis only when the common scale supports the intended comparison without obscuring variation. Otherwise use clearly labeled independent axes, especially for panels that are not comparable by construction or have materially different useful ranges.
 - Preserve negative results and relevant variation. Do not tune axis limits, smoothing, filtering, or color scales to exaggerate an effect.
-- Use accessible colors. Add a redundant visual channel only when the output context requires it.
 
 ## Produce And Inspect The Artifact
 

--- a/.agents/skills/plot-research-results/SKILL.md
+++ b/.agents/skills/plot-research-results/SKILL.md
@@ -5,43 +5,68 @@ description: Create or revise MarinDNA plots and figures for experiment analysis
 
 # Plot Research Results
 
-Apply the guidance in this skill before first presenting a figure to a human. Explicit human direction and an established figure-family or publication style override it.
+Apply the presentation guidance in this skill before first presenting a figure to a human.
+Explicit human direction and an established figure-family or publication style may override these presentation defaults.
+Scientific-integrity and repository-policy requirements remain binding.
 
-Prefer plotting-library defaults, including Seaborn's default color palette, when they express the intended comparison cleanly. Customize only for a specific semantic, legibility, accessibility, or publication constraint.
+Prefer plotting-library presentation defaults, including Seaborn's default color palette, when they express the intended comparison cleanly.
+Customize those defaults only for a specific semantic, legibility, or publication constraint.
+Choose statistical settings explicitly.
+Do not inherit automatic aggregation or uncertainty behavior from a plotting library.
 
 Build the figure around the scientific comparison it must support.
 
 ## Compose The Figure
 
-- Present one scientific comparison at a time. Start with the primary contrast, then add modifiers or interactions only when they answer the next question.
-- Keep the overall figure title, each subplot or facet title, and each axis label on one line within its allotted area. Shorten them or move detail to the caption before they wrap, clip, or overflow.
+- Present one scientific comparison at a time.
+  Start with the primary contrast, then add modifiers or interactions only when they answer the next question.
+- Keep the overall figure title, each subplot or facet title, and each axis label on one line within its allotted area.
+  Shorten them or move detail to the caption before they wrap, clip, or overflow.
 
 ## Choose The Highest-Level Suitable Interface
 
-- Prefer the highest-level plotting interface that expresses the intended figure cleanly. Favor declarative or figure-level APIs that own faceting, labels, legends, scales, and layout.
+- Prefer the highest-level plotting interface that expresses the intended figure cleanly.
+  Favor declarative or figure-level APIs that own faceting, labels, legends, scales, and layout.
 - Use axes-level or low-level drawing when the higher-level interface cannot express the figure without distorting the comparison or requiring brittle workarounds.
-- With seaborn, prefer figure-level functions such as `relplot`, `catplot`, and `displot` when they fit. Use axes-level seaborn or matplotlib for genuinely custom composition.
+- With Seaborn, prefer figure-level functions such as `relplot`, `catplot`, and `displot` when they fit.
+  Use axes-level Seaborn or Matplotlib for genuinely custom composition.
 
-## Size Typography And Layout
+## Size, Typography, And Layout
 
-- Keep the plotting theme's typography consistent. Improve legibility by changing the figure, facet, or intended display size rather than manually setting individual font sizes.
-- Write concise, sentence-case axis labels and legend titles with an initial capital, such as `Parameters` and `Loss`. Put longer definitions in the caption or prose.
-- Prefer square axes for quantitative subplots. Deviate when the data or plot form benefits materially from another aspect ratio.
-- Keep spacing between subplots compact. Size the canvas so square axes fill their allotted cells without large empty gaps.
-- Preserve a semantic legend title. Place the legend where it does not overlap data or create excessive whitespace.
-- Map a variable to one visual channel by default. Do not vary color and line style or marker shape for the same variable unless accessibility, monochrome output, or explicit human direction requires redundant encoding.
+- Keep the plotting theme's typography consistent.
+  Improve legibility by changing the figure, facet, or intended display size rather than manually setting individual font sizes.
+- Write concise, sentence-case axis labels and legend titles with an initial capital, such as `Parameters` and `Loss`.
+  Put longer definitions in the caption or prose.
+- Prefer square physical plot boxes for quantitative subplots.
+  Set the box aspect, such as `aspect=1` in a Seaborn figure-level function or `set_box_aspect(1)` on a Matplotlib axes.
+  Do not force equal x and y data-unit scaling.
+  Deviate when the data or plot form benefits materially from another aspect ratio.
+- Keep spacing between subplots compact.
+  Size the canvas so square plot boxes fill their allotted cells without large empty gaps.
+- Preserve a semantic legend title.
+  Place the legend where it does not overlap data or create excessive whitespace.
+- Map a variable to one visual channel by default.
+  Do not vary color and line style or marker shape for the same variable unless monochrome output or explicit human direction requires redundant encoding.
 
 ## Preserve The Meaning
 
 - Label metrics, units, aggregation, sample definition, and transformations explicitly in the caption or surrounding prose when they do not fit cleanly in the figure.
-- Show uncertainty by default when it can be estimated. Name the quantity, such as standard error, confidence interval, standard deviation, or range. Omit it only when uncertainty is not meaningful for the statistic or explicit human direction calls for another presentation.
-- Share an axis only when the common scale supports the intended comparison without obscuring variation. Otherwise use clearly labeled independent axes, especially for panels that are not comparable by construction or have materially different useful ranges.
-- Preserve negative results and relevant variation. Do not tune axis limits, smoothing, filtering, or color scales to exaggerate an effect.
+- Choose the estimator, aggregation, unit of independence, uncertainty method, confidence level when applicable, and resampling unit explicitly.
+  Account for dependence among repeated observations or nearby genomic positions.
+- Show uncertainty by default when it can be estimated.
+  Name the quantity, such as standard error, confidence interval, standard deviation, or range.
+  Omit it only when uncertainty is not meaningful for the statistic or explicit human direction calls for another presentation.
+- Share an axis only when the common scale supports the intended comparison without obscuring variation.
+  Otherwise use clearly labeled independent axes, especially for panels that are not comparable by construction or have materially different useful ranges.
+- Preserve negative results and relevant variation.
+  Do not tune axis limits, smoothing, filtering, or color scales to exaggerate an effect.
 
 ## Produce And Inspect The Artifact
 
-- Emit SVG by default for a static figure. Add PNG, PDF, or another format only when a downstream consumer requires it.
-- Inspect the rendered artifact before publishing it. Check title length, label capitalization, typography, axis aspect, subplot spacing, legend title and order, clipping, numeric scales, and whether the visual supports the stated takeaway.
+- Emit SVG by default for a static figure.
+  Add PNG, PDF, or another format only when a downstream consumer requires it.
+- Inspect the rendered artifact before publishing it.
+  Check title length, label capitalization, typography, plot-box aspect, subplot spacing, legend title and order, clipping, numeric scales, and whether the visual supports the stated takeaway.
 - Commit every SVG referenced by a knowledge-base experiment page under `docs/research/experiments/figures/<issue>/` on `main`.
 - Store other small figures under `.agents/artifacts/<topic>/` on the permanent task or research branch.
 - Use a raw commit-pinned repository URL when a branch figure must render on GitHub.


### PR DESCRIPTION
Define plotting presentation defaults agents should apply before first human review.
Human direction and established figure-family or publication styles may override presentation defaults; scientific-integrity and repository-policy requirements remain binding.

Prefer plotting-library presentation defaults, including Seaborn's figure-level interfaces and default color palette.
First-pass figures use one scientific comparison, single-line titles and axis labels, named uncertainty by default for estimable quantities, square physical plot boxes, compact layout, semantic legend titles, and one visual channel per variable.
Customize presentation only for a specific semantic, legibility, or publication constraint.

Choose estimators, aggregation, independence units, uncertainty methods, confidence levels, and resampling units explicitly.
Do not inherit automatic aggregation or uncertainty behavior from a plotting library.

Part of #478