### PR TITLE
[evals] Pin uv for remote task bootstraps

### DIFF
--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -176,7 +176,7 @@ load).
 Run embedding extractions **eager** (`torch_compile: false`): compiling the
 hooked forward is unvalidated, and a small run doesn't need it. The ready-made overlay
 [`config/overlays/return_embeddings.yaml`](config/overlays/return_embeddings.yaml)
-deep-merges `return_embeddings: true` + `batch_size: 32` + `torch_compile: false`
+deep-merges `return_embeddings: true` + `batch_size: 96` + `torch_compile: false`
 over the config (preserving `rc` etc.), e.g.
 `snakemake --configfile config/overlays/return_embeddings.yaml --forcerun
 compute_scores -- results/scores/<model>/<dataset>.parquet`. Eager makes the

--- a/snakemake/analysis/evals_v2/sky/probe.yaml
+++ b/snakemake/analysis/evals_v2/sky/probe.yaml
@@ -41,6 +41,9 @@ setup: |
         curl -LsSf https://astral.sh/uv/install.sh | sh
     fi
     export PATH="$HOME/.local/bin:$PATH"
+    if [[ "$(uv --version)" != "uv 0.11.31" ]]; then
+        uv self update 0.11.31
+    fi
 
     # `--group genome-s3` matches run.yaml (s3fs + the snakemake S3 storage
     # deps). The probe reads its scores parquet via the snakemake S3 storage

--- a/snakemake/analysis/evals_v2/sky/probe.yaml
+++ b/snakemake/analysis/evals_v2/sky/probe.yaml
@@ -41,7 +41,7 @@ setup: |
         curl -LsSf https://astral.sh/uv/install.sh | sh
     fi
     export PATH="$HOME/.local/bin:$PATH"
-    if [[ "$(uv --version)" != "uv 0.11.31" ]]; then
+    if [[ "$(uv --version | awk '{print $2}')" != "0.11.31" ]]; then
         uv self update 0.11.31
     fi
 

--- a/snakemake/analysis/evals_v2/sky/run.yaml
+++ b/snakemake/analysis/evals_v2/sky/run.yaml
@@ -59,7 +59,7 @@ setup: |
     if ! command -v uv >/dev/null 2>&1; then
         curl -LsSf https://astral.sh/uv/install.sh | sh
     fi
-    if [[ "$(uv --version)" != "uv 0.11.31" ]]; then
+    if [[ "$(uv --version | awk '{print $2}')" != "0.11.31" ]]; then
         uv self update 0.11.31
     fi
 

--- a/snakemake/analysis/evals_v2/tests/evals/test_gpu_runtime_validation.py
+++ b/snakemake/analysis/evals_v2/tests/evals/test_gpu_runtime_validation.py
@@ -51,7 +51,7 @@ def test_runtime_contract_matches_project_and_sky_configuration() -> None:
         'export PATH="$HOME/google-cloud-sdk/bin:$HOME/.local/bin:$PATH"'
     )
     uv_install = setup.index("if ! command -v uv")
-    uv_version = setup.index('if [[ "$(uv --version)"')
+    uv_version = setup.index("if [[ \"$(uv --version | awk '{print $2}')\"")
     assert path_export < uv_install < uv_version
     assert re.search(r"\bevals-gpu-runtime-check\b[^\n]*\bsmoke\b", setup)
     assert re.search(r"\bevals-gpu-runtime-check\b[^\n]*\bparity\b", run)

--- a/snakemake/analysis/evals_v2/tests/evals/test_sky_tasks.py
+++ b/snakemake/analysis/evals_v2/tests/evals/test_sky_tasks.py
@@ -1,0 +1,35 @@
+"""Contracts for evals_v2 Sky task bootstraps."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).parents[2]
+
+
+def test_locked_sky_tasks_pin_project_uv_version() -> None:
+    with (PROJECT_ROOT / "pyproject.toml").open("rb") as handle:
+        project = tomllib.load(handle)
+    required_version = project["tool"]["uv"]["required-version"]
+    assert required_version.startswith("==")
+    uv_version = required_version.removeprefix("==")
+
+    checked: list[str] = []
+    for task_path in sorted((PROJECT_ROOT / "sky").glob("*.yaml")):
+        with task_path.open(encoding="utf-8") as handle:
+            task = yaml.safe_load(handle)
+        setup = task.get("setup", "")
+        if "uv sync" not in setup or "--locked" not in setup:
+            continue
+
+        checked.append(task_path.name)
+        pin = f"uv self update {uv_version}"
+        assert pin in setup, f"{task_path.name} does not pin {pin!r}"
+        assert setup.index(pin) < setup.index("uv sync"), (
+            f"{task_path.name} pins uv after the locked sync"
+        )
+
+    assert checked == ["probe.yaml", "run.yaml"]

--- a/snakemake/analysis/evals_v2/tests/evals/test_sky_tasks.py
+++ b/snakemake/analysis/evals_v2/tests/evals/test_sky_tasks.py
@@ -27,7 +27,12 @@ def test_locked_sky_tasks_pin_project_uv_version() -> None:
 
         checked.append(task_path.name)
         pin = f"uv self update {uv_version}"
-        assert pin in setup, f"{task_path.name} does not pin {pin!r}"
+        guarded_pin = (
+            f'''if [[ "$(uv --version | awk '{{print $2}}')" != "{uv_version}" ]]; then\n'''
+            f"    {pin}\n"
+            "fi"
+        )
+        assert guarded_pin in setup, f"{task_path.name} does not guard {pin!r}"
         assert setup.index(pin) < setup.index("uv sync"), (
             f"{task_path.name} pins uv after the locked sync"
         )


### PR DESCRIPTION
Pins the CPU probe Sky bootstrap to the project-required `uv 0.11.31` before `uv sync --locked`, matching the GPU task.
Both tasks now compare the parsed version token, so an already-correct installation skips the networked self-update instead of risking a transient setup failure.

A regression reads `tool.uv.required-version` from the project manifest and checks every Sky task that performs a locked sync.
It requires the exact guarded `uv self update` block to appear before the sync, so a future version bump, task addition, or full-output comparison cannot silently reintroduce drift.
The README also corrects the embedding overlay batch size from 32 to its configured value of 96.

Issue #485 reproduced the failure on a fresh node with `uv 0.12.5`; downgrading to 0.11.31 allowed the locked sync and probe task to complete.
Local validation passed the full non-slow evals-v2 suite with 372 tests passed and 5 skipped, plus targeted repository pre-commit checks.
The workflow dry-run completed successfully before the review amendment, which did not change the DAG.
The final GitHub Actions build, pre-commit, selection, and evals-v2 checks are green.

Part of #485