### PR TITLE
[evals_v2] Reject incompatible RoPE schemas

### DIFF
--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -14,6 +14,9 @@ For each `model` × `dataset` in the config:
 1. **Download** the model checkpoint dir (from GCS or HF Hub depending on
    the model entry). The genome reference is read directly from S3 by
    pyfaidx (byte-range reads — no full download).
+   Before tokenizer or model construction, `marin_dna_evals.hf_compat` reads the local `config.json` and validates its effective RoPE semantics.
+   Transformers-5-only `rope_parameters` are translated in memory for the pinned Transformers 4 consumer.
+   Consistent dual-schema exports are accepted, while conflicting, malformed, incomplete, or unrepresentable schemas fail before weights load.
 2. **Score** every variant with `compute_variant_scores`. The score
    bundle is per-strand LLR + JSD (`down_jsd_mean` in issue #175 — the
    per-position 4-nuc next-token JSD averaged over downstream positions).
@@ -409,6 +412,7 @@ Two unavoidable AWS-side failure modes worth knowing about:
 
 Pipeline rules are thin glue around:
 
+- `marin_dna_evals.hf_compat` — fail-closed Transformers 4/5 config normalization plus the `TokenizersBackend` tokenizer fallback used by every maintained HF model-loading path.
 - `marin_dna_evals.inference.compute_variant_scores` — model + genome
   → per-strand score atoms (`llr_fwd`, `llr_rc`, `jsd_fwd`, `jsd_rc`).
 - `marin_dna_evals.metrics.compute_auprc_metrics` — score columns
@@ -424,6 +428,7 @@ Pipeline rules are thin glue around:
   collapses them to token-weighted `LL_upper` / `LL_lower` / `gap`.
 
 These are tested at `tests/evals/test_grouped_vep_metrics.py`,
+`tests/evals/test_hf_compat.py`,
 `tests/evals/test_metrics.py`,
 `tests/evals/test_inference.py`,
 `tests/evals/test_ll_gap.py`, and `tests/model/test_scoring.py`.

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/embedding_umap.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/embedding_umap.py
@@ -21,9 +21,9 @@ from typing import Any, Literal
 import numpy as np
 import pandas as pd
 from datasets import Dataset
-from transformers import AutoModel, AutoTokenizer
 
 from marin_dna.data.genome import Genome
+from marin_dna_evals.hf_compat import load_hf_base_model_and_tokenizer
 from marin_dna_evals.model.runner import run_window_embeddings
 
 # The dataset's 7 region labels → display names (GPN-Star Fig 4A).
@@ -116,10 +116,9 @@ def compute_region_embeddings(
     assert window_size >= n_center_bp, (
         f"window_size {window_size} must be >= n_center_bp {n_center_bp}"
     )
-    tokenizer: Any = AutoTokenizer.from_pretrained(checkpoint_path)
-    # Base AutoModel — we read last_hidden_state, not logits, so the LM head is
-    # dead weight. Trainer.predict handles device placement + bf16 + eval mode.
-    model: Any = AutoModel.from_pretrained(checkpoint_path, trust_remote_code=True)
+    # Use the base model because this path reads hidden states and does not need
+    # the LM head. The shared loader validates the raw RoPE schema first.
+    tokenizer, model = load_hf_base_model_and_tokenizer(checkpoint_path)
 
     genome = Genome(genome_path)
     # Sort by (chrom, start) so the dataloader transform's S3 byte-range reads

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/hf_compat.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/hf_compat.py
@@ -147,6 +147,10 @@ def _canonical_rope_scaling(
         raise HfCheckpointCompatibilityError(
             f"{path}: {field}.factor must be at least 1"
         )
+    if "truncate" in scaling and not isinstance(scaling["truncate"], bool):
+        raise HfCheckpointCompatibilityError(
+            f"{path}: {field}.truncate must be a boolean"
+        )
     if "original_max_position_embeddings" in scaling:
         original_max = scaling["original_max_position_embeddings"]
         if (
@@ -184,6 +188,8 @@ def _canonical_rope_scaling(
                 field=f"{field}.{factors_field}[{index}]",
                 path=path,
             )
+    if rope_type == "default":
+        return None
     return scaling
 
 
@@ -203,15 +209,52 @@ def _legacy_rope_from_parameters(
         parameters.pop("rope_theta"), field="rope_parameters.rope_theta", path=path
     )
     scaling = _canonical_rope_scaling(parameters, field="rope_parameters", path=path)
-    if scaling is not None and scaling["rope_type"] == "default":
-        unexpected = set(scaling) - {"rope_type"}
-        if unexpected:
-            raise HfCheckpointCompatibilityError(
-                f"{path}: default rope_parameters contains fields Transformers 4 cannot preserve: "
-                f"{sorted(unexpected)}"
-            )
-        scaling = None
     return theta, scaling
+
+
+def _validate_longrope_dimensions(
+    config: PretrainedConfig,
+    scaling: dict[str, Any],
+    *,
+    path: Path,
+) -> None:
+    head_dim = getattr(config, "head_dim", None)
+    if head_dim is None:
+        hidden_size = getattr(config, "hidden_size", None)
+        num_attention_heads = getattr(config, "num_attention_heads", None)
+        if (
+            isinstance(hidden_size, bool)
+            or not isinstance(hidden_size, int)
+            or hidden_size <= 0
+            or isinstance(num_attention_heads, bool)
+            or not isinstance(num_attention_heads, int)
+            or num_attention_heads <= 0
+        ):
+            raise HfCheckpointCompatibilityError(
+                f"{path}: cannot derive the rotary dimension for longrope"
+            )
+        head_dim = hidden_size // num_attention_heads
+    if isinstance(head_dim, bool) or not isinstance(head_dim, int) or head_dim <= 0:
+        raise HfCheckpointCompatibilityError(
+            f"{path}: head_dim must be a positive integer for longrope"
+        )
+    partial_rotary_factor = _positive_number(
+        getattr(config, "partial_rotary_factor", 1.0),
+        field="partial_rotary_factor",
+        path=path,
+    )
+    expected_length = int(head_dim * partial_rotary_factor) // 2
+    if expected_length <= 0:
+        raise HfCheckpointCompatibilityError(
+            f"{path}: longrope rotary dimension must be positive"
+        )
+    for field in ("short_factor", "long_factor"):
+        actual_length = len(scaling[field])
+        if actual_length != expected_length:
+            raise HfCheckpointCompatibilityError(
+                f"{path}: rope_scaling.{field} must contain {expected_length} values, "
+                f"got {actual_length}"
+            )
 
 
 def _validate_effective_rope(
@@ -241,6 +284,11 @@ def _validate_effective_rope(
                 f"{path}: Transformers resolved rope_scaling={effective_scaling!r}, "
                 f"expected {expected_scaling!r}"
             )
+        if (
+            effective_scaling is not None
+            and effective_scaling["rope_type"] == "longrope"
+        ):
+            _validate_longrope_dimensions(config, effective_scaling, path=path)
 
 
 def load_hf_checkpoint_config(checkpoint_path: str | Path) -> PretrainedConfig:

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/hf_compat.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/hf_compat.py
@@ -1,0 +1,357 @@
+"""Fail-closed Hugging Face checkpoint loading across Transformers 4 and 5."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+from transformers import (
+    AutoConfig,
+    AutoModel,
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    PretrainedConfig,
+    PreTrainedTokenizerBase,
+    PreTrainedTokenizerFast,
+)
+
+
+class HfCheckpointCompatibilityError(ValueError):
+    """The raw HF checkpoint metadata cannot be loaded without semantic drift."""
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise HfCheckpointCompatibilityError(
+            f"required checkpoint metadata is missing: {path}"
+        )
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise HfCheckpointCompatibilityError(
+            f"cannot read checkpoint metadata {path}: {error}"
+        ) from error
+    if not isinstance(value, dict):
+        raise HfCheckpointCompatibilityError(f"{path} must contain a JSON object")
+    return value
+
+
+def _positive_number(value: Any, *, field: str, path: Path) -> int | float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise HfCheckpointCompatibilityError(
+            f"{path}: {field} must be a positive number, got {value!r}"
+        )
+    if not math.isfinite(float(value)) or value <= 0:
+        raise HfCheckpointCompatibilityError(
+            f"{path}: {field} must be a positive number, got {value!r}"
+        )
+    return value
+
+
+def _canonical_rope_scaling(
+    value: Any, *, field: str, path: Path
+) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise HfCheckpointCompatibilityError(
+            f"{path}: {field} must be a JSON object or null"
+        )
+
+    scaling = dict(value)
+    old_type = scaling.pop("type", None)
+    rope_type = scaling.get("rope_type")
+    if rope_type is None:
+        rope_type = old_type
+        if rope_type is not None:
+            scaling["rope_type"] = rope_type
+    elif old_type is not None and old_type != rope_type:
+        raise HfCheckpointCompatibilityError(
+            f"{path}: {field} has conflicting type={old_type!r} and rope_type={rope_type!r}"
+        )
+    if not isinstance(rope_type, str) or not rope_type:
+        raise HfCheckpointCompatibilityError(
+            f"{path}: {field} is missing a string rope_type"
+        )
+
+    required_by_type = {
+        "default": set(),
+        "linear": {"factor"},
+        "dynamic": {"factor"},
+        "yarn": {"factor"},
+        "llama3": {
+            "factor",
+            "low_freq_factor",
+            "high_freq_factor",
+            "original_max_position_embeddings",
+        },
+        "longrope": {"short_factor", "long_factor"},
+    }
+    optional_by_type = {
+        "default": set(),
+        "linear": set(),
+        "dynamic": {"original_max_position_embeddings"},
+        "yarn": {
+            "attention_factor",
+            "beta_fast",
+            "beta_slow",
+            "original_max_position_embeddings",
+            "mscale",
+            "mscale_all_dim",
+            "truncate",
+        },
+        "llama3": set(),
+        "longrope": {
+            "attention_factor",
+            "factor",
+            "original_max_position_embeddings",
+        },
+    }
+    if rope_type not in required_by_type:
+        raise HfCheckpointCompatibilityError(
+            f"{path}: {field} uses rope_type={rope_type!r}, which Transformers 4 cannot validate"
+        )
+    missing = required_by_type[rope_type] - scaling.keys()
+    if missing:
+        raise HfCheckpointCompatibilityError(
+            f"{path}: {field} for rope_type={rope_type!r} is missing {sorted(missing)}"
+        )
+    unexpected = (
+        scaling.keys()
+        - required_by_type[rope_type]
+        - optional_by_type[rope_type]
+        - {"rope_type"}
+    )
+    if unexpected:
+        raise HfCheckpointCompatibilityError(
+            f"{path}: {field} for rope_type={rope_type!r} has unsupported fields {sorted(unexpected)}"
+        )
+
+    for numeric_field in (
+        "factor",
+        "low_freq_factor",
+        "high_freq_factor",
+        "attention_factor",
+        "beta_fast",
+        "beta_slow",
+        "mscale",
+        "mscale_all_dim",
+    ):
+        if numeric_field in scaling:
+            _positive_number(
+                scaling[numeric_field], field=f"{field}.{numeric_field}", path=path
+            )
+    if "factor" in scaling and scaling["factor"] < 1:
+        raise HfCheckpointCompatibilityError(
+            f"{path}: {field}.factor must be at least 1"
+        )
+    if "original_max_position_embeddings" in scaling:
+        original_max = scaling["original_max_position_embeddings"]
+        if (
+            isinstance(original_max, bool)
+            or not isinstance(original_max, int)
+            or original_max <= 0
+        ):
+            raise HfCheckpointCompatibilityError(
+                f"{path}: {field}.original_max_position_embeddings must be a positive integer"
+            )
+    if (
+        rope_type == "llama3"
+        and scaling["high_freq_factor"] <= scaling["low_freq_factor"]
+    ):
+        raise HfCheckpointCompatibilityError(
+            f"{path}: {field}.high_freq_factor must exceed low_freq_factor"
+        )
+    if rope_type == "yarn" and scaling.get("beta_fast", 32) < scaling.get(
+        "beta_slow", 1
+    ):
+        raise HfCheckpointCompatibilityError(
+            f"{path}: {field}.beta_fast must be at least beta_slow"
+        )
+    for factors_field in ("short_factor", "long_factor"):
+        if factors_field not in scaling:
+            continue
+        factors = scaling[factors_field]
+        if not isinstance(factors, list) or not factors:
+            raise HfCheckpointCompatibilityError(
+                f"{path}: {field}.{factors_field} must be a non-empty list of positive numbers"
+            )
+        for index, factor in enumerate(factors):
+            _positive_number(
+                factor,
+                field=f"{field}.{factors_field}[{index}]",
+                path=path,
+            )
+    return scaling
+
+
+def _legacy_rope_from_parameters(
+    value: Any, *, path: Path
+) -> tuple[int | float, dict[str, Any] | None]:
+    if not isinstance(value, dict):
+        raise HfCheckpointCompatibilityError(
+            f"{path}: rope_parameters must be a JSON object"
+        )
+    parameters = dict(value)
+    if "rope_theta" not in parameters:
+        raise HfCheckpointCompatibilityError(
+            f"{path}: rope_parameters is missing rope_theta; per-layer or incomplete RoPE cannot be translated"
+        )
+    theta = _positive_number(
+        parameters.pop("rope_theta"), field="rope_parameters.rope_theta", path=path
+    )
+    scaling = _canonical_rope_scaling(parameters, field="rope_parameters", path=path)
+    if scaling is not None and scaling["rope_type"] == "default":
+        unexpected = set(scaling) - {"rope_type"}
+        if unexpected:
+            raise HfCheckpointCompatibilityError(
+                f"{path}: default rope_parameters contains fields Transformers 4 cannot preserve: "
+                f"{sorted(unexpected)}"
+            )
+        scaling = None
+    return theta, scaling
+
+
+def _validate_effective_rope(
+    config: PretrainedConfig,
+    *,
+    expected_theta: float | None,
+    expected_scaling: dict[str, Any] | None,
+    check_scaling: bool,
+    path: Path,
+) -> None:
+    if (
+        expected_theta is not None
+        and getattr(config, "rope_theta", None) != expected_theta
+    ):
+        raise HfCheckpointCompatibilityError(
+            f"{path}: Transformers resolved rope_theta={getattr(config, 'rope_theta', None)!r}, "
+            f"expected {expected_theta!r}"
+        )
+    if check_scaling:
+        effective_scaling = _canonical_rope_scaling(
+            getattr(config, "rope_scaling", None),
+            field="effective rope_scaling",
+            path=path,
+        )
+        if effective_scaling != expected_scaling:
+            raise HfCheckpointCompatibilityError(
+                f"{path}: Transformers resolved rope_scaling={effective_scaling!r}, "
+                f"expected {expected_scaling!r}"
+            )
+
+
+def load_hf_checkpoint_config(checkpoint_path: str | Path) -> PretrainedConfig:
+    """Load and validate a local HF config without Transformers-major drift.
+
+    Historical Transformers 5 exports are translated in memory. Consistent
+    dual-schema exports are accepted. Conflicting or incomplete schemas raise
+    before a tokenizer or model weight loader is called.
+    """
+    checkpoint_path = Path(checkpoint_path)
+    config_path = checkpoint_path / "config.json"
+    raw_config = _read_json_object(config_path)
+
+    has_parameters = "rope_parameters" in raw_config
+    has_legacy_theta = "rope_theta" in raw_config
+    has_legacy_scaling = "rope_scaling" in raw_config
+
+    expected_theta: int | float | None = None
+    expected_scaling: dict[str, Any] | None = None
+    check_scaling = False
+
+    if has_parameters:
+        expected_theta, expected_scaling = _legacy_rope_from_parameters(
+            raw_config["rope_parameters"], path=config_path
+        )
+        has_any_legacy = has_legacy_theta or has_legacy_scaling
+        if has_any_legacy:
+            if not has_legacy_theta:
+                raise HfCheckpointCompatibilityError(
+                    f"{config_path}: dual-schema RoPE is missing top-level rope_theta"
+                )
+            legacy_theta = _positive_number(
+                raw_config["rope_theta"], field="rope_theta", path=config_path
+            )
+            legacy_scaling = _canonical_rope_scaling(
+                raw_config.get("rope_scaling"), field="rope_scaling", path=config_path
+            )
+            if legacy_theta != expected_theta or legacy_scaling != expected_scaling:
+                raise HfCheckpointCompatibilityError(
+                    f"{config_path}: conflicting Transformers 4 and 5 RoPE schemas"
+                )
+        check_scaling = True
+        config = AutoConfig.from_pretrained(
+            checkpoint_path,
+            trust_remote_code=True,
+            rope_theta=expected_theta,
+            rope_scaling=expected_scaling,
+        )
+    else:
+        if has_legacy_theta:
+            expected_theta = _positive_number(
+                raw_config["rope_theta"], field="rope_theta", path=config_path
+            )
+        if has_legacy_scaling:
+            expected_scaling = _canonical_rope_scaling(
+                raw_config["rope_scaling"], field="rope_scaling", path=config_path
+            )
+            check_scaling = True
+        config = AutoConfig.from_pretrained(checkpoint_path, trust_remote_code=True)
+
+    _validate_effective_rope(
+        config,
+        expected_theta=expected_theta,
+        expected_scaling=expected_scaling,
+        check_scaling=check_scaling,
+        path=config_path,
+    )
+    return config
+
+
+def load_hf_checkpoint_tokenizer(
+    checkpoint_path: str | Path,
+) -> PreTrainedTokenizerBase:
+    """Load native Transformers 4 and Transformers 5 tokenizer exports."""
+    checkpoint_path = Path(checkpoint_path)
+    tokenizer_config_path = checkpoint_path / "tokenizer_config.json"
+    if tokenizer_config_path.is_file():
+        tokenizer_config = _read_json_object(tokenizer_config_path)
+        if tokenizer_config.get("tokenizer_class") == "TokenizersBackend":
+            tokenizer_json_path = checkpoint_path / "tokenizer.json"
+            if not tokenizer_json_path.is_file():
+                raise HfCheckpointCompatibilityError(
+                    f"TokenizersBackend export is missing tokenizer.json: {tokenizer_json_path}"
+                )
+            return PreTrainedTokenizerFast.from_pretrained(checkpoint_path)
+    return AutoTokenizer.from_pretrained(checkpoint_path)
+
+
+def _load_hf_model_and_tokenizer(
+    checkpoint_path: str | Path, model_loader: Any
+) -> tuple[PreTrainedTokenizerBase, Any]:
+    checkpoint_path = Path(checkpoint_path)
+    config = load_hf_checkpoint_config(checkpoint_path)
+    tokenizer = load_hf_checkpoint_tokenizer(checkpoint_path)
+    model = model_loader.from_pretrained(
+        checkpoint_path,
+        config=config,
+        trust_remote_code=True,
+    )
+    return tokenizer, model
+
+
+def load_hf_causal_lm_and_tokenizer(
+    checkpoint_path: str | Path,
+) -> tuple[PreTrainedTokenizerBase, Any]:
+    """Load a validated causal LM and its compatible tokenizer."""
+    return _load_hf_model_and_tokenizer(checkpoint_path, AutoModelForCausalLM)
+
+
+def load_hf_base_model_and_tokenizer(
+    checkpoint_path: str | Path,
+) -> tuple[PreTrainedTokenizerBase, Any]:
+    """Load a validated base model and its compatible tokenizer."""
+    return _load_hf_model_and_tokenizer(checkpoint_path, AutoModel)

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/hf_compat.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/hf_compat.py
@@ -209,6 +209,11 @@ def _legacy_rope_from_parameters(
         parameters.pop("rope_theta"), field="rope_parameters.rope_theta", path=path
     )
     scaling = _canonical_rope_scaling(parameters, field="rope_parameters", path=path)
+    if scaling is not None and scaling["rope_type"] == "longrope":
+        raise HfCheckpointCompatibilityError(
+            f"{path}: Transformers-5 longrope cannot be translated to Transformers 4 "
+            "without changing its original-context semantics"
+        )
     return theta, scaling
 
 
@@ -218,6 +223,47 @@ def _validate_longrope_dimensions(
     *,
     path: Path,
 ) -> None:
+    max_position_embeddings = getattr(config, "max_position_embeddings", None)
+    if (
+        isinstance(max_position_embeddings, bool)
+        or not isinstance(max_position_embeddings, int)
+        or max_position_embeddings <= 0
+    ):
+        raise HfCheckpointCompatibilityError(
+            f"{path}: max_position_embeddings must be a positive integer for longrope"
+        )
+    original_max = getattr(config, "original_max_position_embeddings", None)
+    nested_original_max = scaling.get("original_max_position_embeddings")
+    if original_max is not None:
+        if (
+            isinstance(original_max, bool)
+            or not isinstance(original_max, int)
+            or original_max <= 0
+        ):
+            raise HfCheckpointCompatibilityError(
+                f"{path}: original_max_position_embeddings must be a positive integer"
+            )
+        if nested_original_max is not None and nested_original_max != original_max:
+            raise HfCheckpointCompatibilityError(
+                f"{path}: top-level and nested original_max_position_embeddings conflict"
+            )
+        if "factor" in scaling and not math.isclose(
+            float(scaling["factor"]),
+            max_position_embeddings / original_max,
+        ):
+            raise HfCheckpointCompatibilityError(
+                f"{path}: longrope factor conflicts with the effective context-length ratio"
+            )
+    elif nested_original_max is not None:
+        raise HfCheckpointCompatibilityError(
+            f"{path}: Transformers 4 ignores nested longrope original_max_position_embeddings"
+        )
+    elif "factor" not in scaling and "attention_factor" not in scaling:
+        raise HfCheckpointCompatibilityError(
+            f"{path}: longrope requires factor when no original context length or "
+            "attention_factor is available"
+        )
+
     head_dim = getattr(config, "head_dim", None)
     if head_dim is None:
         hidden_size = getattr(config, "hidden_size", None)

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/inference.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/inference.py
@@ -5,9 +5,9 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 from datasets import Dataset
-from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from marin_dna.data.genome import Genome
+from marin_dna_evals.hf_compat import load_hf_causal_lm_and_tokenizer
 from marin_dna_evals.model.runner import run_variant_score_bundle
 
 
@@ -112,13 +112,7 @@ def compute_variant_scores(
     # normalization collapses // to /). Genome accepts str | Path and
     # detects the remote scheme itself.
     genome = Genome(genome_path)
-    # AutoTokenizer / AutoModelForCausalLM satisfy the duck-typed interface
-    # marin_dna_evals.model.runner expects — no adapter wrappers needed.
-    tokenizer = AutoTokenizer.from_pretrained(checkpoint_path)
-    model = AutoModelForCausalLM.from_pretrained(
-        checkpoint_path,
-        trust_remote_code=True,
-    )
+    tokenizer, model = load_hf_causal_lm_and_tokenizer(checkpoint_path)
     hf_dataset = Dataset.from_pandas(dataset, preserve_index=False)
 
     inference_kwargs: dict[str, object] = {

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/interpretation.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/interpretation.py
@@ -10,14 +10,14 @@ thin orchestration layer the Snakemake rule calls.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Literal
+from typing import Literal
 
 import numpy as np
 import pandas as pd
 import torch
-from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from marin_dna.data.genome import Genome
+from marin_dna_evals.hf_compat import load_hf_causal_lm_and_tokenizer
 from marin_dna_evals.model.interpretation import nucleotide_dependency_map
 
 
@@ -65,13 +65,7 @@ def compute_dependency_map(
         f"pick a smaller locus or a longer-context model"
     )
 
-    # Duck-typed model/tokenizer throughout interpretation (see
-    # marin_dna_evals.model.interpretation); annotate Any so HF stub overloads on
-    # `.to(device)` don't fight mypy.
-    tokenizer: Any = AutoTokenizer.from_pretrained(checkpoint_path)
-    model: Any = AutoModelForCausalLM.from_pretrained(
-        checkpoint_path, trust_remote_code=True
-    )
+    tokenizer, model = load_hf_causal_lm_and_tokenizer(checkpoint_path)
     device = "cuda" if torch.cuda.is_available() else "cpu"
     model.to(device).eval()
 

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/ll_gap.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/ll_gap.py
@@ -9,21 +9,20 @@ proxy for "captures functional vs non-functional sequence structure" (issue #8).
 This is the model-agnostic core: the computation kernel
 (``marin_dna_evals.model.runner.run_ll_clm`` → ``compute_ll_clm`` over
 ``transform_ll_clm``) is shared with the Evo2 path; only the model loader
-differs. ``compute_hf_ll_gap`` loads an HF ``AutoModelForCausalLM`` directly (no
-Evo2 shims). ``aggregate_ll_gap`` (used by both paths) lives here because it is
-pure numpy and not Evo2-specific.
+differs. ``compute_hf_ll_gap`` loads an HF causal LM through the shared
+fail-closed config boundary. ``aggregate_ll_gap`` (used by both paths) lives
+here because it is pure numpy and not Evo2-specific.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import numpy as np
 import pandas as pd
 from datasets import Dataset
-from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from marin_dna_evals.hf_compat import load_hf_causal_lm_and_tokenizer
 from marin_dna_evals.model.runner import run_ll_clm
 
 
@@ -81,12 +80,7 @@ def compute_hf_ll_gap(
         f"{sorted(seq_lens.unique())[:5]}"
     )
 
-    # AutoTokenizer / AutoModelForCausalLM satisfy the duck-typed interface
-    # marin_dna_evals.model.runner expects — no adapter wrappers needed.
-    tokenizer: Any = AutoTokenizer.from_pretrained(checkpoint_path)
-    model: Any = AutoModelForCausalLM.from_pretrained(
-        checkpoint_path, trust_remote_code=True
-    )
+    tokenizer, model = load_hf_causal_lm_and_tokenizer(checkpoint_path)
 
     hf_dataset = Dataset.from_pandas(sequences[["seq"]], preserve_index=False)
     pred = run_ll_clm(

--- a/snakemake/analysis/evals_v2/tests/evals/test_embedding_umap.py
+++ b/snakemake/analysis/evals_v2/tests/evals/test_embedding_umap.py
@@ -122,8 +122,11 @@ def test_compute_region_embeddings_embeds_all_windows(monkeypatch):
         captured.update(kwargs["inference_kwargs"])
         return emb_block
 
-    monkeypatch.setattr(eu.AutoTokenizer, "from_pretrained", lambda *a, **k: object())
-    monkeypatch.setattr(eu.AutoModel, "from_pretrained", lambda *a, **k: object())
+    monkeypatch.setattr(
+        eu,
+        "load_hf_base_model_and_tokenizer",
+        lambda *a, **k: (object(), object()),
+    )
     monkeypatch.setattr(eu, "Genome", lambda *a, **k: object())
     monkeypatch.setattr(eu, "run_window_embeddings", fake_embeddings)
 

--- a/snakemake/analysis/evals_v2/tests/evals/test_hf_compat.py
+++ b/snakemake/analysis/evals_v2/tests/evals/test_hf_compat.py
@@ -1,0 +1,272 @@
+"""Regression tests for the Transformers 4/5 HF checkpoint boundary."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from marin_dna_evals.hf_compat import (
+    HfCheckpointCompatibilityError,
+    load_hf_base_model_and_tokenizer,
+    load_hf_causal_lm_and_tokenizer,
+    load_hf_checkpoint_config,
+    load_hf_checkpoint_tokenizer,
+)
+
+LLAMA3_SCALING = {
+    "rope_type": "llama3",
+    "factor": 8.0,
+    "low_freq_factor": 1.0,
+    "high_freq_factor": 4.0,
+    "original_max_position_embeddings": 8192,
+}
+LLAMA3_PARAMETERS = {"rope_theta": 500000, **LLAMA3_SCALING}
+
+
+def _write_config(tmp_path: Path, **rope_fields: object) -> None:
+    config = {"model_type": "qwen3", **rope_fields}
+    (tmp_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
+def test_load_config_preserves_transformers4_rope(tmp_path: Path) -> None:
+    _write_config(tmp_path, rope_theta=500000, rope_scaling=LLAMA3_SCALING)
+
+    config = load_hf_checkpoint_config(tmp_path)
+
+    assert config.rope_theta == 500000
+    assert config.rope_scaling == LLAMA3_SCALING
+
+
+def test_load_config_translates_transformers5_rope(tmp_path: Path) -> None:
+    _write_config(tmp_path, rope_parameters=LLAMA3_PARAMETERS)
+
+    config = load_hf_checkpoint_config(tmp_path)
+
+    assert config.rope_theta == 500000
+    assert config.rope_scaling == LLAMA3_SCALING
+
+
+def test_load_config_accepts_consistent_dual_schema(tmp_path: Path) -> None:
+    _write_config(
+        tmp_path,
+        rope_parameters=LLAMA3_PARAMETERS,
+        rope_theta=500000.0,
+        rope_scaling=LLAMA3_SCALING,
+    )
+
+    config = load_hf_checkpoint_config(tmp_path)
+
+    assert config.rope_theta == 500000
+    assert config.rope_scaling == LLAMA3_SCALING
+
+
+@pytest.mark.parametrize(
+    "legacy_fields",
+    [
+        {"rope_theta": 10000, "rope_scaling": LLAMA3_SCALING},
+        {
+            "rope_theta": 500000,
+            "rope_scaling": {**LLAMA3_SCALING, "high_freq_factor": 2.0},
+        },
+    ],
+)
+def test_load_config_rejects_conflicting_dual_schema(
+    tmp_path: Path, legacy_fields: dict[str, object]
+) -> None:
+    _write_config(tmp_path, rope_parameters=LLAMA3_PARAMETERS, **legacy_fields)
+
+    with pytest.raises(HfCheckpointCompatibilityError, match="conflicting"):
+        load_hf_checkpoint_config(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("parameters", "message"),
+    [
+        ({"rope_type": "llama3", **LLAMA3_SCALING}, "missing rope_theta"),
+        ({"rope_theta": 500000, "rope_type": "llama3"}, "is missing"),
+        (["not", "an", "object"], "must be a JSON object"),
+        (
+            {
+                "full_attention": {"rope_type": "default", "rope_theta": 10000},
+                "sliding_attention": {"rope_type": "default", "rope_theta": 10000},
+            },
+            "per-layer or incomplete",
+        ),
+    ],
+)
+def test_load_config_rejects_incomplete_or_malformed_transformers5_schema(
+    tmp_path: Path, parameters: object, message: str
+) -> None:
+    _write_config(tmp_path, rope_parameters=parameters)
+
+    with pytest.raises(HfCheckpointCompatibilityError, match=message):
+        load_hf_checkpoint_config(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("parameters", "message"),
+    [
+        ({"rope_theta": 500000, "rope_type": "future_rope"}, "cannot validate"),
+        (
+            {"rope_theta": 500000, **LLAMA3_SCALING, "producer_only_field": 1},
+            "unsupported fields",
+        ),
+        (
+            {"rope_theta": 500000, "rope_type": "linear", "factor": 0.5},
+            "at least 1",
+        ),
+    ],
+)
+def test_load_config_rejects_unrepresentable_transformers5_schema(
+    tmp_path: Path, parameters: object, message: str
+) -> None:
+    _write_config(tmp_path, rope_parameters=parameters)
+
+    with pytest.raises(HfCheckpointCompatibilityError, match=message):
+        load_hf_checkpoint_config(tmp_path)
+
+
+def test_load_config_translates_unscaled_transformers5_rope(tmp_path: Path) -> None:
+    _write_config(
+        tmp_path,
+        rope_parameters={"rope_type": "default", "rope_theta": 500000},
+    )
+
+    config = load_hf_checkpoint_config(tmp_path)
+
+    assert config.rope_theta == 500000
+    assert config.rope_scaling is None
+
+
+def test_load_config_requires_local_config_json(tmp_path: Path) -> None:
+    with pytest.raises(HfCheckpointCompatibilityError, match="config.json"):
+        load_hf_checkpoint_config(tmp_path)
+
+
+def test_load_tokenizer_uses_auto_for_native_export(tmp_path: Path) -> None:
+    tokenizer = object()
+    with (
+        patch(
+            "marin_dna_evals.hf_compat.AutoTokenizer.from_pretrained",
+            return_value=tokenizer,
+        ) as auto_load,
+        patch(
+            "marin_dna_evals.hf_compat.PreTrainedTokenizerFast.from_pretrained"
+        ) as fast_load,
+    ):
+        assert load_hf_checkpoint_tokenizer(tmp_path) is tokenizer
+    auto_load.assert_called_once_with(tmp_path)
+    fast_load.assert_not_called()
+
+
+def test_load_tokenizer_handles_transformers5_backend(tmp_path: Path) -> None:
+    (tmp_path / "tokenizer_config.json").write_text(
+        '{"tokenizer_class": "TokenizersBackend"}', encoding="utf-8"
+    )
+    (tmp_path / "tokenizer.json").write_text("{}", encoding="utf-8")
+    tokenizer = object()
+    with (
+        patch("marin_dna_evals.hf_compat.AutoTokenizer.from_pretrained") as auto_load,
+        patch(
+            "marin_dna_evals.hf_compat.PreTrainedTokenizerFast.from_pretrained",
+            return_value=tokenizer,
+        ) as fast_load,
+    ):
+        assert load_hf_checkpoint_tokenizer(tmp_path) is tokenizer
+    auto_load.assert_not_called()
+    fast_load.assert_called_once_with(tmp_path)
+
+
+def test_load_tokenizer_requires_json_for_transformers5_backend(tmp_path: Path) -> None:
+    (tmp_path / "tokenizer_config.json").write_text(
+        '{"tokenizer_class": "TokenizersBackend"}', encoding="utf-8"
+    )
+    with pytest.raises(HfCheckpointCompatibilityError, match="missing tokenizer.json"):
+        load_hf_checkpoint_tokenizer(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("function_name", "loader_name"),
+    [
+        ("load_hf_causal_lm_and_tokenizer", "AutoModelForCausalLM"),
+        ("load_hf_base_model_and_tokenizer", "AutoModel"),
+    ],
+)
+def test_model_loaders_pass_validated_config_explicitly(
+    function_name: str, loader_name: str
+) -> None:
+    checkpoint_path = Path("/checkpoint")
+    config = object()
+    tokenizer = object()
+    model = object()
+    function = {
+        "load_hf_causal_lm_and_tokenizer": load_hf_causal_lm_and_tokenizer,
+        "load_hf_base_model_and_tokenizer": load_hf_base_model_and_tokenizer,
+    }[function_name]
+    with (
+        patch(
+            "marin_dna_evals.hf_compat.load_hf_checkpoint_config", return_value=config
+        ),
+        patch(
+            "marin_dna_evals.hf_compat.load_hf_checkpoint_tokenizer",
+            return_value=tokenizer,
+        ),
+        patch(
+            f"marin_dna_evals.hf_compat.{loader_name}.from_pretrained",
+            return_value=model,
+        ) as load,
+    ):
+        assert function(checkpoint_path) == (tokenizer, model)
+    load.assert_called_once_with(
+        checkpoint_path,
+        config=config,
+        trust_remote_code=True,
+    )
+
+
+def test_invalid_config_stops_before_tokenizer_or_weight_loading(
+    tmp_path: Path,
+) -> None:
+    _write_config(
+        tmp_path,
+        rope_parameters=LLAMA3_PARAMETERS,
+        rope_theta=10000,
+        rope_scaling=LLAMA3_SCALING,
+    )
+    with (
+        patch(
+            "marin_dna_evals.hf_compat.load_hf_checkpoint_tokenizer"
+        ) as tokenizer_load,
+        patch(
+            "marin_dna_evals.hf_compat.AutoModelForCausalLM.from_pretrained"
+        ) as model_load,
+        pytest.raises(HfCheckpointCompatibilityError, match="conflicting"),
+    ):
+        load_hf_causal_lm_and_tokenizer(tmp_path)
+    tokenizer_load.assert_not_called()
+    model_load.assert_not_called()
+
+
+def test_production_auto_model_loading_is_centralized() -> None:
+    package_root = Path(__file__).parents[2] / "src" / "marin_dna_evals"
+    offenders: list[str] = []
+    for path in package_root.rglob("*.py"):
+        if path.name == "hf_compat.py":
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(
+                node.func, ast.Attribute
+            ):
+                continue
+            owner = node.func.value
+            if (
+                node.func.attr == "from_pretrained"
+                and isinstance(owner, ast.Name)
+                and owner.id in {"AutoModel", "AutoModelForCausalLM"}
+            ):
+                offenders.append(f"{path.relative_to(package_root)}:{node.lineno}")
+    assert offenders == []

--- a/snakemake/analysis/evals_v2/tests/evals/test_hf_compat.py
+++ b/snakemake/analysis/evals_v2/tests/evals/test_hf_compat.py
@@ -63,6 +63,22 @@ def test_load_config_accepts_consistent_dual_schema(tmp_path: Path) -> None:
     assert config.rope_scaling == LLAMA3_SCALING
 
 
+def test_load_config_accepts_semantically_equivalent_default_dual_schema(
+    tmp_path: Path,
+) -> None:
+    _write_config(
+        tmp_path,
+        rope_parameters={"rope_theta": 500000, "rope_type": "default"},
+        rope_theta=500000,
+        rope_scaling={"rope_type": "default"},
+    )
+
+    config = load_hf_checkpoint_config(tmp_path)
+
+    assert config.rope_theta == 500000
+    assert config.rope_scaling is None
+
+
 @pytest.mark.parametrize(
     "legacy_fields",
     [
@@ -118,6 +134,15 @@ def test_load_config_rejects_incomplete_or_malformed_transformers5_schema(
             {"rope_theta": 500000, "rope_type": "linear", "factor": 0.5},
             "at least 1",
         ),
+        (
+            {
+                "rope_theta": 500000,
+                "rope_type": "yarn",
+                "factor": 8.0,
+                "truncate": "false",
+            },
+            "must be a boolean",
+        ),
     ],
 )
 def test_load_config_rejects_unrepresentable_transformers5_schema(
@@ -126,6 +151,24 @@ def test_load_config_rejects_unrepresentable_transformers5_schema(
     _write_config(tmp_path, rope_parameters=parameters)
 
     with pytest.raises(HfCheckpointCompatibilityError, match=message):
+        load_hf_checkpoint_config(tmp_path)
+
+
+def test_load_config_rejects_longrope_factor_length_mismatch(tmp_path: Path) -> None:
+    _write_config(
+        tmp_path,
+        hidden_size=8,
+        num_attention_heads=2,
+        head_dim=4,
+        rope_parameters={
+            "rope_theta": 500000,
+            "rope_type": "longrope",
+            "short_factor": [1.0],
+            "long_factor": [2.0],
+        },
+    )
+
+    with pytest.raises(HfCheckpointCompatibilityError, match="must contain 2 values"):
         load_hf_checkpoint_config(tmp_path)
 
 

--- a/snakemake/analysis/evals_v2/tests/evals/test_hf_compat.py
+++ b/snakemake/analysis/evals_v2/tests/evals/test_hf_compat.py
@@ -154,7 +154,9 @@ def test_load_config_rejects_unrepresentable_transformers5_schema(
         load_hf_checkpoint_config(tmp_path)
 
 
-def test_load_config_rejects_longrope_factor_length_mismatch(tmp_path: Path) -> None:
+def test_load_config_rejects_transformers5_longrope_as_unrepresentable(
+    tmp_path: Path,
+) -> None:
     _write_config(
         tmp_path,
         hidden_size=8,
@@ -163,8 +165,32 @@ def test_load_config_rejects_longrope_factor_length_mismatch(tmp_path: Path) -> 
         rope_parameters={
             "rope_theta": 500000,
             "rope_type": "longrope",
+            "short_factor": [1.0, 1.0],
+            "long_factor": [2.0, 2.0],
+            "factor": 2.0,
+        },
+    )
+
+    with pytest.raises(HfCheckpointCompatibilityError, match="cannot be translated"):
+        load_hf_checkpoint_config(tmp_path)
+
+
+def test_load_config_rejects_transformers4_longrope_factor_length_mismatch(
+    tmp_path: Path,
+) -> None:
+    _write_config(
+        tmp_path,
+        hidden_size=8,
+        num_attention_heads=2,
+        head_dim=4,
+        max_position_embeddings=8,
+        original_max_position_embeddings=4,
+        rope_theta=500000,
+        rope_scaling={
+            "rope_type": "longrope",
             "short_factor": [1.0],
             "long_factor": [2.0],
+            "factor": 2.0,
         },
     )
 

--- a/snakemake/analysis/evals_v2/tests/evals/test_inference.py
+++ b/snakemake/analysis/evals_v2/tests/evals/test_inference.py
@@ -37,12 +37,8 @@ def _patched_model_load():
     actually downloads a checkpoint or opens a FASTA."""
     return (
         patch(
-            "marin_dna_evals.inference.AutoTokenizer.from_pretrained",
-            return_value=object(),
-        ),
-        patch(
-            "marin_dna_evals.inference.AutoModelForCausalLM.from_pretrained",
-            return_value=object(),
+            "marin_dna_evals.inference.load_hf_causal_lm_and_tokenizer",
+            return_value=(object(), object()),
         ),
         patch(
             "marin_dna_evals.inference.Genome",
@@ -55,10 +51,9 @@ def test_compute_variant_scores_rc_false_returns_two_cols():
     ds = _stub_dataset()
     fwd_arr = np.array([[0.1, 0.01], [0.2, 0.02], [0.3, 0.03], [0.4, 0.04]])
 
-    tok_patch, model_patch, genome_patch = _patched_model_load()
+    load_patch, genome_patch = _patched_model_load()
     with (
-        tok_patch,
-        model_patch,
+        load_patch,
         genome_patch,
         patch(
             "marin_dna_evals.inference.run_variant_score_bundle",
@@ -83,10 +78,9 @@ def test_compute_variant_scores_rc_true_returns_four_cols():
     fwd_arr = np.array([[0.1, 0.01], [0.2, 0.02], [0.3, 0.03], [0.4, 0.04]])
     rc_arr = np.array([[-0.1, 0.05], [-0.2, 0.06], [-0.3, 0.07], [-0.4, 0.08]])
 
-    tok_patch, model_patch, genome_patch = _patched_model_load()
+    load_patch, genome_patch = _patched_model_load()
     with (
-        tok_patch,
-        model_patch,
+        load_patch,
         genome_patch,
         patch(
             "marin_dna_evals.inference.run_variant_score_bundle",
@@ -112,10 +106,9 @@ def test_compute_variant_scores_threads_execution_settings():
     ds = _stub_dataset()
     fwd = np.zeros((len(ds), 2), dtype=np.float32)
     rc = np.zeros((len(ds), 2), dtype=np.float32)
-    tok_patch, model_patch, genome_patch = _patched_model_load()
+    load_patch, genome_patch = _patched_model_load()
     with (
-        tok_patch,
-        model_patch,
+        load_patch,
         genome_patch,
         patch(
             "marin_dna_evals.inference.run_variant_score_bundle",
@@ -150,10 +143,9 @@ def test_compute_variant_scores_avg_derivable_from_atoms():
     fwd_arr = np.array([[1.0, 0.5], [2.0, 0.6], [3.0, 0.7], [4.0, 0.8]])
     rc_arr = np.array([[-1.0, 0.1], [0.0, 0.2], [1.0, 0.3], [2.0, 0.4]])
 
-    tok_patch, model_patch, genome_patch = _patched_model_load()
+    load_patch, genome_patch = _patched_model_load()
     with (
-        tok_patch,
-        model_patch,
+        load_patch,
         genome_patch,
         patch(
             "marin_dna_evals.inference.run_variant_score_bundle",
@@ -210,13 +202,10 @@ def _patched_model_load_with_hidden(hidden_size: int):
     (the driver reads it to slice the embedding block)."""
     return (
         patch(
-            "marin_dna_evals.inference.AutoTokenizer.from_pretrained",
-            return_value=object(),
-        ),
-        patch(
-            "marin_dna_evals.inference.AutoModelForCausalLM.from_pretrained",
-            return_value=SimpleNamespace(
-                config=SimpleNamespace(hidden_size=hidden_size)
+            "marin_dna_evals.inference.load_hf_causal_lm_and_tokenizer",
+            return_value=(
+                object(),
+                SimpleNamespace(config=SimpleNamespace(hidden_size=hidden_size)),
             ),
         ),
         patch(
@@ -237,10 +226,9 @@ def test_compute_variant_scores_embeddings_columns_and_fp32_average():
     fwd[:, 2:] = rng.standard_normal((n, 2 * d)).astype(np.float32)
     rc[:, 2:] = rng.standard_normal((n, 2 * d)).astype(np.float32)
 
-    tok_patch, model_patch, genome_patch = _patched_model_load_with_hidden(d)
+    load_patch, genome_patch = _patched_model_load_with_hidden(d)
     with (
-        tok_patch,
-        model_patch,
+        load_patch,
         genome_patch,
         patch(
             "marin_dna_evals.inference.run_variant_score_bundle",
@@ -287,10 +275,9 @@ def test_compute_variant_scores_embeddings_parquet_roundtrip(tmp_path):
     fwd[:, 2:] = rng.standard_normal((n, 2 * d)).astype(np.float32)
     rc[:, 2:] = rng.standard_normal((n, 2 * d)).astype(np.float32)
 
-    tok_patch, model_patch, genome_patch = _patched_model_load_with_hidden(d)
+    load_patch, genome_patch = _patched_model_load_with_hidden(d)
     with (
-        tok_patch,
-        model_patch,
+        load_patch,
         genome_patch,
         patch(
             "marin_dna_evals.inference.run_variant_score_bundle",
@@ -316,10 +303,9 @@ def test_compute_variant_scores_embeddings_parquet_roundtrip(tmp_path):
 
 def test_compute_variant_scores_return_embeddings_requires_rc():
     ds = _stub_dataset()
-    tok_patch, model_patch, genome_patch = _patched_model_load_with_hidden(3)
+    load_patch, genome_patch = _patched_model_load_with_hidden(3)
     with (
-        tok_patch,
-        model_patch,
+        load_patch,
         genome_patch,
         pytest.raises(AssertionError, match="requires rc=True"),
     ):
@@ -339,10 +325,9 @@ def test_compute_variant_scores_embeddings_width_mismatch_asserts():
     n, d = len(ds), 3
     # Model says hidden_size=d but the array is 2 + 2*(d+1) wide.
     bad = np.zeros((n, 2 + 2 * (d + 1)), dtype=np.float32)
-    tok_patch, model_patch, genome_patch = _patched_model_load_with_hidden(d)
+    load_patch, genome_patch = _patched_model_load_with_hidden(d)
     with (
-        tok_patch,
-        model_patch,
+        load_patch,
         genome_patch,
         patch(
             "marin_dna_evals.inference.run_variant_score_bundle",

--- a/snakemake/analysis/evals_v2/tests/evals/test_interpretation.py
+++ b/snakemake/analysis/evals_v2/tests/evals/test_interpretation.py
@@ -33,9 +33,13 @@ def _mocked_compute(
     returns ``stub_map``.
     """
     genome_inst = MagicMock(return_value=genome_seq or "A" * window_size)
+    model = MagicMock()
+    model.to.return_value = model
     with (
-        patch(f"{_MOD}.AutoTokenizer"),
-        patch(f"{_MOD}.AutoModelForCausalLM"),
+        patch(
+            f"{_MOD}.load_hf_causal_lm_and_tokenizer",
+            return_value=(MagicMock(), model),
+        ),
         patch(f"{_MOD}.Genome", return_value=genome_inst),
         patch(f"{_MOD}.torch.cuda.is_available", return_value=False),
         patch(f"{_MOD}.nucleotide_dependency_map", return_value=stub_map),

--- a/snakemake/analysis/evals_v2/tests/evals/test_ll_gap.py
+++ b/snakemake/analysis/evals_v2/tests/evals/test_ll_gap.py
@@ -25,15 +25,9 @@ def _seqs(n: int = 3, length: int = 8) -> pd.DataFrame:
 
 def _patched_load():
     """Patch the heavy HF loaders so no checkpoint is ever downloaded."""
-    return (
-        patch(
-            "marin_dna_evals.ll_gap.AutoTokenizer.from_pretrained",
-            return_value=object(),
-        ),
-        patch(
-            "marin_dna_evals.ll_gap.AutoModelForCausalLM.from_pretrained",
-            return_value=object(),
-        ),
+    return patch(
+        "marin_dna_evals.ll_gap.load_hf_causal_lm_and_tokenizer",
+        return_value=(object(), object()),
     )
 
 
@@ -42,10 +36,9 @@ def test_compute_hf_ll_gap_returns_atoms_with_id():
     pred = np.array(
         [[-2.0, -5.0, 4, 3], [-1.0, -4.0, 4, 3], [-3.0, -6.0, 4, 3]], dtype=float
     )
-    tok, model = _patched_load()
+    load = _patched_load()
     with (
-        tok,
-        model,
+        load,
         patch("marin_dna_evals.ll_gap.run_ll_clm", return_value=pred),
     ):
         out = compute_hf_ll_gap("/unused", seqs, window_size=8, batch_size=2)
@@ -69,10 +62,9 @@ def test_compute_hf_ll_gap_returns_atoms_with_id():
 def test_compute_hf_ll_gap_threads_compile_and_bf16():
     seqs = _seqs(n=2, length=8)
     pred = np.zeros((2, 4), dtype=float)
-    tok, model = _patched_load()
+    load = _patched_load()
     with (
-        tok,
-        model,
+        load,
         patch("marin_dna_evals.ll_gap.run_ll_clm", return_value=pred) as runner,
     ):
         compute_hf_ll_gap(
@@ -94,10 +86,9 @@ def test_compute_hf_ll_gap_reshapes_flat_array():
     reshaped back to ``[N, 4]`` preserving row order."""
     seqs = _seqs(n=2, length=8)
     flat = np.array([-1.0, -2.0, 4, 3, -1.5, -2.5, 4, 3])  # [N*4]
-    tok, model = _patched_load()
+    load = _patched_load()
     with (
-        tok,
-        model,
+        load,
         patch("marin_dna_evals.ll_gap.run_ll_clm", return_value=flat),
     ):
         out = compute_hf_ll_gap("/unused", seqs, window_size=8, batch_size=2)


### PR DESCRIPTION
Validate raw Hugging Face checkpoint metadata before every maintained `evals_v2` model load. The compatibility boundary preserves Transformers-4 RoPE fields, translates supported Transformers-5 `rope_parameters` in memory, accepts semantically consistent dual schemas, and rejects conflicting or unrepresentable schemas before tokenizer or weight loading. It passes the validated config explicitly to the model loader and retains the `TokenizersBackend` fallback needed by historical exports.

Transformers 4.57 otherwise ignores Transformers-5-only `rope_parameters` and can construct Qwen3 checkpoints with `rope_theta=10000` and no scaling instead of the trained `rope_theta=500000` Llama-3 settings. The upstream producer now writes both schemas, but already-published checkpoints still need a guarded consumer.

The locked project suite passes with 411 tests and 5 optional skips. Repository pre-commit checks and the Snakemake dry-run pass. No #473 evaluation, recomputation, or artifact modification was performed.

Fixes #439