### PR TITLE
Require evals_v2 model registration

### DIFF
--- a/.agents/skills/evaluate-models/SKILL.md
+++ b/.agents/skills/evaluate-models/SKILL.md
@@ -15,6 +15,16 @@ Apply these rules before computing aggregates or choosing tables and plots.
 - Apply this restriction to labeled VEP data only.
   Unlabeled reference sequence and functional-genomics data remain available unless their dataset defines a stricter split.
 
+## Register evals_v2 Models
+
+- Before evaluating a model through `snakemake/analysis/evals_v2`, ensure it has an additive entry under `models:` in `snakemake/analysis/evals_v2/config/config.yaml`.
+  Do not rename, repurpose, or replace an existing model entry.
+- Submit each new registration in a small PR before running the evaluation.
+  Record the canonical model ID in `name`, the exact checkpoint path, `window_size`, and `datasets` scope so future work can discover and reuse existing model-dataset results instead of registering aliases or recomputing them.
+- Check the registry and canonical outputs before adding a model or running a model-dataset cell.
+- Keep evals_v2 outputs in the workflow's fixed `s3://oa-bolinas/snakemake/analysis/evals_v2/results/` layout, including `scores/{model}/{dataset}.parquet` and `metrics/{model}/{dataset}.parquet`.
+  Do not wrap these outputs in commit-keyed or issue-specific score namespaces.
+
 ## Prepare The Evaluation Frame
 
 1. Remove mature miRNA before computing any metric, aggregate, macro average, global score, table, or plot.

--- a/.agents/skills/evaluate-models/SKILL.md
+++ b/.agents/skills/evaluate-models/SKILL.md
@@ -17,9 +17,10 @@ Apply these rules before computing aggregates or choosing tables and plots.
 
 ## Register evals_v2 Models
 
-- Before evaluating a model through `snakemake/analysis/evals_v2`, ensure it has an additive entry under `models:` in `snakemake/analysis/evals_v2/config/config.yaml`.
+- Before evaluating a model through `snakemake/analysis/evals_v2`, ensure the exact model-dataset cell is registered under `models:` in `snakemake/analysis/evals_v2/config/config.yaml`.
+  Add new model entries and widen an existing model's `datasets` scope additively before running an unregistered cell.
   Do not rename, repurpose, or replace an existing model entry.
-- Submit each new registration in a small PR before running the evaluation.
+- Submit each new model registration or dataset-scope expansion in a small PR before running the evaluation.
   Record the canonical model ID in `name`, the exact checkpoint path, `window_size`, and `datasets` scope so future work can discover and reuse existing model-dataset results instead of registering aliases or recomputing them.
 - Check the registry and canonical outputs before adding a model or running a model-dataset cell.
 - Keep evals_v2 outputs in the workflow's fixed `s3://oa-bolinas/snakemake/analysis/evals_v2/results/` layout, including `scores/{model}/{dataset}.parquet` and `metrics/{model}/{dataset}.parquet`.


### PR DESCRIPTION
Require each model-dataset cell evaluated through `snakemake/analysis/evals_v2` to be registered first in the canonical configuration through a small additive PR.
New model entries and dataset-scope expansions keep canonical IDs, checkpoint paths, context windows, and evaluation coverage discoverable so later runs can find existing model-dataset results.

Keep score and metric outputs in the workflow’s fixed `s3://oa-bolinas/snakemake/analysis/evals_v2/results/` layout.
Commit-keyed and issue-specific namespaces are outside the evals_v2 storage contract.