### PR TITLE
[research] Record Carbon species-conditioning result

### DIFF
--- a/docs/research/experiments/486-carbon-species-conditioning.md
+++ b/docs/research/experiments/486-carbon-species-conditioning.md
@@ -1,0 +1,74 @@
+# Carbon species-prompt sensitivity on Mendelian VEP
+
+> [!NOTE]
+> **TL;DR:** On 16,100 development-set Mendelian variants, correct mammalian and far-wrong fungal prompts changed Carbon-3B scores but did not establish a macro-AUPRC difference from no tagging; the frozen-checkpoint result measures inference-time prompt sensitivity, not the value of tag-conditioned pretraining.
+
+## Findings
+
+### Variant-level score agreement
+
+![Grouped bars comparing Pearson correlations between no-tag scores and each tagged condition overall and within every retained variant subset](figures/486/pearson-by-subset.svg)
+
+_Bars report Pearson correlation over all retained variants in each category; the [experiment issue](https://github.com/Open-Athena/marin-dna/issues/486#issuecomment-5371806938) contains the individual-variant scatter plots and positive/negative breakdowns._
+
+No-tag scores had pooled Pearson correlations of 0.970 with correct-mammalian scores and 0.981 with far-wrong-fungal scores.
+Agreement was lower for promoter variants at 0.669 and 0.659 and for distal variants at 0.672 and 0.715.
+Promoter and distal also had the smallest no-tag score scale: mean absolute scores of 0.00169 and 0.00174 nats per DNA target token, with standard deviations of 0.00244 and 0.00242.
+Missense and splicing had mean absolute scores of 0.00786 and 0.00534, with standard deviations of 0.01330 and 0.01520.
+The ratio `SD(tagged − no tag) / SD(no tag)` was therefore 0.75–0.83 for promoter and distal variants, compared with 0.16–0.24 for missense and splicing variants.
+Across the eight subsets, this ratio was inversely rank-correlated with Pearson agreement (Spearman ρ = -1.00 for both tags), while no-tag AUPRC and Pearson agreement were positively associated (Pearson r = 0.81 for both tags).
+The most likely explanation for the lower agreement is limited, near-neutral LLR dynamic range in regions where Carbon weakly separates deleterious variants: the prompt-induced change is nearly as large as the baseline score spread.
+An offset toward zero alone cannot lower Pearson correlation, and the analysis provides no evidence for a regional evolutionary-rate explanation.
+The relative-change ratio is algebraically related to Pearson correlation and does not establish that the prompt-induced change is random noise.
+Pearson correlation measures linear agreement rather than rank preservation, so these comparisons do not establish reranking.
+
+### AUPRC by consequence subset
+
+![Grouped vertical bars comparing no-tag, correct-mammalian, and far-wrong-fungal AUPRC for the macro average and every retained variant subset](figures/486/auprc-by-subset.svg)
+
+_The y-axis begins at 0.1, the prevalence implied by each 1:9 matched group; uncapped whiskers are ±1 bootstrap standard error over complete match groups, lower whiskers below 0.1 are clipped, and mature miRNA is excluded._
+
+AUPRC was similar across prompt conditions, with no consistent subset pattern favoring either tag.
+Subset differences were mixed in direction and exploratory, with no multiplicity correction or testing hierarchy.
+Neither species prompt established a macro-AUPRC difference from no tagging.
+Correct mammalian conditioning changed macro AUPRC by -0.0030, with a 95% paired-bootstrap interval of [-0.0183, 0.0088].
+The far-wrong fungal prompt changed it by +0.0005 [-0.0137, 0.0124].
+
+## Evidence
+
+The analysis held the `HuggingFaceBio/Carbon-3B` checkpoint, sequence, scorer, and variants fixed while changing only the prompt prefix.
+The three prompts were `<dna>` for no tagging, `<species>vertebrate_mammalian<dna>` for correct mammalian conditioning, and `<species>fungi<dna>` for the far-wrong control.
+Carbon saw metadata on half of its eukaryotic pretraining examples, so the same checkpoint supports conditional and unconditional prompts.
+The comparison used the pinned `train` split of `marin-dna/evals_mendelian_traits`, restricted to odd-numbered autosomes and chromosome X.
+No held-out variants were scored or analyzed.
+
+The retained population contained 16,100 single-nucleotide variants in 1,610 complete groups, with one pathogenic positive and nine matched negatives per group.
+The macro average weights eight consequence subsets equally.
+
+Each allele was scored in forward and reverse-complement orientations after the 8,192-base input was truncated to 8,190 bases at Carbon's deterministic 6-mer boundary.
+The variant score was the negative mean REF-to-ALT causal log-likelihood difference, averaged across orientations.
+Carbon's raw means include prompt tokens, giving 1,365 post-first tokens without a tag, 1,373 with the mammalian prefix, and 1,370 with the fungal prefix.
+Cross-prompt score comparisons therefore multiply each raw score by its post-first token count divided by 1,365, yielding nats per common DNA target token.
+This rescaling does not change within-prompt AUPRC or pairwise Pearson correlation.
+
+Uncertainty used 1,000 seeded bootstrap draws over complete match groups.
+The same draw was used for both prompts in every paired AUPRC contrast.
+
+## Limitations
+
+- The experiment used development data and explored consequence-specific patterns on the same data.
+  It has no multiplicity correction or testing hierarchy.
+- One frozen Carbon-3B checkpoint and one human 8-kb context regime do not measure training-seed uncertainty, model-scale dependence, shorter-context behavior, or performance in low-resource taxa.
+- Comparing prompts at inference in one checkpoint cannot identify the causal effect of metadata-conditioned pretraining.
+- The mammalian and fungal prefixes differ in token count and content.
+  Common-denominator normalization removes the deterministic mean-likelihood scale difference but does not create an equal-length semantic control.
+- Pearson correlation and the relative prompt-change ratio have no uncertainty intervals here.
+  Pearson does not establish rank preservation or rank change, and the relative ratio is a diagnostic algebraically related to Pearson rather than independent evidence of noise.
+
+## Related questions
+
+- [Does conditioning on species/clade help?](../questions/species-conditioning.md)
+
+## Research record
+
+- [Experiment issue #486](https://github.com/Open-Athena/marin-dna/issues/486)

--- a/docs/research/experiments/figures/486/auprc-by-subset.svg
+++ b/docs/research/experiments/figures/486/auprc-by-subset.svg
@@ -1,0 +1,1710 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="842.4pt" height="424.8pt" viewBox="0 0 842.4 424.8" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-21T15:58:51.277301</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 424.8
+L 842.4 424.8
+L 842.4 0
+L 0 0
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 47.64 365.579746
+L 831.6 365.579746
+L 831.6 26.16
+L 47.64 26.16
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="mb3416c01e2" d="M 0 0
+L 0 3.5
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mb3416c01e2" x="112.697565" y="365.579746" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- Macro Avg -->
+      <g transform="translate(108.898737 379.159509) rotate(-330) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 628 4666
+L 1569 4666
+L 2759 1491
+L 3956 4666
+L 4897 4666
+L 4897 0
+L 4281 0
+L 4281 4097
+L 3078 897
+L 2444 897
+L 1241 4097
+L 1241 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-44" d="M 2194 1759
+Q 1497 1759 1228 1600
+Q 959 1441 959 1056
+Q 959 750 1161 570
+Q 1363 391 1709 391
+Q 2188 391 2477 730
+Q 2766 1069 2766 1631
+L 2766 1759
+L 2194 1759
+z
+M 3341 1997
+L 3341 0
+L 2766 0
+L 2766 531
+Q 2569 213 2275 61
+Q 1981 -91 1556 -91
+Q 1019 -91 701 211
+Q 384 513 384 1019
+Q 384 1609 779 1909
+Q 1175 2209 1959 2209
+L 2766 2209
+L 2766 2266
+Q 2766 2663 2505 2880
+Q 2244 3097 1772 3097
+Q 1472 3097 1187 3025
+Q 903 2953 641 2809
+L 641 3341
+Q 956 3463 1253 3523
+Q 1550 3584 1831 3584
+Q 2591 3584 2966 3190
+Q 3341 2797 3341 1997
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-46" d="M 3122 3366
+L 3122 2828
+Q 2878 2963 2633 3030
+Q 2388 3097 2138 3097
+Q 1578 3097 1268 2742
+Q 959 2388 959 1747
+Q 959 1106 1268 751
+Q 1578 397 2138 397
+Q 2388 397 2633 464
+Q 2878 531 3122 666
+L 3122 134
+Q 2881 22 2623 -34
+Q 2366 -91 2075 -91
+Q 1284 -91 818 406
+Q 353 903 353 1747
+Q 353 2603 823 3093
+Q 1294 3584 2113 3584
+Q 2378 3584 2631 3529
+Q 2884 3475 3122 3366
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-55" d="M 2631 2963
+Q 2534 3019 2420 3045
+Q 2306 3072 2169 3072
+Q 1681 3072 1420 2755
+Q 1159 2438 1159 1844
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1341 3275 1631 3429
+Q 1922 3584 2338 3584
+Q 2397 3584 2469 3576
+Q 2541 3569 2628 3553
+L 2631 2963
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-52" d="M 1959 3097
+Q 1497 3097 1228 2736
+Q 959 2375 959 1747
+Q 959 1119 1226 758
+Q 1494 397 1959 397
+Q 2419 397 2687 759
+Q 2956 1122 2956 1747
+Q 2956 2369 2687 2733
+Q 2419 3097 1959 3097
+z
+M 1959 3584
+Q 2709 3584 3137 3096
+Q 3566 2609 3566 1747
+Q 3566 888 3137 398
+Q 2709 -91 1959 -91
+Q 1206 -91 779 398
+Q 353 888 353 1747
+Q 353 2609 779 3096
+Q 1206 3584 1959 3584
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-3" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-24" d="M 2188 4044
+L 1331 1722
+L 3047 1722
+L 2188 4044
+z
+M 1831 4666
+L 2547 4666
+L 4325 0
+L 3669 0
+L 3244 1197
+L 1141 1197
+L 716 0
+L 50 0
+L 1831 4666
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-59" d="M 191 3500
+L 800 3500
+L 1894 563
+L 2988 3500
+L 3597 3500
+L 2284 0
+L 1503 0
+L 191 3500
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4a" d="M 2906 1791
+Q 2906 2416 2648 2759
+Q 2391 3103 1925 3103
+Q 1463 3103 1205 2759
+Q 947 2416 947 1791
+Q 947 1169 1205 825
+Q 1463 481 1925 481
+Q 2391 481 2648 825
+Q 2906 1169 2906 1791
+z
+M 3481 434
+Q 3481 -459 3084 -895
+Q 2688 -1331 1869 -1331
+Q 1566 -1331 1297 -1286
+Q 1028 -1241 775 -1147
+L 775 -588
+Q 1028 -725 1275 -790
+Q 1522 -856 1778 -856
+Q 2344 -856 2625 -561
+Q 2906 -266 2906 331
+L 2906 616
+Q 2728 306 2450 153
+Q 2172 0 1784 0
+Q 1141 0 747 490
+Q 353 981 353 1791
+Q 353 2603 747 3093
+Q 1141 3584 1784 3584
+Q 2172 3584 2450 3431
+Q 2728 3278 2906 2969
+L 2906 3500
+L 3481 3500
+L 3481 434
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-44" transform="translate(86.28125 0)"/>
+       <use xlink:href="#DejaVuSans-46" transform="translate(147.5625 0)"/>
+       <use xlink:href="#DejaVuSans-55" transform="translate(202.546875 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(241.453125 0)"/>
+       <use xlink:href="#DejaVuSans-3" transform="translate(302.640625 0)"/>
+       <use xlink:href="#DejaVuSans-24" transform="translate(334.421875 0)"/>
+       <use xlink:href="#DejaVuSans-59" transform="translate(396.96875 0)"/>
+       <use xlink:href="#DejaVuSans-4a" transform="translate(456.15625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#mb3416c01e2" x="194.428173" y="365.579746" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- Missense -->
+      <g transform="translate(190.628955 379.160186) rotate(-330) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-4c" d="M 603 3500
+L 1178 3500
+L 1178 0
+L 603 0
+L 603 3500
+z
+M 603 4863
+L 1178 4863
+L 1178 4134
+L 603 4134
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-56" d="M 2834 3397
+L 2834 2853
+Q 2591 2978 2328 3040
+Q 2066 3103 1784 3103
+Q 1356 3103 1142 2972
+Q 928 2841 928 2578
+Q 928 2378 1081 2264
+Q 1234 2150 1697 2047
+L 1894 2003
+Q 2506 1872 2764 1633
+Q 3022 1394 3022 966
+Q 3022 478 2636 193
+Q 2250 -91 1575 -91
+Q 1294 -91 989 -36
+Q 684 19 347 128
+L 347 722
+Q 666 556 975 473
+Q 1284 391 1588 391
+Q 1994 391 2212 530
+Q 2431 669 2431 922
+Q 2431 1156 2273 1281
+Q 2116 1406 1581 1522
+L 1381 1569
+Q 847 1681 609 1914
+Q 372 2147 372 2553
+Q 372 3047 722 3315
+Q 1072 3584 1716 3584
+Q 2034 3584 2315 3537
+Q 2597 3491 2834 3397
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-48" d="M 3597 1894
+L 3597 1613
+L 953 1613
+Q 991 1019 1311 708
+Q 1631 397 2203 397
+Q 2534 397 2845 478
+Q 3156 559 3463 722
+L 3463 178
+Q 3153 47 2828 -22
+Q 2503 -91 2169 -91
+Q 1331 -91 842 396
+Q 353 884 353 1716
+Q 353 2575 817 3079
+Q 1281 3584 2069 3584
+Q 2775 3584 3186 3129
+Q 3597 2675 3597 1894
+z
+M 3022 2063
+Q 3016 2534 2758 2815
+Q 2500 3097 2075 3097
+Q 1594 3097 1305 2825
+Q 1016 2553 972 2059
+L 3022 2063
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-51" d="M 3513 2113
+L 3513 0
+L 2938 0
+L 2938 2094
+Q 2938 2591 2744 2837
+Q 2550 3084 2163 3084
+Q 1697 3084 1428 2787
+Q 1159 2491 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1366 3272 1645 3428
+Q 1925 3584 2291 3584
+Q 2894 3584 3203 3211
+Q 3513 2838 3513 2113
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-4c" transform="translate(86.28125 0)"/>
+       <use xlink:href="#DejaVuSans-56" transform="translate(114.0625 0)"/>
+       <use xlink:href="#DejaVuSans-56" transform="translate(166.15625 0)"/>
+       <use xlink:href="#DejaVuSans-48" transform="translate(218.25 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(279.78125 0)"/>
+       <use xlink:href="#DejaVuSans-56" transform="translate(343.15625 0)"/>
+       <use xlink:href="#DejaVuSans-48" transform="translate(395.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#mb3416c01e2" x="276.158782" y="365.579746" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- Splicing -->
+      <g transform="translate(272.359564 379.160186) rotate(-330) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 3425 4513
+L 3425 3897
+Q 3066 4069 2747 4153
+Q 2428 4238 2131 4238
+Q 1616 4238 1336 4038
+Q 1056 3838 1056 3469
+Q 1056 3159 1242 3001
+Q 1428 2844 1947 2747
+L 2328 2669
+Q 3034 2534 3370 2195
+Q 3706 1856 3706 1288
+Q 3706 609 3251 259
+Q 2797 -91 1919 -91
+Q 1588 -91 1214 -16
+Q 841 59 441 206
+L 441 856
+Q 825 641 1194 531
+Q 1563 422 1919 422
+Q 2459 422 2753 634
+Q 3047 847 3047 1241
+Q 3047 1584 2836 1778
+Q 2625 1972 2144 2069
+L 1759 2144
+Q 1053 2284 737 2584
+Q 422 2884 422 3419
+Q 422 4038 858 4394
+Q 1294 4750 2059 4750
+Q 2388 4750 2728 4690
+Q 3069 4631 3425 4513
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-53" d="M 1159 525
+L 1159 -1331
+L 581 -1331
+L 581 3500
+L 1159 3500
+L 1159 2969
+Q 1341 3281 1617 3432
+Q 1894 3584 2278 3584
+Q 2916 3584 3314 3078
+Q 3713 2572 3713 1747
+Q 3713 922 3314 415
+Q 2916 -91 2278 -91
+Q 1894 -91 1617 61
+Q 1341 213 1159 525
+z
+M 3116 1747
+Q 3116 2381 2855 2742
+Q 2594 3103 2138 3103
+Q 1681 3103 1420 2742
+Q 1159 2381 1159 1747
+Q 1159 1113 1420 752
+Q 1681 391 2138 391
+Q 2594 391 2855 752
+Q 3116 1113 3116 1747
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4f" d="M 603 4863
+L 1178 4863
+L 1178 0
+L 603 0
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-53" transform="translate(63.484375 0)"/>
+       <use xlink:href="#DejaVuSans-4f" transform="translate(126.96875 0)"/>
+       <use xlink:href="#DejaVuSans-4c" transform="translate(154.75 0)"/>
+       <use xlink:href="#DejaVuSans-46" transform="translate(182.53125 0)"/>
+       <use xlink:href="#DejaVuSans-4c" transform="translate(237.515625 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(265.296875 0)"/>
+       <use xlink:href="#DejaVuSans-4a" transform="translate(328.671875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mb3416c01e2" x="357.889391" y="365.579746" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- Synonymous -->
+      <g transform="translate(354.090563 379.159509) rotate(-330) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-5c" d="M 2059 -325
+Q 1816 -950 1584 -1140
+Q 1353 -1331 966 -1331
+L 506 -1331
+L 506 -850
+L 844 -850
+Q 1081 -850 1212 -737
+Q 1344 -625 1503 -206
+L 1606 56
+L 191 3500
+L 800 3500
+L 1894 763
+L 2988 3500
+L 3597 3500
+L 2059 -325
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-50" d="M 3328 2828
+Q 3544 3216 3844 3400
+Q 4144 3584 4550 3584
+Q 5097 3584 5394 3201
+Q 5691 2819 5691 2113
+L 5691 0
+L 5113 0
+L 5113 2094
+Q 5113 2597 4934 2840
+Q 4756 3084 4391 3084
+Q 3944 3084 3684 2787
+Q 3425 2491 3425 1978
+L 3425 0
+L 2847 0
+L 2847 2094
+Q 2847 2600 2669 2842
+Q 2491 3084 2119 3084
+Q 1678 3084 1418 2786
+Q 1159 2488 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1356 3278 1631 3431
+Q 1906 3584 2284 3584
+Q 2666 3584 2933 3390
+Q 3200 3197 3328 2828
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-58" d="M 544 1381
+L 544 3500
+L 1119 3500
+L 1119 1403
+Q 1119 906 1312 657
+Q 1506 409 1894 409
+Q 2359 409 2629 706
+Q 2900 1003 2900 1516
+L 2900 3500
+L 3475 3500
+L 3475 0
+L 2900 0
+L 2900 538
+Q 2691 219 2414 64
+Q 2138 -91 1772 -91
+Q 1169 -91 856 284
+Q 544 659 544 1381
+z
+M 1991 3584
+L 1991 3584
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-5c" transform="translate(63.484375 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(122.671875 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(186.046875 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(247.234375 0)"/>
+       <use xlink:href="#DejaVuSans-5c" transform="translate(310.609375 0)"/>
+       <use xlink:href="#DejaVuSans-50" transform="translate(369.796875 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(467.203125 0)"/>
+       <use xlink:href="#DejaVuSans-58" transform="translate(528.390625 0)"/>
+       <use xlink:href="#DejaVuSans-56" transform="translate(591.765625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#mb3416c01e2" x="439.62" y="365.579746" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- Promoter -->
+      <g transform="translate(435.821172 379.159509) rotate(-330) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 1259 4147
+L 1259 2394
+L 2053 2394
+Q 2494 2394 2734 2622
+Q 2975 2850 2975 3272
+Q 2975 3691 2734 3919
+Q 2494 4147 2053 4147
+L 1259 4147
+z
+M 628 4666
+L 2053 4666
+Q 2838 4666 3239 4311
+Q 3641 3956 3641 3272
+Q 3641 2581 3239 2228
+Q 2838 1875 2053 1875
+L 1259 1875
+L 1259 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-57" d="M 1172 4494
+L 1172 3500
+L 2356 3500
+L 2356 3053
+L 1172 3053
+L 1172 1153
+Q 1172 725 1289 603
+Q 1406 481 1766 481
+L 2356 481
+L 2356 0
+L 1766 0
+Q 1100 0 847 248
+Q 594 497 594 1153
+L 594 3053
+L 172 3053
+L 172 3500
+L 594 3500
+L 594 4494
+L 1172 4494
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-55" transform="translate(58.546875 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(97.453125 0)"/>
+       <use xlink:href="#DejaVuSans-50" transform="translate(158.640625 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(256.046875 0)"/>
+       <use xlink:href="#DejaVuSans-57" transform="translate(317.234375 0)"/>
+       <use xlink:href="#DejaVuSans-48" transform="translate(356.4375 0)"/>
+       <use xlink:href="#DejaVuSans-55" transform="translate(417.96875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mb3416c01e2" x="521.350609" y="365.579746" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 5' UTR -->
+      <g transform="translate(517.551781 379.159509) rotate(-330) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-18" d="M 691 4666
+L 3169 4666
+L 3169 4134
+L 1269 4134
+L 1269 2991
+Q 1406 3038 1543 3061
+Q 1681 3084 1819 3084
+Q 2600 3084 3056 2656
+Q 3513 2228 3513 1497
+Q 3513 744 3044 326
+Q 2575 -91 1722 -91
+Q 1428 -91 1123 -41
+Q 819 9 494 109
+L 494 744
+Q 775 591 1075 516
+Q 1375 441 1709 441
+Q 2250 441 2565 725
+Q 2881 1009 2881 1497
+Q 2881 1984 2565 2268
+Q 2250 2553 1709 2553
+Q 1456 2553 1204 2497
+Q 953 2441 691 2322
+L 691 4666
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-a" d="M 1147 4666
+L 1147 2931
+L 616 2931
+L 616 4666
+L 1147 4666
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-38" d="M 556 4666
+L 1191 4666
+L 1191 1831
+Q 1191 1081 1462 751
+Q 1734 422 2344 422
+Q 2950 422 3222 751
+Q 3494 1081 3494 1831
+L 3494 4666
+L 4128 4666
+L 4128 1753
+Q 4128 841 3676 375
+Q 3225 -91 2344 -91
+Q 1459 -91 1007 375
+Q 556 841 556 1753
+L 556 4666
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-37" d="M -19 4666
+L 3928 4666
+L 3928 4134
+L 2272 4134
+L 2272 0
+L 1638 0
+L 1638 4134
+L -19 4134
+L -19 4666
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-35" d="M 2841 2188
+Q 3044 2119 3236 1894
+Q 3428 1669 3622 1275
+L 4263 0
+L 3584 0
+L 2988 1197
+Q 2756 1666 2539 1819
+Q 2322 1972 1947 1972
+L 1259 1972
+L 1259 0
+L 628 0
+L 628 4666
+L 2053 4666
+Q 2853 4666 3247 4331
+Q 3641 3997 3641 3322
+Q 3641 2881 3436 2590
+Q 3231 2300 2841 2188
+z
+M 1259 4147
+L 1259 2491
+L 2053 2491
+Q 2509 2491 2742 2702
+Q 2975 2913 2975 3322
+Q 2975 3731 2742 3939
+Q 2509 4147 2053 4147
+L 1259 4147
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-18"/>
+       <use xlink:href="#DejaVuSans-a" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-3" transform="translate(91.109375 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(122.890625 0)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(196.078125 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(257.15625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#mb3416c01e2" x="603.081218" y="365.579746" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 3' UTR -->
+      <g transform="translate(599.28239 379.159509) rotate(-330) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-16" d="M 2597 2516
+Q 3050 2419 3304 2112
+Q 3559 1806 3559 1356
+Q 3559 666 3084 287
+Q 2609 -91 1734 -91
+Q 1441 -91 1130 -33
+Q 819 25 488 141
+L 488 750
+Q 750 597 1062 519
+Q 1375 441 1716 441
+Q 2309 441 2620 675
+Q 2931 909 2931 1356
+Q 2931 1769 2642 2001
+Q 2353 2234 1838 2234
+L 1294 2234
+L 1294 2753
+L 1863 2753
+Q 2328 2753 2575 2939
+Q 2822 3125 2822 3475
+Q 2822 3834 2567 4026
+Q 2313 4219 1838 4219
+Q 1578 4219 1281 4162
+Q 984 4106 628 3988
+L 628 4550
+Q 988 4650 1302 4700
+Q 1616 4750 1894 4750
+Q 2613 4750 3031 4423
+Q 3450 4097 3450 3541
+Q 3450 3153 3228 2886
+Q 3006 2619 2597 2516
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-16"/>
+       <use xlink:href="#DejaVuSans-a" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-3" transform="translate(91.109375 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(122.890625 0)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(196.078125 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(257.15625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#mb3416c01e2" x="684.811827" y="365.579746" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- Distal -->
+      <g transform="translate(681.012608 379.160186) rotate(-330) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-27" d="M 1259 4147
+L 1259 519
+L 2022 519
+Q 2988 519 3436 956
+Q 3884 1394 3884 2338
+Q 3884 3275 3436 3711
+Q 2988 4147 2022 4147
+L 1259 4147
+z
+M 628 4666
+L 1925 4666
+Q 3281 4666 3915 4102
+Q 4550 3538 4550 2338
+Q 4550 1131 3912 565
+Q 3275 0 1925 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-27"/>
+       <use xlink:href="#DejaVuSans-4c" transform="translate(77 0)"/>
+       <use xlink:href="#DejaVuSans-56" transform="translate(104.78125 0)"/>
+       <use xlink:href="#DejaVuSans-57" transform="translate(156.875 0)"/>
+       <use xlink:href="#DejaVuSans-44" transform="translate(196.078125 0)"/>
+       <use xlink:href="#DejaVuSans-4f" transform="translate(257.359375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#mb3416c01e2" x="766.542435" y="365.579746" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- ncRNA -->
+      <g transform="translate(762.743607 379.159509) rotate(-330) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 628 4666
+L 1478 4666
+L 3547 763
+L 3547 4666
+L 4159 4666
+L 4159 0
+L 3309 0
+L 1241 3903
+L 1241 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-46" transform="translate(63.375 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(118.359375 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(187.84375 0)"/>
+       <use xlink:href="#DejaVuSans-24" transform="translate(262.65625 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_10">
+      <path d="M 47.64 365.579746
+L 831.6 365.579746
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #dddddd; stroke-width: 0.7; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11">
+      <defs>
+       <path id="m5c05124bbc" d="M 0 0
+L -3.5 0
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m5c05124bbc" x="47.64" y="365.579746" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0.1 -->
+      <g transform="translate(24.736875 369.378574) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-13" d="M 2034 4250
+Q 1547 4250 1301 3770
+Q 1056 3291 1056 2328
+Q 1056 1369 1301 889
+Q 1547 409 2034 409
+Q 2525 409 2770 889
+Q 3016 1369 3016 2328
+Q 3016 3291 2770 3770
+Q 2525 4250 2034 4250
+z
+M 2034 4750
+Q 2819 4750 3233 4129
+Q 3647 3509 3647 2328
+Q 3647 1150 3233 529
+Q 2819 -91 2034 -91
+Q 1250 -91 836 529
+Q 422 1150 422 2328
+Q 422 3509 836 4129
+Q 1250 4750 2034 4750
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-11" d="M 684 794
+L 1344 794
+L 1344 0
+L 684 0
+L 684 794
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-14" d="M 794 531
+L 1825 531
+L 1825 4091
+L 703 3866
+L 703 4441
+L 1819 4666
+L 2450 4666
+L 2450 531
+L 3481 531
+L 3481 0
+L 794 0
+L 794 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-14" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_12">
+      <path d="M 47.64 311.703596
+L 831.6 311.703596
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #dddddd; stroke-width: 0.7; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m5c05124bbc" x="47.64" y="311.703596" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 0.2 -->
+      <g transform="translate(24.736875 315.502424) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-15" d="M 1228 531
+L 3431 531
+L 3431 0
+L 469 0
+L 469 531
+Q 828 903 1448 1529
+Q 2069 2156 2228 2338
+Q 2531 2678 2651 2914
+Q 2772 3150 2772 3378
+Q 2772 3750 2511 3984
+Q 2250 4219 1831 4219
+Q 1534 4219 1204 4116
+Q 875 4013 500 3803
+L 500 4441
+Q 881 4594 1212 4672
+Q 1544 4750 1819 4750
+Q 2544 4750 2975 4387
+Q 3406 4025 3406 3419
+Q 3406 3131 3298 2873
+Q 3191 2616 2906 2266
+Q 2828 2175 2409 1742
+Q 1991 1309 1228 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_14">
+      <path d="M 47.64 257.827446
+L 831.6 257.827446
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #dddddd; stroke-width: 0.7; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m5c05124bbc" x="47.64" y="257.827446" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 0.3 -->
+      <g transform="translate(24.736875 261.626274) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-16" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_16">
+      <path d="M 47.64 203.951296
+L 831.6 203.951296
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #dddddd; stroke-width: 0.7; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m5c05124bbc" x="47.64" y="203.951296" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 0.4 -->
+      <g transform="translate(24.736875 207.750124) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-17" d="M 2419 4116
+L 825 1625
+L 2419 1625
+L 2419 4116
+z
+M 2253 4666
+L 3047 4666
+L 3047 1625
+L 3713 1625
+L 3713 1100
+L 3047 1100
+L 3047 0
+L 2419 0
+L 2419 1100
+L 313 1100
+L 313 1709
+L 2253 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_18">
+      <path d="M 47.64 150.075145
+L 831.6 150.075145
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #dddddd; stroke-width: 0.7; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m5c05124bbc" x="47.64" y="150.075145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 0.5 -->
+      <g transform="translate(24.736875 153.873973) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_20">
+      <path d="M 47.64 96.198995
+L 831.6 96.198995
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #dddddd; stroke-width: 0.7; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m5c05124bbc" x="47.64" y="96.198995" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 0.6 -->
+      <g transform="translate(24.736875 99.997823) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-19" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_22">
+      <path d="M 47.64 42.322845
+L 831.6 42.322845
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #dddddd; stroke-width: 0.7; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m5c05124bbc" x="47.64" y="42.322845" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 0.7 -->
+      <g transform="translate(24.736875 46.121673) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-1a" d="M 525 4666
+L 3525 4666
+L 3525 4397
+L 1831 0
+L 1172 0
+L 2766 4134
+L 525 4134
+L 525 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-1a" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_17">
+     <!-- AUPRC -->
+     <g transform="translate(18.334531 212.68081) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-26" d="M 4122 4306
+L 4122 3641
+Q 3803 3938 3442 4084
+Q 3081 4231 2675 4231
+Q 1875 4231 1450 3742
+Q 1025 3253 1025 2328
+Q 1025 1406 1450 917
+Q 1875 428 2675 428
+Q 3081 428 3442 575
+Q 3803 722 4122 1019
+L 4122 359
+Q 3791 134 3420 21
+Q 3050 -91 2638 -91
+Q 1578 -91 968 557
+Q 359 1206 359 2328
+Q 359 3453 968 4101
+Q 1578 4750 2638 4750
+Q 3056 4750 3426 4639
+Q 3797 4528 4122 4306
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-24"/>
+      <use xlink:href="#DejaVuSans-38" transform="translate(68.40625 0)"/>
+      <use xlink:href="#DejaVuSans-33" transform="translate(141.59375 0)"/>
+      <use xlink:href="#DejaVuSans-35" transform="translate(201.890625 0)"/>
+      <use xlink:href="#DejaVuSans-26" transform="translate(266.390625 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 83.274545 419.455896
+L 102.889892 419.455896
+L 102.889892 226.471554
+L 83.274545 226.471554
+z
+" clip-path="url(#p90e7c21085)" style="fill: #7f7f7f; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 165.005154 419.455896
+L 184.6205 419.455896
+L 184.6205 178.994779
+L 165.005154 178.994779
+z
+" clip-path="url(#p90e7c21085)" style="fill: #7f7f7f; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 246.735763 419.455896
+L 266.351109 419.455896
+L 266.351109 49.618854
+L 246.735763 49.618854
+z
+" clip-path="url(#p90e7c21085)" style="fill: #7f7f7f; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 328.466372 419.455896
+L 348.081718 419.455896
+L 348.081718 105.891514
+L 328.466372 105.891514
+z
+" clip-path="url(#p90e7c21085)" style="fill: #7f7f7f; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 410.196981 419.455896
+L 429.812327 419.455896
+L 429.812327 323.820423
+L 410.196981 323.820423
+z
+" clip-path="url(#p90e7c21085)" style="fill: #7f7f7f; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 491.92759 419.455896
+L 511.542936 419.455896
+L 511.542936 218.617359
+L 491.92759 218.617359
+z
+" clip-path="url(#p90e7c21085)" style="fill: #7f7f7f; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 573.658198 419.455896
+L 593.273545 419.455896
+L 593.273545 226.804691
+L 573.658198 226.804691
+z
+" clip-path="url(#p90e7c21085)" style="fill: #7f7f7f; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 655.388807 419.455896
+L 675.004153 419.455896
+L 675.004153 343.025439
+L 655.388807 343.025439
+z
+" clip-path="url(#p90e7c21085)" style="fill: #7f7f7f; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 737.119416 419.455896
+L 756.734762 419.455896
+L 756.734762 364.999374
+L 737.119416 364.999374
+z
+" clip-path="url(#p90e7c21085)" style="fill: #7f7f7f; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 102.889892 419.455896
+L 122.505238 419.455896
+L 122.505238 228.097466
+L 102.889892 228.097466
+z
+" clip-path="url(#p90e7c21085)" style="fill: #4c72b0; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 184.6205 419.455896
+L 204.235847 419.455896
+L 204.235847 183.627663
+L 184.6205 183.627663
+z
+" clip-path="url(#p90e7c21085)" style="fill: #4c72b0; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 266.351109 419.455896
+L 285.966455 419.455896
+L 285.966455 57.978207
+L 266.351109 57.978207
+z
+" clip-path="url(#p90e7c21085)" style="fill: #4c72b0; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 348.081718 419.455896
+L 367.697064 419.455896
+L 367.697064 120.424835
+L 348.081718 120.424835
+z
+" clip-path="url(#p90e7c21085)" style="fill: #4c72b0; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 429.812327 419.455896
+L 449.427673 419.455896
+L 449.427673 325.825648
+L 429.812327 325.825648
+z
+" clip-path="url(#p90e7c21085)" style="fill: #4c72b0; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 511.542936 419.455896
+L 531.158282 419.455896
+L 531.158282 228.713175
+L 511.542936 228.713175
+z
+" clip-path="url(#p90e7c21085)" style="fill: #4c72b0; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 593.273545 419.455896
+L 612.888891 419.455896
+L 612.888891 210.824
+L 593.273545 210.824
+z
+" clip-path="url(#p90e7c21085)" style="fill: #4c72b0; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 675.004153 419.455896
+L 694.6195 419.455896
+L 694.6195 336.075337
+L 675.004153 336.075337
+z
+" clip-path="url(#p90e7c21085)" style="fill: #4c72b0; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 756.734762 419.455896
+L 776.350108 419.455896
+L 776.350108 361.310863
+L 756.734762 361.310863
+z
+" clip-path="url(#p90e7c21085)" style="fill: #4c72b0; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 122.505238 419.455896
+L 142.120584 419.455896
+L 142.120584 226.176278
+L 122.505238 226.176278
+z
+" clip-path="url(#p90e7c21085)" style="fill: #dd8452; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 204.235847 419.455896
+L 223.851193 419.455896
+L 223.851193 181.803869
+L 204.235847 181.803869
+z
+" clip-path="url(#p90e7c21085)" style="fill: #dd8452; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 285.966455 419.455896
+L 305.581802 419.455896
+L 305.581802 49.828072
+L 285.966455 49.828072
+z
+" clip-path="url(#p90e7c21085)" style="fill: #dd8452; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 367.697064 419.455896
+L 387.31241 419.455896
+L 387.31241 126.796611
+L 367.697064 126.796611
+z
+" clip-path="url(#p90e7c21085)" style="fill: #dd8452; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 449.427673 419.455896
+L 469.043019 419.455896
+L 469.043019 337.334837
+L 449.427673 337.334837
+z
+" clip-path="url(#p90e7c21085)" style="fill: #dd8452; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 531.158282 419.455896
+L 550.773628 419.455896
+L 550.773628 228.545964
+L 531.158282 228.545964
+z
+" clip-path="url(#p90e7c21085)" style="fill: #dd8452; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 612.888891 419.455896
+L 632.504237 419.455896
+L 632.504237 192.107649
+L 612.888891 192.107649
+z
+" clip-path="url(#p90e7c21085)" style="fill: #dd8452; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 694.6195 419.455896
+L 714.234846 419.455896
+L 714.234846 332.237879
+L 694.6195 332.237879
+z
+" clip-path="url(#p90e7c21085)" style="fill: #dd8452; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 776.350108 419.455896
+L 795.965455 419.455896
+L 795.965455 360.755346
+L 776.350108 360.755346
+z
+" clip-path="url(#p90e7c21085)" style="fill: #dd8452; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_1">
+    <path d="M 93.082219 233.343654
+L 93.082219 219.599455
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 174.812827 189.448644
+L 174.812827 168.540914
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 256.543436 63.371471
+L 256.543436 35.866237
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 338.274045 138.530146
+L 338.274045 73.252882
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 420.004654 336.121927
+L 420.004654 311.518919
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 501.735263 236.079985
+L 501.735263 201.154733
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 583.465872 256.656399
+L 583.465872 196.952984
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 665.19648 362.00397
+L 665.19648 324.046908
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 746.927089 371.782297
+L 746.927089 358.216452
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+   </g>
+   <g id="LineCollection_2">
+    <path d="M 112.697565 235.138087
+L 112.697565 221.056845
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 194.428173 194.004666
+L 194.428173 173.250661
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 276.158782 71.502889
+L 276.158782 44.453526
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 357.889391 153.495984
+L 357.889391 87.353686
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 439.62 337.756584
+L 439.62 313.894712
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 521.350609 245.957952
+L 521.350609 211.468399
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 603.081218 242.787281
+L 603.081218 178.86072
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 684.811827 354.445695
+L 684.811827 317.704978
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 766.542435 368.754516
+L 766.542435 353.867209
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+   </g>
+   <g id="LineCollection_3">
+    <path d="M 132.312911 233.178192
+L 132.312911 219.174365
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 214.04352 192.292837
+L 214.04352 171.3149
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 295.774128 63.263719
+L 295.774128 36.392425
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 377.504737 158.449449
+L 377.504737 95.143774
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 459.235346 347.467655
+L 459.235346 327.202018
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 540.965955 246.329834
+L 540.965955 210.762094
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 622.696564 224.344498
+L 622.696564 159.870801
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 704.427173 352.897789
+L 704.427173 311.577969
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+    <path d="M 786.157781 368.541135
+L 786.157781 352.969558
+" clip-path="url(#p90e7c21085)" style="fill: none; stroke: #333333"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 47.64 365.579746
+L 47.64 26.16
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 831.6 365.579746
+L 831.6 26.16
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 47.64 365.579746
+L 831.6 365.579746
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 47.64 26.16
+L 831.6 26.16
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_18">
+    <!-- Mendelian AUPRC by prompt and variant subset -->
+    <g transform="translate(295.45125 20.16) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-47" d="M 2906 2969
+L 2906 4863
+L 3481 4863
+L 3481 0
+L 2906 0
+L 2906 525
+Q 2725 213 2448 61
+Q 2172 -91 1784 -91
+Q 1150 -91 751 415
+Q 353 922 353 1747
+Q 353 2572 751 3078
+Q 1150 3584 1784 3584
+Q 2172 3584 2448 3432
+Q 2725 3281 2906 2969
+z
+M 947 1747
+Q 947 1113 1208 752
+Q 1469 391 1925 391
+Q 2381 391 2643 752
+Q 2906 1113 2906 1747
+Q 2906 2381 2643 2742
+Q 2381 3103 1925 3103
+Q 1469 3103 1208 2742
+Q 947 2381 947 1747
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-45" d="M 3116 1747
+Q 3116 2381 2855 2742
+Q 2594 3103 2138 3103
+Q 1681 3103 1420 2742
+Q 1159 2381 1159 1747
+Q 1159 1113 1420 752
+Q 1681 391 2138 391
+Q 2594 391 2855 752
+Q 3116 1113 3116 1747
+z
+M 1159 2969
+Q 1341 3281 1617 3432
+Q 1894 3584 2278 3584
+Q 2916 3584 3314 3078
+Q 3713 2572 3713 1747
+Q 3713 922 3314 415
+Q 2916 -91 2278 -91
+Q 1894 -91 1617 61
+Q 1341 213 1159 525
+L 1159 0
+L 581 0
+L 581 4863
+L 1159 4863
+L 1159 2969
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(86.28125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(147.8125 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(211.1875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(274.671875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(336.203125 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(363.984375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(391.765625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(453.046875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(516.421875 0)"/>
+     <use xlink:href="#DejaVuSans-24" transform="translate(548.203125 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(616.609375 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(689.796875 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(750.09375 0)"/>
+     <use xlink:href="#DejaVuSans-26" transform="translate(814.59375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(884.421875 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(916.203125 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(979.6875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1038.875 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1070.65625 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1134.140625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1173.046875 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(1234.234375 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1331.640625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1395.125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1434.328125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1466.109375 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1527.390625 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1590.765625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1654.25 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(1686.03125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1745.21875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1806.5 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1847.609375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1875.390625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1936.671875 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(2000.046875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2039.25 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(2071.03125 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(2123.125 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(2186.5 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(2249.984375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2302.078125 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(2363.609375 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_34">
+     <path d="M 695.421875 42.758438
+L 715.421875 42.758438
+L 715.421875 35.758438
+L 695.421875 35.758438
+z
+" style="fill: #7f7f7f; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_19">
+     <!-- No tag -->
+     <g transform="translate(723.421875 42.758438) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-31"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(74.8125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(136 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(167.78125 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(206.984375 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(268.265625 0)"/>
+     </g>
+    </g>
+    <g id="patch_35">
+     <path d="M 695.421875 57.759219
+L 715.421875 57.759219
+L 715.421875 50.759219
+L 695.421875 50.759219
+z
+" style="fill: #4c72b0; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_20">
+     <!-- Correct mammalian -->
+     <g transform="translate(723.421875 57.759219) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-26"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(69.828125 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(131.015625 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(170.375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(209.28125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(270.8125 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(325.796875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(365 0)"/>
+      <use xlink:href="#DejaVuSans-50" transform="translate(396.78125 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(494.1875 0)"/>
+      <use xlink:href="#DejaVuSans-50" transform="translate(555.46875 0)"/>
+      <use xlink:href="#DejaVuSans-50" transform="translate(652.875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(750.28125 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(811.5625 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(839.34375 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(867.125 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(928.40625 0)"/>
+     </g>
+    </g>
+    <g id="patch_36">
+     <path d="M 695.421875 72.76
+L 715.421875 72.76
+L 715.421875 65.76
+L 695.421875 65.76
+z
+" style="fill: #dd8452; stroke: #ffffff; stroke-width: 0.7; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_21">
+     <!-- Far-wrong fungal -->
+     <g transform="translate(723.421875 72.76) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-29" d="M 628 4666
+L 3309 4666
+L 3309 4134
+L 1259 4134
+L 1259 2759
+L 3109 2759
+L 3109 2228
+L 1259 2228
+L 1259 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-10" d="M 313 2009
+L 1997 2009
+L 1997 1497
+L 313 1497
+L 313 2009
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5a" d="M 269 3500
+L 844 3500
+L 1563 769
+L 2278 3500
+L 2956 3500
+L 3675 769
+L 4391 3500
+L 4966 3500
+L 4050 0
+L 3372 0
+L 2619 2869
+L 1863 0
+L 1184 0
+L 269 3500
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-49" d="M 2375 4863
+L 2375 4384
+L 1825 4384
+Q 1516 4384 1395 4259
+Q 1275 4134 1275 3809
+L 1275 3500
+L 2222 3500
+L 2222 3053
+L 1275 3053
+L 1275 0
+L 697 0
+L 697 3053
+L 147 3053
+L 147 3500
+L 697 3500
+L 697 3744
+Q 697 4328 969 4595
+Q 1241 4863 1831 4863
+L 2375 4863
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-29"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(48.34375 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(109.625 0)"/>
+      <use xlink:href="#DejaVuSans-10" transform="translate(144.34375 0)"/>
+      <use xlink:href="#DejaVuSans-5a" transform="translate(180.421875 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(262.203125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(301.109375 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(362.296875 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(425.671875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(489.15625 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(520.9375 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(556.140625 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(619.515625 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(682.890625 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(746.375 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(807.65625 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p90e7c21085">
+   <rect x="47.64" y="26.16" width="783.96" height="339.419746"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/research/experiments/figures/486/pearson-by-subset.svg
+++ b/docs/research/experiments/figures/486/pearson-by-subset.svg
@@ -1,0 +1,1522 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="843.604601pt" height="425.99952pt" viewBox="0 0 843.604601 425.99952" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-21T15:40:27.738485</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 425.99952
+L 843.604601 425.99952
+L 843.604601 0
+L 0 0
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 44.103125 370.946297
+L 641.08169 370.946297
+L 641.08169 22.318125
+L 44.103125 22.318125
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m83ecafbd94" d="M 0 0
+L 0 3.5
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m83ecafbd94" x="93.643882" y="370.946297" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- All variants -->
+      <g transform="translate(43.853272 412.579862) rotate(-30) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-24" d="M 2188 4044
+L 1331 1722
+L 3047 1722
+L 2188 4044
+z
+M 1831 4666
+L 2547 4666
+L 4325 0
+L 3669 0
+L 3244 1197
+L 1141 1197
+L 716 0
+L 50 0
+L 1831 4666
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4f" d="M 603 4863
+L 1178 4863
+L 1178 0
+L 603 0
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-3" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-59" d="M 191 3500
+L 800 3500
+L 1894 563
+L 2988 3500
+L 3597 3500
+L 2284 0
+L 1503 0
+L 191 3500
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-44" d="M 2194 1759
+Q 1497 1759 1228 1600
+Q 959 1441 959 1056
+Q 959 750 1161 570
+Q 1363 391 1709 391
+Q 2188 391 2477 730
+Q 2766 1069 2766 1631
+L 2766 1759
+L 2194 1759
+z
+M 3341 1997
+L 3341 0
+L 2766 0
+L 2766 531
+Q 2569 213 2275 61
+Q 1981 -91 1556 -91
+Q 1019 -91 701 211
+Q 384 513 384 1019
+Q 384 1609 779 1909
+Q 1175 2209 1959 2209
+L 2766 2209
+L 2766 2266
+Q 2766 2663 2505 2880
+Q 2244 3097 1772 3097
+Q 1472 3097 1187 3025
+Q 903 2953 641 2809
+L 641 3341
+Q 956 3463 1253 3523
+Q 1550 3584 1831 3584
+Q 2591 3584 2966 3190
+Q 3341 2797 3341 1997
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-55" d="M 2631 2963
+Q 2534 3019 2420 3045
+Q 2306 3072 2169 3072
+Q 1681 3072 1420 2755
+Q 1159 2438 1159 1844
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1341 3275 1631 3429
+Q 1922 3584 2338 3584
+Q 2397 3584 2469 3576
+Q 2541 3569 2628 3553
+L 2631 2963
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4c" d="M 603 3500
+L 1178 3500
+L 1178 0
+L 603 0
+L 603 3500
+z
+M 603 4863
+L 1178 4863
+L 1178 4134
+L 603 4134
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-51" d="M 3513 2113
+L 3513 0
+L 2938 0
+L 2938 2094
+Q 2938 2591 2744 2837
+Q 2550 3084 2163 3084
+Q 1697 3084 1428 2787
+Q 1159 2491 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1366 3272 1645 3428
+Q 1925 3584 2291 3584
+Q 2894 3584 3203 3211
+Q 3513 2838 3513 2113
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-57" d="M 1172 4494
+L 1172 3500
+L 2356 3500
+L 2356 3053
+L 1172 3053
+L 1172 1153
+Q 1172 725 1289 603
+Q 1406 481 1766 481
+L 2356 481
+L 2356 0
+L 1766 0
+Q 1100 0 847 248
+Q 594 497 594 1153
+L 594 3053
+L 172 3053
+L 172 3500
+L 594 3500
+L 594 4494
+L 1172 4494
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-56" d="M 2834 3397
+L 2834 2853
+Q 2591 2978 2328 3040
+Q 2066 3103 1784 3103
+Q 1356 3103 1142 2972
+Q 928 2841 928 2578
+Q 928 2378 1081 2264
+Q 1234 2150 1697 2047
+L 1894 2003
+Q 2506 1872 2764 1633
+Q 3022 1394 3022 966
+Q 3022 478 2636 193
+Q 2250 -91 1575 -91
+Q 1294 -91 989 -36
+Q 684 19 347 128
+L 347 722
+Q 666 556 975 473
+Q 1284 391 1588 391
+Q 1994 391 2212 530
+Q 2431 669 2431 922
+Q 2431 1156 2273 1281
+Q 2116 1406 1581 1522
+L 1381 1569
+Q 847 1681 609 1914
+Q 372 2147 372 2553
+Q 372 3047 722 3315
+Q 1072 3584 1716 3584
+Q 2034 3584 2315 3537
+Q 2597 3491 2834 3397
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-24"/>
+       <use xlink:href="#DejaVuSans-4f" transform="translate(68.40625 0)"/>
+       <use xlink:href="#DejaVuSans-4f" transform="translate(96.1875 0)"/>
+       <use xlink:href="#DejaVuSans-3" transform="translate(123.96875 0)"/>
+       <use xlink:href="#DejaVuSans-59" transform="translate(155.75 0)"/>
+       <use xlink:href="#DejaVuSans-44" transform="translate(214.9375 0)"/>
+       <use xlink:href="#DejaVuSans-55" transform="translate(276.21875 0)"/>
+       <use xlink:href="#DejaVuSans-4c" transform="translate(317.328125 0)"/>
+       <use xlink:href="#DejaVuSans-44" transform="translate(345.109375 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(406.390625 0)"/>
+       <use xlink:href="#DejaVuSans-57" transform="translate(469.765625 0)"/>
+       <use xlink:href="#DejaVuSans-56" transform="translate(508.96875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m83ecafbd94" x="155.881013" y="370.946297" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- Missense -->
+      <g transform="translate(115.121425 407.3658) rotate(-30) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 628 4666
+L 1569 4666
+L 2759 1491
+L 3956 4666
+L 4897 4666
+L 4897 0
+L 4281 0
+L 4281 4097
+L 3078 897
+L 2444 897
+L 1241 4097
+L 1241 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-48" d="M 3597 1894
+L 3597 1613
+L 953 1613
+Q 991 1019 1311 708
+Q 1631 397 2203 397
+Q 2534 397 2845 478
+Q 3156 559 3463 722
+L 3463 178
+Q 3153 47 2828 -22
+Q 2503 -91 2169 -91
+Q 1331 -91 842 396
+Q 353 884 353 1716
+Q 353 2575 817 3079
+Q 1281 3584 2069 3584
+Q 2775 3584 3186 3129
+Q 3597 2675 3597 1894
+z
+M 3022 2063
+Q 3016 2534 2758 2815
+Q 2500 3097 2075 3097
+Q 1594 3097 1305 2825
+Q 1016 2553 972 2059
+L 3022 2063
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-4c" transform="translate(86.28125 0)"/>
+       <use xlink:href="#DejaVuSans-56" transform="translate(114.0625 0)"/>
+       <use xlink:href="#DejaVuSans-56" transform="translate(166.15625 0)"/>
+       <use xlink:href="#DejaVuSans-48" transform="translate(218.25 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(279.78125 0)"/>
+       <use xlink:href="#DejaVuSans-56" transform="translate(343.15625 0)"/>
+       <use xlink:href="#DejaVuSans-48" transform="translate(395.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m83ecafbd94" x="218.118145" y="370.946297" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- Splicing -->
+      <g transform="translate(182.955245 404.13455) rotate(-30) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 3425 4513
+L 3425 3897
+Q 3066 4069 2747 4153
+Q 2428 4238 2131 4238
+Q 1616 4238 1336 4038
+Q 1056 3838 1056 3469
+Q 1056 3159 1242 3001
+Q 1428 2844 1947 2747
+L 2328 2669
+Q 3034 2534 3370 2195
+Q 3706 1856 3706 1288
+Q 3706 609 3251 259
+Q 2797 -91 1919 -91
+Q 1588 -91 1214 -16
+Q 841 59 441 206
+L 441 856
+Q 825 641 1194 531
+Q 1563 422 1919 422
+Q 2459 422 2753 634
+Q 3047 847 3047 1241
+Q 3047 1584 2836 1778
+Q 2625 1972 2144 2069
+L 1759 2144
+Q 1053 2284 737 2584
+Q 422 2884 422 3419
+Q 422 4038 858 4394
+Q 1294 4750 2059 4750
+Q 2388 4750 2728 4690
+Q 3069 4631 3425 4513
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-53" d="M 1159 525
+L 1159 -1331
+L 581 -1331
+L 581 3500
+L 1159 3500
+L 1159 2969
+Q 1341 3281 1617 3432
+Q 1894 3584 2278 3584
+Q 2916 3584 3314 3078
+Q 3713 2572 3713 1747
+Q 3713 922 3314 415
+Q 2916 -91 2278 -91
+Q 1894 -91 1617 61
+Q 1341 213 1159 525
+z
+M 3116 1747
+Q 3116 2381 2855 2742
+Q 2594 3103 2138 3103
+Q 1681 3103 1420 2742
+Q 1159 2381 1159 1747
+Q 1159 1113 1420 752
+Q 1681 391 2138 391
+Q 2594 391 2855 752
+Q 3116 1113 3116 1747
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-46" d="M 3122 3366
+L 3122 2828
+Q 2878 2963 2633 3030
+Q 2388 3097 2138 3097
+Q 1578 3097 1268 2742
+Q 959 2388 959 1747
+Q 959 1106 1268 751
+Q 1578 397 2138 397
+Q 2388 397 2633 464
+Q 2878 531 3122 666
+L 3122 134
+Q 2881 22 2623 -34
+Q 2366 -91 2075 -91
+Q 1284 -91 818 406
+Q 353 903 353 1747
+Q 353 2603 823 3093
+Q 1294 3584 2113 3584
+Q 2378 3584 2631 3529
+Q 2884 3475 3122 3366
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4a" d="M 2906 1791
+Q 2906 2416 2648 2759
+Q 2391 3103 1925 3103
+Q 1463 3103 1205 2759
+Q 947 2416 947 1791
+Q 947 1169 1205 825
+Q 1463 481 1925 481
+Q 2391 481 2648 825
+Q 2906 1169 2906 1791
+z
+M 3481 434
+Q 3481 -459 3084 -895
+Q 2688 -1331 1869 -1331
+Q 1566 -1331 1297 -1286
+Q 1028 -1241 775 -1147
+L 775 -588
+Q 1028 -725 1275 -790
+Q 1522 -856 1778 -856
+Q 2344 -856 2625 -561
+Q 2906 -266 2906 331
+L 2906 616
+Q 2728 306 2450 153
+Q 2172 0 1784 0
+Q 1141 0 747 490
+Q 353 981 353 1791
+Q 353 2603 747 3093
+Q 1141 3584 1784 3584
+Q 2172 3584 2450 3431
+Q 2728 3278 2906 2969
+L 2906 3500
+L 3481 3500
+L 3481 434
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-53" transform="translate(63.484375 0)"/>
+       <use xlink:href="#DejaVuSans-4f" transform="translate(126.96875 0)"/>
+       <use xlink:href="#DejaVuSans-4c" transform="translate(154.75 0)"/>
+       <use xlink:href="#DejaVuSans-46" transform="translate(182.53125 0)"/>
+       <use xlink:href="#DejaVuSans-4c" transform="translate(237.515625 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(265.296875 0)"/>
+       <use xlink:href="#DejaVuSans-4a" transform="translate(328.671875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m83ecafbd94" x="280.355276" y="370.946297" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- Synonymous -->
+      <g transform="translate(223.394247 416.719029) rotate(-30) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-5c" d="M 2059 -325
+Q 1816 -950 1584 -1140
+Q 1353 -1331 966 -1331
+L 506 -1331
+L 506 -850
+L 844 -850
+Q 1081 -850 1212 -737
+Q 1344 -625 1503 -206
+L 1606 56
+L 191 3500
+L 800 3500
+L 1894 763
+L 2988 3500
+L 3597 3500
+L 2059 -325
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-52" d="M 1959 3097
+Q 1497 3097 1228 2736
+Q 959 2375 959 1747
+Q 959 1119 1226 758
+Q 1494 397 1959 397
+Q 2419 397 2687 759
+Q 2956 1122 2956 1747
+Q 2956 2369 2687 2733
+Q 2419 3097 1959 3097
+z
+M 1959 3584
+Q 2709 3584 3137 3096
+Q 3566 2609 3566 1747
+Q 3566 888 3137 398
+Q 2709 -91 1959 -91
+Q 1206 -91 779 398
+Q 353 888 353 1747
+Q 353 2609 779 3096
+Q 1206 3584 1959 3584
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-50" d="M 3328 2828
+Q 3544 3216 3844 3400
+Q 4144 3584 4550 3584
+Q 5097 3584 5394 3201
+Q 5691 2819 5691 2113
+L 5691 0
+L 5113 0
+L 5113 2094
+Q 5113 2597 4934 2840
+Q 4756 3084 4391 3084
+Q 3944 3084 3684 2787
+Q 3425 2491 3425 1978
+L 3425 0
+L 2847 0
+L 2847 2094
+Q 2847 2600 2669 2842
+Q 2491 3084 2119 3084
+Q 1678 3084 1418 2786
+Q 1159 2488 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1356 3278 1631 3431
+Q 1906 3584 2284 3584
+Q 2666 3584 2933 3390
+Q 3200 3197 3328 2828
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-58" d="M 544 1381
+L 544 3500
+L 1119 3500
+L 1119 1403
+Q 1119 906 1312 657
+Q 1506 409 1894 409
+Q 2359 409 2629 706
+Q 2900 1003 2900 1516
+L 2900 3500
+L 3475 3500
+L 3475 0
+L 2900 0
+L 2900 538
+Q 2691 219 2414 64
+Q 2138 -91 1772 -91
+Q 1169 -91 856 284
+Q 544 659 544 1381
+z
+M 1991 3584
+L 1991 3584
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-5c" transform="translate(63.484375 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(122.671875 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(186.046875 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(247.234375 0)"/>
+       <use xlink:href="#DejaVuSans-5c" transform="translate(310.609375 0)"/>
+       <use xlink:href="#DejaVuSans-50" transform="translate(369.796875 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(467.203125 0)"/>
+       <use xlink:href="#DejaVuSans-58" transform="translate(528.390625 0)"/>
+       <use xlink:href="#DejaVuSans-56" transform="translate(591.765625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m83ecafbd94" x="342.592408" y="370.946297" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- Promoter -->
+      <g transform="translate(301.633904 407.479967) rotate(-30) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 1259 4147
+L 1259 2394
+L 2053 2394
+Q 2494 2394 2734 2622
+Q 2975 2850 2975 3272
+Q 2975 3691 2734 3919
+Q 2494 4147 2053 4147
+L 1259 4147
+z
+M 628 4666
+L 2053 4666
+Q 2838 4666 3239 4311
+Q 3641 3956 3641 3272
+Q 3641 2581 3239 2228
+Q 2838 1875 2053 1875
+L 1259 1875
+L 1259 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-55" transform="translate(58.546875 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(97.453125 0)"/>
+       <use xlink:href="#DejaVuSans-50" transform="translate(158.640625 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(256.046875 0)"/>
+       <use xlink:href="#DejaVuSans-57" transform="translate(317.234375 0)"/>
+       <use xlink:href="#DejaVuSans-48" transform="translate(356.4375 0)"/>
+       <use xlink:href="#DejaVuSans-55" transform="translate(417.96875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m83ecafbd94" x="404.829539" y="370.946297" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 5' UTR -->
+      <g transform="translate(375.340459 400.858092) rotate(-30) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-18" d="M 691 4666
+L 3169 4666
+L 3169 4134
+L 1269 4134
+L 1269 2991
+Q 1406 3038 1543 3061
+Q 1681 3084 1819 3084
+Q 2600 3084 3056 2656
+Q 3513 2228 3513 1497
+Q 3513 744 3044 326
+Q 2575 -91 1722 -91
+Q 1428 -91 1123 -41
+Q 819 9 494 109
+L 494 744
+Q 775 591 1075 516
+Q 1375 441 1709 441
+Q 2250 441 2565 725
+Q 2881 1009 2881 1497
+Q 2881 1984 2565 2268
+Q 2250 2553 1709 2553
+Q 1456 2553 1204 2497
+Q 953 2441 691 2322
+L 691 4666
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-a" d="M 1147 4666
+L 1147 2931
+L 616 2931
+L 616 4666
+L 1147 4666
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-38" d="M 556 4666
+L 1191 4666
+L 1191 1831
+Q 1191 1081 1462 751
+Q 1734 422 2344 422
+Q 2950 422 3222 751
+Q 3494 1081 3494 1831
+L 3494 4666
+L 4128 4666
+L 4128 1753
+Q 4128 841 3676 375
+Q 3225 -91 2344 -91
+Q 1459 -91 1007 375
+Q 556 841 556 1753
+L 556 4666
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-37" d="M -19 4666
+L 3928 4666
+L 3928 4134
+L 2272 4134
+L 2272 0
+L 1638 0
+L 1638 4134
+L -19 4134
+L -19 4666
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-35" d="M 2841 2188
+Q 3044 2119 3236 1894
+Q 3428 1669 3622 1275
+L 4263 0
+L 3584 0
+L 2988 1197
+Q 2756 1666 2539 1819
+Q 2322 1972 1947 1972
+L 1259 1972
+L 1259 0
+L 628 0
+L 628 4666
+L 2053 4666
+Q 2853 4666 3247 4331
+Q 3641 3997 3641 3322
+Q 3641 2881 3436 2590
+Q 3231 2300 2841 2188
+z
+M 1259 4147
+L 1259 2491
+L 2053 2491
+Q 2509 2491 2742 2702
+Q 2975 2913 2975 3322
+Q 2975 3731 2742 3939
+Q 2509 4147 2053 4147
+L 1259 4147
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-18"/>
+       <use xlink:href="#DejaVuSans-a" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-3" transform="translate(91.109375 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(122.890625 0)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(196.078125 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(257.15625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m83ecafbd94" x="467.066671" y="370.946297" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 3' UTR -->
+      <g transform="translate(437.577591 400.858092) rotate(-30) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-16" d="M 2597 2516
+Q 3050 2419 3304 2112
+Q 3559 1806 3559 1356
+Q 3559 666 3084 287
+Q 2609 -91 1734 -91
+Q 1441 -91 1130 -33
+Q 819 25 488 141
+L 488 750
+Q 750 597 1062 519
+Q 1375 441 1716 441
+Q 2309 441 2620 675
+Q 2931 909 2931 1356
+Q 2931 1769 2642 2001
+Q 2353 2234 1838 2234
+L 1294 2234
+L 1294 2753
+L 1863 2753
+Q 2328 2753 2575 2939
+Q 2822 3125 2822 3475
+Q 2822 3834 2567 4026
+Q 2313 4219 1838 4219
+Q 1578 4219 1281 4162
+Q 984 4106 628 3988
+L 628 4550
+Q 988 4650 1302 4700
+Q 1616 4750 1894 4750
+Q 2613 4750 3031 4423
+Q 3450 4097 3450 3541
+Q 3450 3153 3228 2886
+Q 3006 2619 2597 2516
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-16"/>
+       <use xlink:href="#DejaVuSans-a" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-3" transform="translate(91.109375 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(122.890625 0)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(196.078125 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(257.15625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m83ecafbd94" x="529.303802" y="370.946297" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- Distal -->
+      <g transform="translate(503.408728 398.783768) rotate(-30) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-27" d="M 1259 4147
+L 1259 519
+L 2022 519
+Q 2988 519 3436 956
+Q 3884 1394 3884 2338
+Q 3884 3275 3436 3711
+Q 2988 4147 2022 4147
+L 1259 4147
+z
+M 628 4666
+L 1925 4666
+Q 3281 4666 3915 4102
+Q 4550 3538 4550 2338
+Q 4550 1131 3912 565
+Q 3275 0 1925 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-27"/>
+       <use xlink:href="#DejaVuSans-4c" transform="translate(77 0)"/>
+       <use xlink:href="#DejaVuSans-56" transform="translate(104.78125 0)"/>
+       <use xlink:href="#DejaVuSans-57" transform="translate(156.875 0)"/>
+       <use xlink:href="#DejaVuSans-44" transform="translate(196.078125 0)"/>
+       <use xlink:href="#DejaVuSans-4f" transform="translate(257.359375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m83ecafbd94" x="591.540934" y="370.946297" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- ncRNA -->
+      <g transform="translate(561.668908 401.079186) rotate(-30) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 628 4666
+L 1478 4666
+L 3547 763
+L 3547 4666
+L 4159 4666
+L 4159 0
+L 3309 0
+L 1241 3903
+L 1241 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-51"/>
+       <use xlink:href="#DejaVuSans-46" transform="translate(63.375 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(118.359375 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(187.84375 0)"/>
+       <use xlink:href="#DejaVuSans-24" transform="translate(262.65625 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_10">
+      <defs>
+       <path id="mc09aec3e9b" d="M 0 0
+L -3.5 0
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mc09aec3e9b" x="44.103125" y="370.946297" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0.0 -->
+      <g transform="translate(21.2 374.745125) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-13" d="M 2034 4250
+Q 1547 4250 1301 3770
+Q 1056 3291 1056 2328
+Q 1056 1369 1301 889
+Q 1547 409 2034 409
+Q 2525 409 2770 889
+Q 3016 1369 3016 2328
+Q 3016 3291 2770 3770
+Q 2525 4250 2034 4250
+z
+M 2034 4750
+Q 2819 4750 3233 4129
+Q 3647 3509 3647 2328
+Q 3647 1150 3233 529
+Q 2819 -91 2034 -91
+Q 1250 -91 836 529
+Q 422 1150 422 2328
+Q 422 3509 836 4129
+Q 1250 4750 2034 4750
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-11" d="M 684 794
+L 1344 794
+L 1344 0
+L 684 0
+L 684 794
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#mc09aec3e9b" x="44.103125" y="301.220663" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 0.2 -->
+      <g transform="translate(21.2 305.019491) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-15" d="M 1228 531
+L 3431 531
+L 3431 0
+L 469 0
+L 469 531
+Q 828 903 1448 1529
+Q 2069 2156 2228 2338
+Q 2531 2678 2651 2914
+Q 2772 3150 2772 3378
+Q 2772 3750 2511 3984
+Q 2250 4219 1831 4219
+Q 1534 4219 1204 4116
+Q 875 4013 500 3803
+L 500 4441
+Q 881 4594 1212 4672
+Q 1544 4750 1819 4750
+Q 2544 4750 2975 4387
+Q 3406 4025 3406 3419
+Q 3406 3131 3298 2873
+Q 3191 2616 2906 2266
+Q 2828 2175 2409 1742
+Q 1991 1309 1228 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#mc09aec3e9b" x="44.103125" y="231.495028" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 0.4 -->
+      <g transform="translate(21.2 235.293856) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-17" d="M 2419 4116
+L 825 1625
+L 2419 1625
+L 2419 4116
+z
+M 2253 4666
+L 3047 4666
+L 3047 1625
+L 3713 1625
+L 3713 1100
+L 3047 1100
+L 3047 0
+L 2419 0
+L 2419 1100
+L 313 1100
+L 313 1709
+L 2253 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#mc09aec3e9b" x="44.103125" y="161.769394" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 0.6 -->
+      <g transform="translate(21.2 165.568222) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-19" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#mc09aec3e9b" x="44.103125" y="92.043759" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 0.8 -->
+      <g transform="translate(21.2 95.842588) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-1b" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-1b" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#mc09aec3e9b" x="44.103125" y="22.318125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 1.0 -->
+      <g transform="translate(21.2 26.116953) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-14" d="M 794 531
+L 1825 531
+L 1825 4091
+L 703 3866
+L 703 4441
+L 1819 4666
+L 2450 4666
+L 2450 531
+L 3481 531
+L 3481 0
+L 794 0
+L 794 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_16">
+     <!-- Pearson r -->
+     <g transform="translate(14.797656 220.142367) rotate(-90) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(56.734375 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(118.265625 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(179.546875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(220.65625 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(272.75 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(333.9375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(397.3125 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(429.09375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 71.238514 370.946297
+L 93.643882 370.946297
+L 93.643882 32.74307
+L 71.238514 32.74307
+z
+" clip-path="url(#p20a1bab2f4)" style="fill: #4c72b0"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 133.475646 370.946297
+L 155.881013 370.946297
+L 155.881013 29.038164
+L 133.475646 29.038164
+z
+" clip-path="url(#p20a1bab2f4)" style="fill: #4c72b0"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 195.712777 370.946297
+L 218.118145 370.946297
+L 218.118145 32.044428
+L 195.712777 32.044428
+z
+" clip-path="url(#p20a1bab2f4)" style="fill: #4c72b0"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 257.949909 370.946297
+L 280.355276 370.946297
+L 280.355276 35.360698
+L 257.949909 35.360698
+z
+" clip-path="url(#p20a1bab2f4)" style="fill: #4c72b0"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 320.18704 370.946297
+L 342.592408 370.946297
+L 342.592408 137.65392
+L 320.18704 137.65392
+z
+" clip-path="url(#p20a1bab2f4)" style="fill: #4c72b0"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 382.424172 370.946297
+L 404.829539 370.946297
+L 404.829539 71.941175
+L 382.424172 71.941175
+z
+" clip-path="url(#p20a1bab2f4)" style="fill: #4c72b0"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 444.661303 370.946297
+L 467.066671 370.946297
+L 467.066671 45.236546
+L 444.661303 45.236546
+z
+" clip-path="url(#p20a1bab2f4)" style="fill: #4c72b0"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 506.898435 370.946297
+L 529.303802 370.946297
+L 529.303802 136.677985
+L 506.898435 136.677985
+z
+" clip-path="url(#p20a1bab2f4)" style="fill: #4c72b0"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 569.135566 370.946297
+L 591.540934 370.946297
+L 591.540934 82.846208
+L 569.135566 82.846208
+z
+" clip-path="url(#p20a1bab2f4)" style="fill: #4c72b0"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 93.643882 370.946297
+L 116.049249 370.946297
+L 116.049249 29.107688
+L 93.643882 29.107688
+z
+" clip-path="url(#p20a1bab2f4)" style="fill: #dd8452"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 155.881013 370.946297
+L 178.286381 370.946297
+L 178.286381 26.925729
+L 155.881013 26.925729
+z
+" clip-path="url(#p20a1bab2f4)" style="fill: #dd8452"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 218.118145 370.946297
+L 240.523512 370.946297
+L 240.523512 27.443769
+L 218.118145 27.443769
+z
+" clip-path="url(#p20a1bab2f4)" style="fill: #dd8452"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 280.355276 370.946297
+L 302.760643 370.946297
+L 302.760643 32.010777
+L 280.355276 32.010777
+z
+" clip-path="url(#p20a1bab2f4)" style="fill: #dd8452"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 342.592408 370.946297
+L 364.997775 370.946297
+L 364.997775 141.344909
+L 342.592408 141.344909
+z
+" clip-path="url(#p20a1bab2f4)" style="fill: #dd8452"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 404.829539 370.946297
+L 427.234906 370.946297
+L 427.234906 63.690948
+L 404.829539 63.690948
+z
+" clip-path="url(#p20a1bab2f4)" style="fill: #dd8452"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 467.066671 370.946297
+L 489.472038 370.946297
+L 489.472038 41.100905
+L 467.066671 41.100905
+z
+" clip-path="url(#p20a1bab2f4)" style="fill: #dd8452"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 529.303802 370.946297
+L 551.709169 370.946297
+L 551.709169 121.509363
+L 529.303802 121.509363
+z
+" clip-path="url(#p20a1bab2f4)" style="fill: #dd8452"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 591.540934 370.946297
+L 613.946301 370.946297
+L 613.946301 79.176562
+L 591.540934 79.176562
+z
+" clip-path="url(#p20a1bab2f4)" style="fill: #dd8452"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 44.103125 370.946297
+L 44.103125 22.318125
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 641.08169 370.946297
+L 641.08169 22.318125
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 44.103125 370.946297
+L 641.08169 370.946297
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 44.103125 22.318125
+L 641.08169 22.318125
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_17">
+    <!-- Pearson correlation by variant subset -->
+    <g transform="translate(230.471158 16.318125) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-45" d="M 3116 1747
+Q 3116 2381 2855 2742
+Q 2594 3103 2138 3103
+Q 1681 3103 1420 2742
+Q 1159 2381 1159 1747
+Q 1159 1113 1420 752
+Q 1681 391 2138 391
+Q 2594 391 2855 752
+Q 3116 1113 3116 1747
+z
+M 1159 2969
+Q 1341 3281 1617 3432
+Q 1894 3584 2278 3584
+Q 2916 3584 3314 3078
+Q 3713 2572 3713 1747
+Q 3713 922 3314 415
+Q 2916 -91 2278 -91
+Q 1894 -91 1617 61
+Q 1341 213 1159 525
+L 1159 0
+L 581 0
+L 581 4863
+L 1159 4863
+L 1159 2969
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(56.734375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(118.265625 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(179.546875 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(220.65625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(272.75 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(333.9375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(397.3125 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(429.09375 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(484.078125 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(545.265625 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(584.625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(623.53125 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(685.0625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(712.84375 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(774.125 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(813.328125 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(841.109375 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(902.296875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(965.671875 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(997.453125 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(1060.9375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1120.125 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(1151.90625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1211.09375 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1272.375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1313.484375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1341.265625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1402.546875 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1465.921875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1505.125 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1536.90625 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1589 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(1652.375 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1715.859375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1767.953125 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1829.484375 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_25">
+     <path d="M 654.051476 75.320469
+L 834.404601 75.320469
+Q 836.404601 75.320469 836.404601 73.320469
+L 836.404601 29.318125
+Q 836.404601 27.318125 834.404601 27.318125
+L 654.051476 27.318125
+Q 652.051476 27.318125 652.051476 29.318125
+L 652.051476 73.320469
+Q 652.051476 75.320469 654.051476 75.320469
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_18">
+     <!-- Comparison -->
+     <g transform="translate(714.29132 38.916562) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-26" d="M 4122 4306
+L 4122 3641
+Q 3803 3938 3442 4084
+Q 3081 4231 2675 4231
+Q 1875 4231 1450 3742
+Q 1025 3253 1025 2328
+Q 1025 1406 1450 917
+Q 1875 428 2675 428
+Q 3081 428 3442 575
+Q 3803 722 4122 1019
+L 4122 359
+Q 3791 134 3420 21
+Q 3050 -91 2638 -91
+Q 1578 -91 968 557
+Q 359 1206 359 2328
+Q 359 3453 968 4101
+Q 1578 4750 2638 4750
+Q 3056 4750 3426 4639
+Q 3797 4528 4122 4306
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-26"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(69.828125 0)"/>
+      <use xlink:href="#DejaVuSans-50" transform="translate(131.015625 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(228.421875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(291.90625 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(353.1875 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(394.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(422.078125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(474.171875 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(535.359375 0)"/>
+     </g>
+    </g>
+    <g id="patch_26">
+     <path d="M 656.051476 53.917344
+L 676.051476 53.917344
+L 676.051476 46.917344
+L 656.051476 46.917344
+z
+" style="fill: #4c72b0"/>
+    </g>
+    <g id="text_19">
+     <!-- No tag vs correct mammalian -->
+     <g transform="translate(684.051476 53.917344) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-31"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(74.8125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(136 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(167.78125 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(206.984375 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(268.265625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(331.75 0)"/>
+      <use xlink:href="#DejaVuSans-59" transform="translate(363.53125 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(422.71875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(474.8125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(506.59375 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(561.578125 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(622.765625 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(662.125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(701.03125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(762.5625 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(817.546875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(856.75 0)"/>
+      <use xlink:href="#DejaVuSans-50" transform="translate(888.53125 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(985.9375 0)"/>
+      <use xlink:href="#DejaVuSans-50" transform="translate(1047.21875 0)"/>
+      <use xlink:href="#DejaVuSans-50" transform="translate(1144.625 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(1242.03125 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(1303.3125 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(1331.09375 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(1358.875 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(1420.15625 0)"/>
+     </g>
+    </g>
+    <g id="patch_27">
+     <path d="M 656.051476 68.918125
+L 676.051476 68.918125
+L 676.051476 61.918125
+L 656.051476 61.918125
+z
+" style="fill: #dd8452"/>
+    </g>
+    <g id="text_20">
+     <!-- No tag vs far-wrong fungal -->
+     <g transform="translate(684.051476 68.918125) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-49" d="M 2375 4863
+L 2375 4384
+L 1825 4384
+Q 1516 4384 1395 4259
+Q 1275 4134 1275 3809
+L 1275 3500
+L 2222 3500
+L 2222 3053
+L 1275 3053
+L 1275 0
+L 697 0
+L 697 3053
+L 147 3053
+L 147 3500
+L 697 3500
+L 697 3744
+Q 697 4328 969 4595
+Q 1241 4863 1831 4863
+L 2375 4863
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-10" d="M 313 2009
+L 1997 2009
+L 1997 1497
+L 313 1497
+L 313 2009
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5a" d="M 269 3500
+L 844 3500
+L 1563 769
+L 2278 3500
+L 2956 3500
+L 3675 769
+L 4391 3500
+L 4966 3500
+L 4050 0
+L 3372 0
+L 2619 2869
+L 1863 0
+L 1184 0
+L 269 3500
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-31"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(74.8125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(136 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(167.78125 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(206.984375 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(268.265625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(331.75 0)"/>
+      <use xlink:href="#DejaVuSans-59" transform="translate(363.53125 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(422.71875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(474.8125 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(506.59375 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(541.796875 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(603.078125 0)"/>
+      <use xlink:href="#DejaVuSans-10" transform="translate(637.796875 0)"/>
+      <use xlink:href="#DejaVuSans-5a" transform="translate(673.875 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(755.65625 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(794.5625 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(855.75 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(919.125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(982.609375 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(1014.390625 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(1049.59375 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(1112.96875 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(1176.34375 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(1239.828125 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(1301.109375 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p20a1bab2f4">
+   <rect x="44.103125" y="22.318125" width="596.978565" height="348.628172"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/research/questions/species-conditioning.md
+++ b/docs/research/questions/species-conditioning.md
@@ -1,7 +1,7 @@
 # Does conditioning on species/clade help?
 
 > [!NOTE]
-> **TL;DR:** No matched MarinDNA ablation has tested taxon conditioning; Carbon finds unchanged overall sequence recovery and gains only for low-resource eukaryote groups, without VEP evidence, so confidence is low and the cheapest next test is a frozen-Carbon tagged, untagged, and wrong-tag VEP comparison.
+> **TL;DR:** Carbon-3B used species prefixes during human Mendelian variant scoring, but correct mammalian and far-wrong fungal prompts did not establish a macro-AUPRC difference from no tagging; whether tag-conditioned pretraining helps remains untested, so confidence is low.
 
 ## Question
 
@@ -12,16 +12,23 @@ Can taxon-tag dropout preserve a useful unconditional mode?
 
 ## Current answer
 
-No MarinDNA experiment has compared identical examples with and without an explicit taxon input.
-The current model-facing path retains sequence but does not expose species identity, so every multispecies model must infer organismal context from the DNA window.
+MarinDNA has tested whether a metadata-trained checkpoint uses taxon prompts at inference.
+[Experiment #486](../experiments/486-carbon-species-conditioning.md) held Carbon-3B, 8-kb human sequences, and development-set Mendelian variants fixed while comparing no tag, the correct mammalian tag, and a far-wrong fungal tag.
+Correct conditioning changed macro AUPRC by -0.0030 [-0.0183, 0.0088] relative to no tagging, while fungal conditioning changed it by +0.0005 [-0.0137, 0.0124].
+Neither prompt established an aggregate ranking difference.
+
+Carbon-3B did use the prompt prefix.
+Tagged-versus-no-tag score agreement varied by consequence subset and was lowest where no-tag LLR-derived scores had limited near-neutral dynamic range.
+This establishes inference-time prompt sensitivity in one human setting without showing that the changes are useful.
+It does not identify the causal value of metadata-conditioned pretraining, which requires otherwise-matched models trained with and without tags.
 
 [Carbon](https://www.biorxiv.org/content/10.64898/2026.05.22.727119v1) supplies the most direct published evidence so far.
 Its released 3B and 8B autoregressive models see species- and gene-type-tagged prompts on 50% of pretraining examples.
 The reported tag ablation leaves overall sequence recovery essentially unchanged, while a correct species tag improves recovery for fungi, protozoa, and invertebrates and leaves high-resource groups unchanged.
 Carbon evaluates ClinVar, BRCA2, and TraitGym VEP separately, but does not report how those results change with conditioning.
-The released checkpoints support both conditional and unconditional prompts, enabling a same-checkpoint VEP intervention now; this measures inference-time use of metadata, not the causal effect of metadata-conditioned pretraining.
+The released checkpoints support both conditional and unconditional prompts, which enabled the same-checkpoint intervention in experiment #486.
 
-The evidence supports a conditional hypothesis with low confidence.
+The combined evidence supports a conditional hypothesis with low confidence.
 Taxon labels are most likely to help when the sequence window is too short to identify the relevant organismal regime and when the target feature varies across clades.
 The benefit may shrink with longer context or larger models, and a label may expose compositional shortcuts instead of functional biology.
 
@@ -40,7 +47,7 @@ Validation-loss improvement alone would not show that conditioning learned usefu
 |---|---|---|
 | [Species-aware DNA language models](https://doi.org/10.1186/s13059-024-03221-x) | A learned species token was prepended to short fungal regulatory sequences from 806 species. Species-aware models modestly improved motif reconstruction and several representation tasks. | Explicit taxon context can help short regulatory models. Held-out species required a hand-chosen proxy token, so unseen-species behavior remains unresolved. |
 | [LOL-EVE](https://openreview.net/pdf?id=WxHbIY90IS) | A causal promoter model conditions on clade, species, and proximal-gene embeddings and randomly drops control tags. It reports strong promoter-variant performance. | This supplies a practical hierarchy and dropout design. No matched ablation isolates the taxon tags from gene conditioning, data, and architecture. |
-| [Carbon](https://www.biorxiv.org/content/10.64898/2026.05.22.727119v1) | Released 3B and 8B autoregressive models mix species and gene-type tags into 50% of pretraining prompts. Tags leave overall sequence recovery essentially unchanged; a correct species tag improves recovery for low-resource eukaryote groups. Its VEP suite includes ClinVar, BRCA2, and TraitGym Mendelian, but does not cross VEP with conditioning. | This is direct conditioning evidence and provides frozen checkpoints for a cheap tagged-versus-untagged VEP test. That test isolates inference-time dependence on the supplied tag; a tag-trained versus never-tag-trained model comparison is still needed to isolate the pretraining effect. |
+| [Carbon](https://www.biorxiv.org/content/10.64898/2026.05.22.727119v1) | Released 3B and 8B autoregressive models mix species and gene-type tags into 50% of pretraining prompts. Tags leave overall sequence recovery essentially unchanged; a correct species tag improves recovery for low-resource eukaryote groups. Its VEP suite includes ClinVar, BRCA2, and TraitGym Mendelian, but does not cross VEP with conditioning. [Experiment #486](../experiments/486-carbon-species-conditioning.md) supplied that frozen-checkpoint comparison for Carbon-3B and found prompt-sensitive scores without an established macro-AUPRC difference. | Carbon and experiment #486 show that the checkpoint uses species context in some settings. An otherwise-matched tag-trained versus never-tag-trained model comparison is still needed to isolate the pretraining effect. |
 | [Evo 2](https://doi.org/10.1038/s41586-026-10176-5) | A large sequence-only model uses long DNA prompts to recover alternative genetic codes and species-shaped completion statistics. | Long context can make explicit tags redundant. The result does not show that a short-window model can infer taxon efficiently. |
 | [SynCodonLM](https://academic.oup.com/nar/article/54/5/gkag166/8496864) | Species-group embeddings produced similar average benchmark scores in small ablations, but the no-taxon model was less robust to synonymous perturbations and full-scale taxon IDs gave a small gain. | Taxon context may add coding priors while average gains remain small. The setup is restricted to CDS, codon tokens, and masked modeling. |
 | [CodonTransformer](https://doi.org/10.1038/s41467-025-58588-7) | Organism embeddings enable host-specific codon optimization across 164 organisms. | Taxon conditioning supports controllable generation when host identity is part of the task. It does not isolate benefits for a general genomic LM. |
@@ -52,6 +59,8 @@ Validation-loss improvement alone would not show that conditioning learned usefu
 <details>
 <summary>Related experiments</summary>
 
+- [Experiment #486](../experiments/486-carbon-species-conditioning.md) compared no tag, a correct mammalian tag, and a far-wrong fungal tag for one frozen Carbon-3B checkpoint on development-set human Mendelian variants.
+  The tags changed per-variant scores but did not establish a macro-AUPRC difference; the intervention isolates inference-time prompt sensitivity rather than the effect of tagged pretraining.
 - [#55](https://github.com/Open-Athena/marin-dna/issues/55) compared promoter training across human, primate, mammal, vertebrate, and animal corpora.
   Mammalian data learned human Mendelian VEP faster, but phylogenetic breadth, unique-data quantity, and epoch count changed together; the experiment motivates conditioning without testing it.
 - [#58](https://github.com/Open-Athena/marin-dna/issues/58) repeated the timescale comparison for CDS and found a different trajectory: shallower arms led early, while the animal arm later became stronger for missense VEP.
@@ -69,13 +78,6 @@ Validation-loss improvement alone would not show that conditioning learned usefu
 - **Does it help at fixed compute and data?**
   Compare models trained on the same examples, order, optimizer, seed, and token budget.
   The primary contrast should be sequence-only versus correctly conditioned; a shuffled-label control can test whether any extra token/parameters alone explain the result.
-- **Can the released Carbon checkpoints test inference-time VEP sensitivity now?**
-  Start with Carbon-500M, then replicate any signal on 3B and 8B.
-  Score the same development-safe human variants from odd-numbered autosomes and X under `<dna>` (untagged), `<vertebrate_mammalian><dna>` (correct), and equal-length wrong or shuffled taxon tags; optionally cross gene-type tags.
-  Keep the checkpoint, window, strand handling, and scorer fixed.
-  Compare paired per-variant score changes and consequence-stratified or macro AUPRC.
-  Correct-versus-wrong tags control the semantics of the prefix more cleanly than correct-versus-untagged alone.
-  This tests whether a trained Carbon model's VEP scores use metadata, not whether metadata-conditioned pretraining caused better VEP.
 - **Species, clade, or hierarchy?**
   Compare a leaf-species token with hierarchical rank tokens (for example class/order/family/genus/species) or a shared phylogenetic embedding.
   A hierarchy may capture both universal and lineage-specific rules more efficiently than unrelated leaf embeddings.


### PR DESCRIPTION
Record the accepted interpretation of issue #486 in the research knowledge base and update the species-conditioning synthesis.

On 16,100 development-set Mendelian variants across eight consequence subsets, neither the correct mammalian prompt nor the far-wrong fungal prompt established a macro-AUPRC difference from no tagging.
Correct mammalian changed macro AUPRC by -0.0030, with a 95% paired-bootstrap interval of [-0.0183, 0.0088].
Far-wrong fungal changed it by +0.0005 [-0.0137, 0.0124].
Subset differences were mixed in direction, with no consistent pattern favoring either tag.

No-tag scores had pooled Pearson correlations of 0.970 with correct-mammalian scores and 0.981 with fungal scores.
Agreement was lower for promoter and distal variants, where no-tag mean absolute scores were about 0.0017 nats per DNA target token and score SD was about 0.0024.
The prompt-induced change was 0.75–0.83 times that baseline SD, compared with 0.16–0.24 for missense and splicing variants.
Limited, near-neutral LLR dynamic range where Carbon weakly separates deleterious variants is therefore the most likely explanation for the lower agreement.
The analysis provides no evidence for a regional evolutionary-rate explanation, and the relative-change diagnostic is algebraically related to Pearson rather than independent evidence of random noise.

The experiment page presents compact Pearson and AUPRC bar charts.
The individual-variant scatter grids remain in [issue #486](https://github.com/Open-Athena/marin-dna/issues/486#issuecomment-5371806938), and implementation and dense artifacts remain at the [reviewed research snapshot](https://github.com/Open-Athena/marin-dna/tree/carbon-conditioning-vep-reviewed-normalized-20260820).

This same-checkpoint intervention establishes inference-time prompt sensitivity.
It does not identify the causal value of metadata-conditioned pretraining, which requires otherwise-matched models trained with and without tags.

Part of #486
