### PR TITLE
[evals] Register issue 417 repair trajectory and issue 473 control

### DIFF
--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -234,6 +234,13 @@ uv run --locked --group genome-s3 snakemake
 The default profile (`workflow/profiles/default/config.yaml`) uses S3 storage
 at `s3://oa-bolinas/snakemake/analysis/evals_v2/`.
 
+### Issue #417 repair trajectory and #473 validation control
+
+The default `all` target includes nine checkpoints from the repaired issue #417 CDS full-window trajectory at steps 1,000 through 4,999 and the terminal issue #473 CDS full-window random-validation control.
+Every registration evaluates the Mendelian, Complex Traits, and SGE development `train` splits.
+Together they add ten checkpoint targets and 30 model–dataset score and metric cells to the default evaluation matrix.
+Existing S3 outputs are reused when present.
+
 ### Interpretation targets (off `rule all`)
 
 Two visual-interpretation analyses live alongside the metrics DAG but are kept

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -611,7 +611,7 @@ models:
     datasets: [mendelian_traits]
 
   # exp473 — terminal CDS full-window split control (issue #473). Both 0.25B
-  # models use the same center-seeded projection and anchor recipe. The #417
+  # models use the same CDS full-window projection and anchor recipe. The #417
   # checkpoint held chromosome 18 out; the control sampled 16,384 validation
   # rows before reverse-complement augmentation. Restrict evaluation to the
   # three development VEP datasets relevant to a CDS-trained model.

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -610,6 +610,20 @@ models:
     window_size: 255
     datasets: [mendelian_traits]
 
+  # exp473 — terminal CDS full-window split control (issue #473). Both 0.25B
+  # models use the same center-seeded projection and anchor recipe. The #417
+  # checkpoint held chromosome 18 out; the control sampled 16,384 validation
+  # rows before reverse-complement augmentation. Restrict evaluation to the
+  # three development VEP datasets relevant to a CDS-trained model.
+  - name: exp417-cds-combined-vertebrates-step-4999
+    gcs_path: gs://marin-us-east5/checkpoints/dna-exp417-cds-combined-vertebrates-p255m-b2m-5k/2026.08.01/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits, sge]
+  - name: exp473-cds-full-window-random-val-step-4999
+    gcs_path: gs://marin-us-east5/MarinDNA/exp473_center_seeded_projection/checkpoints/dna-exp473-0p25b-cds-fullwindow-random-val-v1/2026.08.21/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits, sge]
+
   # Eric's mix-v0.9 1B runs (Slack #marin_dna, 2026-05-18). Qwen3-1B,
   # 255 bp + BOS context. The i0-uniform run is the headline uniform-
   # mixture baseline; the i16 run continues training from i0's final

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -610,6 +610,42 @@ models:
     window_size: 255
     datasets: [mendelian_traits]
 
+  # exp473 — RoPE-consistent repair of the reused #417 CDS full-window
+  # trajectory (issue #473). These legacy exports require the maintained
+  # compatibility loader. Development VEP datasets only.
+  - name: exp417-cds-combined-vertebrates-step-1000
+    gcs_path: gs://marin-us-east5/checkpoints/dna-exp417-cds-combined-vertebrates-p255m-b2m-5k/2026.08.01/hf/step-1000
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits, sge]
+  - name: exp417-cds-combined-vertebrates-step-1500
+    gcs_path: gs://marin-us-east5/checkpoints/dna-exp417-cds-combined-vertebrates-p255m-b2m-5k/2026.08.01/hf/step-1500
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits, sge]
+  - name: exp417-cds-combined-vertebrates-step-2000
+    gcs_path: gs://marin-us-east5/checkpoints/dna-exp417-cds-combined-vertebrates-p255m-b2m-5k/2026.08.01/hf/step-2000
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits, sge]
+  - name: exp417-cds-combined-vertebrates-step-2500
+    gcs_path: gs://marin-us-east5/checkpoints/dna-exp417-cds-combined-vertebrates-p255m-b2m-5k/2026.08.01/hf/step-2500
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits, sge]
+  - name: exp417-cds-combined-vertebrates-step-3000
+    gcs_path: gs://marin-us-east5/checkpoints/dna-exp417-cds-combined-vertebrates-p255m-b2m-5k/2026.08.01/hf/step-3000
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits, sge]
+  - name: exp417-cds-combined-vertebrates-step-3500
+    gcs_path: gs://marin-us-east5/checkpoints/dna-exp417-cds-combined-vertebrates-p255m-b2m-5k/2026.08.01/hf/step-3500
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits, sge]
+  - name: exp417-cds-combined-vertebrates-step-4000
+    gcs_path: gs://marin-us-east5/checkpoints/dna-exp417-cds-combined-vertebrates-p255m-b2m-5k/2026.08.01/hf/step-4000
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits, sge]
+  - name: exp417-cds-combined-vertebrates-step-4500
+    gcs_path: gs://marin-us-east5/checkpoints/dna-exp417-cds-combined-vertebrates-p255m-b2m-5k/2026.08.01/hf/step-4500
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits, sge]
+
   # exp473 — terminal CDS full-window split control (issue #473). Both 0.25B
   # models use the same CDS full-window projection and anchor recipe. The #417
   # checkpoint held chromosome 18 out; the control sampled 16,384 validation


### PR DESCRIPTION
Register the complete issue #417 CDS full-window repair trajectory and the issue #473 row-random-validation terminal control in the standard `evals_v2` model registry.

The issue #417 registrations cover steps 1,000 through 4,999 at nine checkpoints.
Every registration uses a 255 bp window and the Mendelian, Complex Traits, and SGE development `train` datasets.
The maintained loader translates the legacy issue #417 Transformers-5 RoPE metadata in memory; the issue #473 checkpoint already contains consistent dual-schema metadata.

The default `all` target gains ten checkpoint targets and 30 model–dataset score and metric cells.
All canonical outputs already exist under `s3://oa-bolinas/snakemake/analysis/evals_v2/results/`, and the current dry-run scheduled no issue #417 or #473 work.
No shared rule changes, and no held-out VEP access is introduced.

Part of #473.