### PR TITLE
[research] Condense the accepted knowledge base

### DIFF
--- a/docs/research/experiments/402-fixed-ortholog-rag.md
+++ b/docs/research/experiments/402-fixed-ortholog-rag.md
@@ -1,12 +1,7 @@
 # Fixed-ortholog retrieval prototype
 
 > [!NOTE]
-> **TL;DR:** The fixed-ortholog 104M model reached VEP performance not seen in comparable small single-sequence models in MarinDNA's experiment history or Gonzalo Benegas's prior work; Gonzalo attributes the unusually strong performance to retrieval, while the experiment does not quantify the gain against a matched single-sequence arm; broader species coverage, longer training, and larger readers are the clearest next scale axes.
-
-![Graphical abstract showing seven mammalian ortholog windows conditioning a 104M causal model and its development-cohort VEP comparisons](figures/402/marindna-rag-visual-abstract.svg)
-
-_The fixed offline retrieval method and official development/`train` macro-AUPRC comparisons; error bars are ±1 SE and dataset facets use independent axes._
-_The figure has no matched no-retrieval training arm, so it does not quantify the retrieval gain._
+> **TL;DR:** The fixed-ortholog 104M model reached VEP performance not seen in comparable small single-sequence models in MarinDNA's experiment history or Gonzalo Benegas's prior work; Gonzalo attributes the unusually strong performance to retrieval, while the experiment does not quantify the gain against a matched single-sequence arm.
 
 ## Findings
 
@@ -22,6 +17,11 @@ The finding applies to an offline, alignment-derived context scheme.
 It does not establish the accuracy or practicality of online retrieval, arbitrary unaligned queries, or indel-effect prediction.
 
 ## Evidence
+
+![Graphical abstract showing seven mammalian ortholog windows conditioning a 104M causal model and its development-cohort VEP comparisons](figures/402/marindna-rag-visual-abstract.svg)
+
+_The fixed offline retrieval method and official development/`train` macro-AUPRC comparisons; error bars are ±1 SE and dataset facets use independent axes._
+_The figure has no matched no-retrieval training arm, so it does not quantify the retrieval gain._
 
 Each training document contained seven fixed 255-base mammalian windows projected through the Zoonomia alignment, followed by the homologous 255-base human window.
 The 46M- and 104M-parameter causal models each trained from scratch for 30,000 optimizer updates and 62.9 billion token presentations.
@@ -47,13 +47,6 @@ Behavioral checks showed that the model used the prefixed context.
 Removing, rolling, or replacing ortholog windows worsened human-token validation loss; changing the sequence-boundary tokens also changed outputs.
 Available projected bases received more attention than missing-`N` controls, with attention concentrated near the expected aligned causal offset.
 Across segment slots, loss decreased as identity to the best earlier available segment increased; the within-slot Spearman correlation was -0.471 for the 46M model and -0.470 for the 104M model across 13,169 available windows.
-
-## Promising directions
-
-The strongest near-term scale opportunity is broader species coverage because the current context covers only seven mammalian species and no non-mammalian vertebrates.
-Longer optimization is another direct axis because both validation losses were still falling at 30,000 updates.
-Larger readers are also promising because only 46M- and 104M-parameter models were tested and the 104M result was unusually strong.
-One seed per size does not establish a scaling law, so the gain from model scale remains to be measured.
 
 ## Limitations
 

--- a/docs/research/experiments/485-m5-1-inference-context.md
+++ b/docs/research/experiments/485-m5-1-inference-context.md
@@ -3,13 +3,6 @@
 > [!NOTE]
 > **TL;DR:** For the 255 bp-trained m5.1 checkpoint, cropping inference below 255 bp reduced Mendelian development macro AUPRC, extending to 511 bp produced a small zero-shot gain but no probe gain, and extending to 1023 bp sharply degraded both protocols.
 
-![Nine consequence panels showing zero-shot Mendelian AUPRC from 31 through 1023 bp inference contexts](figures/485/zero-shot-context.svg)
-
-_Zero-shot matched-pair AUPRC for the fixed m5.1 checkpoint; error bars are ±1 SE, each panel has an independent y-axis, and 511 and 1023 bp are inference-only extensions beyond the 255 bp training context._
-
-![Nine consequence panels showing frozen-probe Mendelian AUPRC from 31 through 1023 bp inference contexts](figures/485/probe-context.svg)
-
-_Frozen-probe per-chromosome-weighted AUPRC when a new probe is trained at each context; error bars are ±1 SE and each panel has an independent y-axis._
 
 ## Findings
 
@@ -26,6 +19,14 @@ Both paired intervals excluded zero, and every zero-shot consequence subset decl
 Inference-only extension to four times the checkpoint's training context is therefore unreliable for this checkpoint and task.
 
 ## Evidence
+
+![Nine consequence panels showing zero-shot Mendelian AUPRC from 31 through 1023 bp inference contexts](figures/485/zero-shot-context.svg)
+
+_Zero-shot matched-pair AUPRC for the fixed m5.1 checkpoint; error bars are ±1 SE, each panel has an independent y-axis, and 511 and 1023 bp are inference-only extensions beyond the 255 bp training context._
+
+![Nine consequence panels showing frozen-probe Mendelian AUPRC from 31 through 1023 bp inference contexts](figures/485/probe-context.svg)
+
+_Frozen-probe per-chromosome-weighted AUPRC when a new probe is trained at each context; error bars are ±1 SE and each panel has an independent y-axis._
 
 The experiment used `mix-v0.9-p1B-i24-exp135-m5.1-step-59158`, a causal 1B-parameter model trained with 255 DNA bases plus a BOS token.
 The six inference windows were 31, 63, 127, 255, 511, and 1023 DNA bases, centered on the same SNV.

--- a/docs/research/experiments/486-carbon-species-conditioning.md
+++ b/docs/research/experiments/486-carbon-species-conditioning.md
@@ -14,6 +14,7 @@ _Bars report Pearson correlation over all retained variants in each category; th
 No-tag scores had pooled Pearson correlations of 0.970 with correct-mammalian scores and 0.981 with far-wrong-fungal scores.
 Agreement was lower for promoter variants at 0.669 and 0.659 and for distal variants at 0.672 and 0.715.
 Prompt-induced changes were largest relative to the no-tag score spread in these near-neutral subsets.
+The ratio `SD(tagged − no tag) / SD(no tag)` was 0.75–0.83 for promoter and distal variants, compared with 0.16–0.24 for missense and splicing variants.
 This supports prompt sensitivity without establishing useful or biological reranking; Pearson correlation does not measure rank preservation.
 
 ### AUPRC by consequence subset

--- a/docs/research/experiments/486-carbon-species-conditioning.md
+++ b/docs/research/experiments/486-carbon-species-conditioning.md
@@ -13,14 +13,8 @@ _Bars report Pearson correlation over all retained variants in each category; th
 
 No-tag scores had pooled Pearson correlations of 0.970 with correct-mammalian scores and 0.981 with far-wrong-fungal scores.
 Agreement was lower for promoter variants at 0.669 and 0.659 and for distal variants at 0.672 and 0.715.
-Promoter and distal also had the smallest no-tag score scale: mean absolute scores of 0.00169 and 0.00174 nats per DNA target token, with standard deviations of 0.00244 and 0.00242.
-Missense and splicing had mean absolute scores of 0.00786 and 0.00534, with standard deviations of 0.01330 and 0.01520.
-The ratio `SD(tagged − no tag) / SD(no tag)` was therefore 0.75–0.83 for promoter and distal variants, compared with 0.16–0.24 for missense and splicing variants.
-Across the eight subsets, this ratio was inversely rank-correlated with Pearson agreement (Spearman ρ = -1.00 for both tags), while no-tag AUPRC and Pearson agreement were positively associated (Pearson r = 0.81 for both tags).
-The most likely explanation for the lower agreement is limited, near-neutral LLR dynamic range in regions where Carbon weakly separates deleterious variants: the prompt-induced change is nearly as large as the baseline score spread.
-An offset toward zero alone cannot lower Pearson correlation, and the analysis provides no evidence for a regional evolutionary-rate explanation.
-The relative-change ratio is algebraically related to Pearson correlation and does not establish that the prompt-induced change is random noise.
-Pearson correlation measures linear agreement rather than rank preservation, so these comparisons do not establish reranking.
+Prompt-induced changes were largest relative to the no-tag score spread in these near-neutral subsets.
+This supports prompt sensitivity without establishing useful or biological reranking; Pearson correlation does not measure rank preservation.
 
 ### AUPRC by consequence subset
 

--- a/docs/research/questions/complex-trait-vep.md
+++ b/docs/research/questions/complex-trait-vep.md
@@ -30,19 +30,9 @@ The decisive next evidence is a fixed-compute footprint ablation, followed by ma
 <details>
 <summary>Related work</summary>
 
-- The [Mendelian leaderboard](https://open-athena.github.io/marin-dna/leaderboards/mendelian), [complex-trait leaderboard](https://open-athena.github.io/marin-dna/leaderboards/complex), [#161](https://github.com/Open-Athena/marin-dna/issues/161), [#162](https://github.com/Open-Athena/marin-dna/issues/162), and [#145](https://github.com/Open-Athena/marin-dna/issues/145) define the current evaluation and GPN-Star baseline contract.
-  They expose the Mendelian-versus-complex gap under consistent dashboard metrics.
-  They do not identify whether data coverage, timescale, architecture, or scoring causes it.
 - [Ye, Benegas et al., Predicting functional constraints across evolutionary timescales with phylogeny-informed genomic language models](https://www.biorxiv.org/content/10.1101/2025.09.21.677619v1) compares vertebrate-, mammal-, and primate-alignment models.
-  Deeper evolution favors coding and rarer large-effect variants, while shallower models can favor non-coding or broader complex-trait endpoints; mammal and primate models lead different complex-trait readouts.
-  This motivates a mammal-versus-primate test rather than assuming the closest clade wins.
-  The paper does not isolate timescale from alignment-conditioned architecture for MarinDNA.
-- [How should evolutionary timescale shape training?](evolutionary-timescale.md) is the broader evolutionary-timescale synthesis.
-  Its implication here is that region and endpoint can prefer different breadths; it does not yet contain a matched complex-trait timescale result.
-- [Which genomic regions to train on, and how to find them?](training-regions.md) covers the training footprint.
-  It connects conservation filtering, weakly conserved regulatory sequence, sampling, and loss weighting, but no completed experiment yet tests the causal coverage hypothesis.
-- [Can autoregressive RAG gLMs be accurate and practical?](retrieval-augmented-models.md) covers retrieval.
-  Alignment-conditioned context is a plausible explanation for GPN-Star’s advantage, but the current RAG evidence lacks a matched no-retrieval control.
+  Deeper evolution favors coding and rarer large-effect variants, while mammal and primate models lead different complex-trait endpoints.
+  The study motivates an endpoint-specific timescale test but does not isolate timescale from alignment-conditioned architecture for MarinDNA.
 
 </details>
 
@@ -69,30 +59,9 @@ The decisive next evidence is a fixed-compute footprint ablation, followed by ma
 <details>
 <summary>Possible directions</summary>
 
-1. **Does training-footprint coverage explain the gap?**
-   Stratify current predictions by [#213](https://github.com/Open-Athena/marin-dna/issues/213)'s variant-centered conserved fraction, kept-window membership, and consequence group.
-   Compare MarinDNA with GPN-Star within each stratum.
-
-2. **Does less-conserved training sequence causally help?**
-   At fixed architecture, tokens, genome mixture, and window size, sweep the conservation cutoff and add a weakly conserved/background arm.
-   Evaluate complex global/distal AUPRC and the Mendelian tradeoff; explicitly check coordinate and sequence-similarity leakage.
-
-3. **What is the best timescale at fixed data quantity?**
-   Train matched primate, mammal, and deeper-vertebrate arms while controlling tokens and unique human loci.
-   Consider a deliberately reweighted mammal+primate mixture.
-
-4. **Is retrieval the missing capability?**
-   Compare one backbone with and without human-anchored ortholog retrieval using the same loci, species, objective, and compute.
-   As a cheaper first test, ask whether MarinDNA's error relative to GPN-Star grows as conservation weakens or alignment evidence becomes more informative.
-
-5. **How much is evaluation/readout?**
-   Use a fixed, leakage-free scoring protocol informed by [#175](https://github.com/Open-Athena/marin-dna/issues/175) and cluster-bootstrap uncertainty.
-   Stratify by PIP, consequence, MAF, and conservation to estimate any ceiling from fine-mapping ambiguity.
-
-6. **What would distinguish the hypotheses?**
-   - Improvement from a fixed-compute less-conserved-data arm, concentrated on low-conservation variants, supports hypothesis 1.
-   - Improvement from a controlled mammal/primate arm, without merely adding tokens or loci, supports hypothesis 2.
-   - Improvement from retrieval, largest on weakly conserved variants, supports hypothesis 3.
-   - If none helps, benchmark noise or missing tissue/cell-state information becomes the leading explanation.
+- Stratify current MarinDNA and GPN-Star predictions by kept-window membership, conserved fraction, consequence, and fine-mapping confidence.
+- At fixed architecture, tokens, genome mixture, and window size, compare the current footprint with weaker-conservation and background arms; measure complex-trait gains and Mendelian tradeoffs.
+- If coverage does not explain the gap, compare primate, mammal, and deeper-vertebrate training at fixed unique human loci and token exposure.
+- Estimate the incremental value of ortholog retrieval with matched reader, loci, species, objective, and compute, using a fixed leakage-free scoring protocol.
 
 </details>

--- a/docs/research/questions/data-mixtures.md
+++ b/docs/research/questions/data-mixtures.md
@@ -6,10 +6,8 @@
 ## Question
 
 How should we optimize genomic pretraining data mixtures to improve downstream genomic performance at target scale?
-This includes deciding how to partition the data, what objective to optimize, and which optimization strategies are reliable and compute-efficient.
-
-This issue tracks evidence across multiple possible approaches; swarm-based regression with small proxy models is one especially promising candidate, but it is not the definition of the research question.
-The intended outcome is a reproducible way to choose mixtures, not only a single set of weights.
+This includes deciding how to partition the data, what objective to optimize, and which selection strategies are reliable and compute-efficient.
+The intended outcome is a reproducible selection method, not a single set of weights.
 
 ## Current answer
 
@@ -17,11 +15,11 @@ No validated method for optimizing genomic pretraining mixtures exists yet.
 The current evidence shows that mixture components matter: region specialists differ sharply by downstream class, and mammalian species density affects some regions but not others.
 It does not show how to select a joint mixture.
 
-Proxy-swarm regression is a plausible candidate, not the answer.
+Proxy-swarm regression is a plausible candidate.
 Its usefulness depends on four unverified conditions: the downstream objective must have measurable signal in small models; mixture rankings must transfer to target scale; finite high-value components must tolerate the repetitions implied by target weights; and the component manifest, overlap policy, and leakage rules must remain fixed.
 
 The optimization target is also unresolved.
-Macro-average VEP, minimax performance, zero-shot scores, global probes, per-subset probes, and later regulatory tasks can favor different recipes.
+Macro-average VEP, minimax performance, zero-shot scores, global probes, per-subset probes, and regulatory tasks can favor different recipes.
 Selecting whichever readout looks best after the swarm would invalidate the optimization claim.
 
 Confidence is low.
@@ -31,20 +29,11 @@ A broad swarm or target-scale launch is not justified until rank stability, repe
 <details>
 <summary>Related work</summary>
 
-- The [Open Athena pretraining data community meeting slides](https://www.figma.com/deck/LcfkIgrKJUHV1DrJ40XbXb/Open-Athena-Pretraining-Data-Community-Meeting) define a source → normalize → deduplicate/decontaminate → bucket → optimize → train/evaluate pipeline and treat a mixture as a sampling policy over fixed buckets.
-  The implication is that component definitions and overlap policy are part of the optimization contract.
-  The remaining gap is a versioned MarinDNA manifest with unique-token budgets and leakage audits.
 - [RegMix](https://arxiv.org/abs/2407.01492) samples mixtures, trains small proxy models, fits a surrogate, and optimizes predicted performance.
   [Olmix](https://arxiv.org/abs/2602.12237) studies this family more systematically.
-  These methods motivate offline proxy swarms and held-out-mixture validation.
-  Their proxy sizes, swarm sizes, and rank-transfer behavior cannot be assumed to carry over to genomic objectives.
+  These methods motivate offline proxy swarms and held-out-mixture validation, but their rank-transfer behavior cannot be assumed to carry over to genomic objectives.
 - [Scaling Data-Constrained Language Models](https://arxiv.org/abs/2305.16264) shows diminishing returns from repeated data.
-  This makes target-scale epoching part of mixture feasibility: a component that is barely repeated in a proxy may be heavily repeated in the final run.
-  The missing observable is performance as a function of realized repetition for each genomic component.
-- Candidate surrogate families include linear/log-linear models, regularized interactions, tree models, and rank or pairwise objectives.
-  Flexible models require held-out mixtures or nested validation; in-swarm fit alone does not support mixture selection.
-- Candidate outputs should include intended and realized weights, unique tokens and repetitions per component, per-subset downstream scores, uncertainty, held-out ranking, and target-scale regret.
-  Without those fields, a selected weight vector is not a reproducible optimization result.
+  Target-scale epoching is therefore part of mixture feasibility even when repetition is mild in a proxy run.
 
 </details>
 
@@ -52,395 +41,20 @@ A broad swarm or target-scale launch is not justified until rank stability, repe
 <summary>Related experiments</summary>
 
 - [#232](https://github.com/Open-Athena/marin-dna/issues/232) trained six region specialists and a background arm.
-  Home-region specialists won their matched Mendelian classes, showing that biological-domain mixture components can have distinct downstream utility; it did not optimize a combined mixture.
+  Home-region specialists won their matched Mendelian classes, showing that biological-domain components can have distinct downstream utility; the experiment did not optimize a combined mixture.
 - [#255](https://github.com/Open-Athena/marin-dna/issues/255) compared 108-family and 19-order mammalian cohorts at matched compute across five regions.
-  Species density was neutral for some regions and harmful for others, showing interaction between taxonomic mixture and biological domain; one seed and different epoch counts limit surrogate use.
+  Species density was neutral for some regions and harmful for others, showing an interaction between taxonomic mixture and biological domain; one seed and different epoch counts limit surrogate use.
 
 </details>
 
 <details>
 <summary>Possible directions</summary>
 
-### Core questions
-
-1. How should the training corpus be partitioned into mixture components?
-2. Which downstream objective should define a "good" mixture?
-3. Which optimization approach, or combination of approaches, should be used?
-4. For proxy-based approaches, can the objective be measured with enough signal at small scale?
-5. For surrogate approaches, should the model predict absolute performance, within-swarm rankings, or pairwise differences between mixtures?
-6. How should finite data and target-scale repetition be represented?
-7. Do selected mixtures remain effective as model size and training-token budget increase?
-8. Optionally, what evolutionary breadth or taxonomic mixture should the training data cover?
-9. Should weights be stationary throughout training, or differ between broad pretraining and a cooldown or midtraining phase?
-
-### Candidate optimization approaches
-
-The research question does not presuppose one optimization method.
-Candidate approaches include, but are not limited to:
-
-1. **Expert-designed mixtures and controlled ablations:** useful as baselines and for testing a small number of strong biological hypotheses.
-2. **Direct search:** random, structured, Bayesian, or evolutionary search over mixture weights when the number of components and training cost permit.
-3. **Offline proxy-swarm regression:** train small models on sampled mixtures, fit a surrogate, and optimize its predicted downstream utility, as in RegMix and Olmix.
-4. **Online or adaptive reweighting:** update mixture weights during training using learning dynamics, validation signals, or estimated domain utility.
-5. **Scaling-law, analytical, or hybrid methods:** model how data quantity, repetition, model scale, and domain interactions affect utility, possibly combined with proxy or online measurements.
-   Structured saturation and overexposure models such as the Domain Saturation-Penalty (DSP) form highlighted in the community slides are concrete candidates alongside black-box regressors.
-
-Comparisons should account for the compute spent selecting the mixture, not only the compute of the final training run.
-Different approaches may also be appropriate at different stages or scales.
-
-### Candidate mixture axes
-
-Treat mixture construction as a grid over at least two axes.
-
-#### Axis 1: biological domain
-
-Use the five v4 specialist partitions from the latest per-region experiment ([exp255](https://github.com/Open-Athena/marin-dna/blob/6370a321fcd08eb0a55bcb19cdd1b0586f382118/experiments/exp255_per_region_order.py#L4-L12)) as the provisional starting taxonomy:
-
-- coding sequence (`v4_cds`);
-- non-promoter cCRE (`v4_ccre_non_promoter`);
-- 3′ UTR (`v4_utr3`);
-- ncRNA exon (`v4_ncrna_exon`); and
-- TSS region plus 5′ UTR (`v4_tss_region_and_utr5`).
-
-These are the five specialist v4 partitions; `v4_bg` is the separate background partition.
-Retain background as an optional mixture component or control rather than calling it a sixth functional region.
-
-#### Axis 2: putative data quality
-
-Partition each biological domain into pinned conservation tiers, such as high, medium, and low conservation, rather than assuming only a binary conserved/unconserved split.
-The exact conservation statistic, species panel, thresholds, and missing-value policy remain part of this research question.
-
-Conservation should initially be described as a *putative quality proxy*, not as ground-truth data quality.
-The experiment should be able to discover that less-conserved data are useful, either in general or for particular downstream tasks.
-
-The resulting components are cells such as:
-
-```text
-CDS × high conservation
-CDS × medium conservation
-CDS × low conservation
-non-promoter cCRE × high conservation
-...
-TSS region + 5′ UTR × low conservation
-```
-
-#### Axis 3 (optional): evolutionary scale
-
-A third axis could control the evolutionary distances represented in training: for example, how much data should come from primates, mammals, vertebrates, plants, or other clades.
-This is scientifically important but substantially expands the search space, so it can remain an optional follow-up direction.
-
-The example taxonomic groups are nested: primates are mammals, and mammals are vertebrates.
-Do not assign independent mixture weights to overlapping groups.
-Use one of two explicit formulations:
-
-1. **Disjoint clade buckets:** for example, primates, non-primate mammals, non-mammalian vertebrates, plants, and any additional non-overlapping groups supported by the data.
-2. **Hierarchical allocation:** first allocate weight among broad clades, then allocate each clade's weight across its descendant groups and the biological-domain-by-conservation cells.
-
-This axis is also confounded by the number of available species and their phylogenetic redundancy.
-Raw sequence counts should not make a densely sampled clade dominate by construction.
-Compare species-sampling policies such as all available species, one species per family, and one species per order, and record both token exposure and phylogenetic coverage.
-
-Avoid beginning with the full domain-by-conservation-by-clade Cartesian product.
-It may create too many small or weakly identifiable cells.
-Start with a factorized or hierarchical parameterization and add cross-axis interactions only when proxy data support estimating them.
-
-### Static versus phase-specific mixtures
-
-The community slides distinguish a broad-coverage Phase 0 from a cooldown or midtraining Phase 1, using the same buckets with different weights and fitting those weights for a particular model size and token budget.
-This is a schedule decision, not another biological component axis.
-A phase-aware formulation would optimize vectors `p^(0)` and `p^(1)` together with pinned phase budgets `R^(0)` and `R^(1)`.
-
-For component `j` with `N_j` unique tokens, total target-scale exposure becomes
-
-```math
-e_j = \frac{R^{(0)}p_j^{(0)} + R^{(1)}p_j^{(1)}}{N_j}.
-```
-
-For components with nonzero total exposure, the late-phase share can also be recorded as
-
-```math
-r_j = \frac{R^{(1)}p_j^{(1)}}{R^{(0)}p_j^{(0)} + R^{(1)}p_j^{(1)}}.
-```
-
-Start with a stationary mixture as the identifiable baseline.
-Add a phase-specific arm only if proxy or intermediate-scale evidence can distinguish schedule effects, and compare schedules at matched total per-component exposure so that a cooldown effect is not confused with simply seeing more copies of a scarce component.
-### What should the mixture optimize?
-
-A plausible initial follow-up issue could focus on the project's current Mendelian-trait variant-effect-prediction (VEP) evaluation and treat [DART-Eval](https://arxiv.org/abs/2412.05430) as a separate target.
-DART-Eval covers regulatory DNA in zero-shot, probing, and fine-tuning settings, and may favor a different data mixture from Mendelian VEP.
-That difference is scientifically useful and should not be hidden by immediately collapsing every evaluation into one score.
-
-Let `s_t(p)` be AUPRC for trait or evaluation subset `t` after training on mixture `p`.
-Candidate objectives include:
-
-1. **Macro average:** `U_mean(p) = (1/T) sum_t s_t(p)`
-
-   This rewards average performance and gives each trait equal weight.
-
-2. **Worst-subset or minimax performance:** `U_min(p) = min_t s_t(p)`
-
-   This protects against a mixture that improves the mean by sacrificing one trait, but it may be dominated by the noisiest or smallest subset.
-
-3. **Robust compromise**
-
-   Use a predeclared soft minimum, lower quantile, or `U_mean(p) - lambda D(p)` objective, where `D(p)` measures performance dispersion, to trade some mean performance for consistency without allowing one noisy subset to determine the entire mixture.
-
-4. **Baseline-relative constrained improvement**
-
-   Let `p_0` be a pinned baseline or expert proposal.
-   Optimize a predeclared primary utility while requiring every guardrail subset to remain within a tolerance of its baseline score:
-
-   ```math
-   \max_p U_{\mathrm{primary}}(p) - \eta D(p,p_0)
-   \quad \text{subject to} \quad
-   s_t(p) \geq s_t(p_0) - \epsilon_t \;\; \text{for all guardrail subsets } t.
-   ```
-
-   This adapts the A2B pattern in the community slides: guard all tasks, improve selected targets, and stay local to the proposal.
-   It may be easier to interpret than collapsing primary and guardrail tasks into one scalar, but the tolerances, distance, and primary target must be preregistered.
-#### Which evaluation readout defines the objective?
-
-The optimization metric must also specify how model performance is read out.
-Candidate definitions are:
-
-- zero-shot variant scores;
-- one global linear probe shared across applicable subsets; and
-- separate per-subset linear probes.
-
-Avoid defining the objective as the post hoc "best of zero-shot and probe."
-That gives every mixture multiple chances to win and makes the selected objective depend on evaluation noise.
-Better options are to:
-
-- preregister one readout as primary and report the others as secondary;
-- define a fixed composite of normalized zero-shot and probe scores; or
-- treat the readouts as a multi-objective problem and report a Pareto frontier.
-
-Probe training data, hyperparameter searches, and random seeds must be identical across mixtures.
-The test split used to report the final comparison must not be used to fit mixture weights.
-
-### Can proxy models provide signal at small scale?
-
-A possible follow-up experiment could audit signal over a small set of deliberately different anchor mixtures—for example natural proportions, uniform cells, CDS-heavy, regulatory-heavy, high-conservation-heavy, and low-conservation-heavy—before considering a large swarm.
-
-For each proxy scale and evaluation readout, estimate:
-
-- between-mixture variation;
-- seed-to-seed and probe-to-probe variation;
-- confidence intervals for per-subset and aggregate scores;
-- separation from a random or trivial predictor;
-- stability over training checkpoints; and
-- Spearman/Kendall rank agreement across proxy sizes and token budgets.
-
-The mixture signal must be distinguishable from run and evaluation noise.
-If a metric is effectively random at proxy scale, it should not be used as a regression target merely because it is meaningful at large scale.
-Options are to increase proxy size or duration, use a lower-variance intermediate metric, or stop and record that the proposed optimization is not currently cost-effective.
-
-The community slides sharpen the intermediate-metric option into a concrete open problem: build low-cost, smooth evaluations that emerge at swarm scale and correlate with the intended target-scale objective, because many hard benchmarks show no signal in small proxies.
-A smooth proxy metric may be used for screening only after its cross-mixture correlation and rank transfer are evaluated on held-out mixtures at one or more larger scales; smoothness alone is not evidence of relevance.
-
-### Proxy-swarm targets: absolute versus relative performance
-
-Possible surrogate targets include:
-
-1. **Absolute performance:** predict the measured score for each mixture.
-2. **Centered or ranked performance:** predict a mixture's rank or its score after centering within a common swarm/evaluation batch.
-3. **Pairwise preference:** predict which of two mixtures performs better, preferably using matched evaluation and training seeds where possible.
-
-Relative targets may suppress shared run-level noise and align directly with the goal of selecting the best mixture.
-They also discard effect-size information and can become incomparable across independently trained swarms.
-Include the same anchor mixtures in every swarm batch so batches can be calibrated, and evaluate all target formulations on held-out mixtures.
-
-Surrogate quality should be judged by selection behavior, not training fit:
-
-- rank correlation on held-out mixtures;
-- recall among the top `k` mixtures;
-- regret relative to the best observed held-out mixture;
-- calibration or error for absolute-score models; and
-- stability of the proposed optimum under bootstrap resampling of proxy runs.
-
-### Simulating target-scale epoching
-
-For target training budget `R` tokens, component `j` with `N_j` unique tokens and proposed weight `p_j` has an approximate exposure count
-
-```math
-e_j(p) = \frac{R p_j}{N_j}.
-```
-This exposes a mismatch between a short proxy run and a long target run.
-Possible treatments include:
-
-1. **Hard repetition constraints:** `p_j <= e_j^max N_j / R`
-
-   Optimize the learned surrogate only over mixtures that do not exceed a predeclared maximum exposure for any component.
-
-2. **Repetition-aware utility**
-
-   Penalize or discount weights whose implied target-scale epochs enter a diminishing-return regime.
-   The penalty must be fixed from an independent repetition study or estimated in a nested training split, not tuned on the final evaluation.
-
-3. **Simulated target exposure in proxy training**
-
-   Construct proxy sampling schedules that reproduce the target run's component-level epoch counts or repetition pattern at reduced compute, then test whether this improves rank transfer.
-
-The first approach follows Olmix's practical recommendation to enforce finite-data feasibility during mixture optimization.
-The third most directly captures the "simulated epoching" hypothesis.
-A follow-up experiment could compare them rather than assuming that scarce high-conservation cells must simply be downweighted in the regression itself.
-
-Report the unconstrained optimum as a diagnostic.
-A large gap between the unconstrained and feasible optima is evidence that data availability, not only estimated utility, is determining the final recipe.
-
-### Implementation ideas for follow-up issues
-
-The following are a menu of possible implementation and analysis directions, not a prescribed study or ordered roadmap.
-The proxy-swarm path is currently the most developed because it appears especially promising, not because this issue has selected it over the alternatives.
-Each item could become a separate EDA or experiment issue.
-
-#### Possible comparison: Benchmark optimization approaches
-
-- Compare selected approaches against natural and expert-designed mixtures.
-- Match or report both mixture-selection compute and final-training compute.
-- Evaluate whether different approaches converge on similar weights.
-- Record whether an approach remains practical as the number of mixture components grows.
-
-#### Possible foundation: Define the data and evaluation contract
-
-- Pin the biological-domain and conservation-tier definitions.
-- Resolve overlaps, duplicates, and empty or tiny cells.
-- Inventory unique tokens per cell.
-- Pin train, probe-training, validation, and final test partitions.
-- Audit direct sequence overlap and locus leakage into VEP and DART-Eval.
-- Define a baseline mixture and the target training-token budget.
-
-#### Possible experiment: Measure the proxy noise floor
-
-- Train anchor mixtures with enough repeated seeds to separate mixture effects from run noise.
-- Compare zero-shot, global-probe, and per-subset-probe signal.
-- Select a primary objective and proxy scale before the full swarm.
-- Stop or revise the proxy design if rankings are not reproducible.
-
-#### Possible experiment: Train a mixture swarm
-
-- Sample feasible mixtures from the simplex, combining broad exploration with perturbations around the baseline mixture.
-- Include fixed anchor mixtures in every batch.
-- Keep architecture, tokenizer, optimizer, training-token budget, evaluation cadence, and data preprocessing matched across runs.
-- Record both sampled weights and realized token counts; assert that sampling noise does not materially change the intended mixtures.
-- Choose swarm size from a documented power/sample-complexity analysis rather than copying a fixed run count from NLP.
-
-Dense versus sparse Dirichlet swarms should be treated as a design choice to validate.
-With a grid of correlated genomic cells, sparse mixtures may expose cell effects more clearly, while dense mixtures may better resemble feasible target recipes.
-
-#### Possible analysis: Fit and validate surrogates
-
-Compare simple baselines before more flexible regressors:
-
-- linear and log-linear models;
-- a regularized model with interactions between domain and conservation axes;
-- a tree-based model such as LightGBM when the swarm is large enough; and
-- rank or pairwise models for the relative-performance hypothesis.
-
-Use held-out mixtures or nested cross-validation for all model and hyperparameter selection.
-A flexible regressor with excellent in-swarm fit but poor held-out ranking is not useful.
-
-When optimizing the surrogate:
-
-- enforce the target-scale data constraints;
-- consider a pinned KL or distance penalty from the baseline mixture to avoid unsupported extrapolation;
-- quantify uncertainty in both the proposed weights and predicted utility; and
-- return several diverse, near-optimal candidates when the optimum is flat.
-
-#### Possible experiment: Test scale transfer
-
-A confirmatory comparison could train matched models on:
-
-1. natural data proportions;
-2. the current expert-designed baseline;
-3. the proxy-predicted macro-optimal mixture;
-4. the proxy-predicted robust/minimax mixture; and
-5. a deliberately different or randomly selected held-out mixture.
-
-One risk-reducing option is to validate at an intermediate scale not used to fit the surrogate before comparing the best-supported candidates at the intended target scale.
-Architecture, tokenizer, optimizer, total training tokens, evaluation protocol, and number of seeds should be matched wherever feasible.
-
-This research-question issue does not authorize paid large-scale training or a broad swarm.
-Any follow-up experiment proposing such a launch must obtain explicit approval.
-
-#### Possible follow-up: Test objective specificity with DART-Eval
-
-A separate follow-up issue could repeat or reuse the mixture analysis with DART-Eval regulatory tasks to ask whether:
-
-- the VEP-optimized mixture transfers to regulatory tasks;
-- a separately optimized DART-Eval mixture favors regulatory, UTR, ncRNA, or conservation cells differently; and
-- a stable Pareto compromise exists between the two evaluation families.
-
-Do not treat failure to transfer as a failure of mixture optimization; it may show that the optimal data recipe is downstream-objective dependent.
-
-### Open design choices for follow-up issues
-
-| Design choice | Candidate options | Possible evidence |
-| --- | --- | --- |
-| Optimization approach | expert/ablation; direct search; proxy-swarm regression; DSP-style saturation model; online/adaptive; scaling-law or hybrid | downstream utility, selection compute, robustness, and scale transfer |
-| Mixture components | domain only; conservation only; domain × conservation | cell sizes, identifiability, held-out performance |
-| Primary VEP utility | macro AUPRC; minimax; robust compromise; baseline-relative constrained improvement | uncertainty and sensitivity to small/noisy subsets |
-| Evaluation readout | zero-shot; global probe; per-subset probes; fixed composite | proxy-scale signal and target-scale rank transfer |
-| Surrogate target | absolute; centered/rank; pairwise | held-out rank, regret, and stability |
-| Repetition handling | hard cap; utility penalty; simulated epoching; DSP-style saturation and overexposure terms | transfer under the target token budget |
-| Weight schedule | stationary; Phase 0 plus cooldown or midtraining | held-out schedule transfer at matched total exposure |
-| Evolutionary axis | omit initially; disjoint clade weights; hierarchical allocation | proxy signal, phylogenetic coverage, and target-scale transfer |
-| Proxy configuration | model size, token budget, checkpoint | reproducibility and rank agreement with intermediate scale |
-| Swarm design | dense; sparse; baseline-local; hybrid | coverage, regression fit, and selected-mixture regret |
-| Final scope | one universal mixture; task-specific mixtures; Pareto family | Mendelian VEP and later DART-Eval results |
-
-### Possible outputs from follow-up work
-
-Depending on which follow-up issues are pursued, useful outputs could include:
-
-- A versioned manifest defining the selected data cells and their unique-token budgets.
-- A leakage audit covering evaluation loci, homologous/projected sequences, chromosomes, and duplicates.
-- A clearly stated primary objective and evaluation protocol for a particular experiment.
-- Reproducible configs for anchor, swarm, held-out-mixture, and scale-transfer runs.
-- A machine-readable table with intended and realized mixture weights, training metadata, per-subset scores, aggregate objectives, and uncertainty.
-- Held-out comparisons of surrogate families and target formulations.
-- Repetition-feasibility plots or tables at the intended target budget.
-- An intermediate/target-scale report comparing optimized and baseline mixtures at matched compute.
-- Evidence supporting adoption, revision, or rejection of a mixture-selection method at the tested scales.
-
-### Evidence that would advance the question
-
-This research question can accumulate evidence across several independent issues.
-Meaningful progress would include one or more of:
-
-- defining interpretable, versioned mixture components;
-- identifying an evaluation objective with measurable proxy-scale signal;
-- determining whether absolute, ranked, or pairwise surrogate targets work best on unseen mixtures;
-- understanding how target-scale repetition changes feasible mixtures;
-- measuring whether mixture rankings transfer across model scales or token budgets;
-- learning whether different downstream objectives favor different mixtures; or
-- establishing that proxy-regression mixture selection is not reliable or cost-effective in the tested regime.
-
-### Boundaries
-
-- Assuming conservation is synonymous with data quality.
-- Selecting a mixture from final test-set performance.
-- Treating the post hoc best of zero-shot and probing evaluations as a valid preregistered objective.
-- Copying RegMix or Olmix proxy/swarm sizes without measuring genomic proxy-scale signal.
-- Launching an exhaustive combinatorial sweep over the mixture grid.
-- Selecting a smooth proxy metric without validating its held-out cross-mixture relationship to the target-scale objective.
-- Fitting a stationary mixture and then changing the target run's cooldown or midtraining schedule without representing the resulting component exposures.
-- Assuming that DART-Eval and Mendelian VEP must be optimized jointly in the same follow-up issue.
-- Claiming that one optimized mixture will be best for every downstream task.
-
-### Interpretations to confirm
-
-This draft makes the following non-blocking interpretations of the transcription:
-
-1. "Mendelian traits barne effect prediction" means the current **Mendelian-trait variant-effect-prediction** evaluation, summarized by AUPRC across trait subsets.
-2. "OlmoMix" refers to **Olmix**, the data-mixing framework developed in the OLMo ecosystem, rather than OLMoE or a dataset named OLMo-mix.
-3. "Simulated epoching" means accounting for the number and pattern of times each finite data component would be repeated at the target training budget.
-   If it refers to a specific named method, add that citation and align the experimental arm with its definition.
-4. The initial biological-domain axis is the five v4 specialist partitions used by exp255: CDS, non-promoter cCRE, 3′ UTR, ncRNA exon, and TSS region plus 5′ UTR.
-   Background remains a separate candidate component/control.
-5. DART-Eval is a separate possible follow-up target rather than necessarily part of the same scalar objective as Mendelian VEP.
-6. Evolutionary scale is an optional follow-up axis.
-   If included, nested taxonomic groups must be converted to disjoint buckets or modeled hierarchically so the same data are not counted under multiple weights.
-7. Phase-specific mixing means separate weight vectors over the same semantic cells for broad pretraining and cooldown or midtraining; phase is not an additional biological bucket axis.
+- Define a versioned, non-overlapping component manifest with unique-token budgets, leakage rules, and realized exposure counts.
+- Predeclare one primary downstream objective and readout; report other tasks and subsets separately rather than selecting the best result after training.
+- Measure the proxy noise floor with repeated anchor mixtures before launching a swarm.
+- Compare simple expert mixtures with held-out-mixture predictions from regularized absolute, rank, or pairwise surrogates.
+- Constrain candidate weights by target-scale repetition, then test whether proxy rankings transfer to an intermediate or target scale.
+- Add conservation tier, evolutionary breadth, or phase-specific weights only after the simpler domain mixture is identifiable.
 
 </details>

--- a/docs/research/questions/evolutionary-timescale.md
+++ b/docs/research/questions/evolutionary-timescale.md
@@ -30,12 +30,8 @@ This would separate early sample efficiency from final endpoint quality and test
 <details>
 <summary>Related work</summary>
 
-- [Does conditioning on species/clade help?](species-conditioning.md) asks whether explicit species or clade conditioning can expose taxonomic context that sequence-only training must infer.
-  Conditioning could reduce the need to choose one static timescale, but no matched MarinDNA conditioning ablation exists.
-- [Why do MarinDNA models lag on complex-trait VEP?](complex-trait-vep.md) asks whether shallower evolutionary context helps complex-trait VEP.
-  GPN-Star’s mammal and primate models lead different complex-trait endpoints, so the relevant comparison is endpoint-specific rather than a generic “closer is better” claim.
-- The distinction between nominal and effective breadth is methodological: annotation, whole-genome alignment, and human-anchored nucleotide projection admit different distant species even under the same taxonomic label.
-  Future comparisons should report realized per-species tokens and locus coverage, not only the requested clade.
+- [Ye, Benegas et al., Predicting functional constraints across evolutionary timescales with phylogeny-informed genomic language models](https://www.biorxiv.org/content/10.1101/2025.09.21.677619v1) compares primate-, mammal-, and vertebrate-alignment models across coding, regulatory, Mendelian, and complex-trait endpoints.
+  Different endpoints prefer different breadths, while alignment-conditioned architecture and training data remain confounded for comparison with MarinDNA.
 
 </details>
 
@@ -62,32 +58,9 @@ This would separate early sample efficiency from final endpoint quality and test
 <details>
 <summary>Possible directions</summary>
 
-1. **What exactly should “evolutionary timescale” mean experimentally?**
-   Phylogenetic breadth (primates versus mammals versus vertebrates versus animals), species density within a clade, total unique bases, and distance from the target organism are separate axes and should not be collapsed into one variable.
-
-2. **What is the clean fixed-compute comparison?**
-   Train matched primate-, mammal-, vertebrate-, and animal-scope arms with the same model, optimizer, total tokens, sequence-selection method, and evaluation checkpoints.
-   Report both fixed-token and matched-epoch or matched-unique-locus views so that breadth is not mistaken for repetition or dataset size.
-
-3. **Does broad-to-narrow training dominate a static mixture?**
-   At matched total tokens, compare broad-only, target-clade-only, broad pretraining followed by target-clade adaptation, and an interleaved/reweighted mixture.
-   Sweep the fraction of compute spent in each stage and measure both target-task gains and catastrophic forgetting of broader capabilities.
-
-4. **How does the answer vary by genomic region?**
-   Run the comparison separately for CDS, promoters/TSS, 5′ and 3′ UTRs, ncRNA exons, enhancers/distal regulatory sequence, and background.
-   A region-specific species mixture or curriculum may be better than a single whole-genome recipe.
-
-5. **How does the answer vary by biological endpoint?**
-   Separate language-model loss and functional-versus-background LL gaps from human Mendelian VEP, complex-trait VEP, eQTL/regulatory effects, saturation assays, and cross-species transfer.
-   Rare coding variants and common regulatory variants may reflect different evolutionary timescales.
-
-6. **Does the optimum change with model scale, context length, or token budget?**
-   A small or short-context model may benefit more from narrowly relevant data, whereas a larger model may have enough capacity and compute to absorb broad diversity without sacrificing target-clade performance.
-
-7. **What result would support each training strategy?**
-   - Broad-only winning at matched compute would support diversity and deeper conservation as the dominant source of signal.
-   - Target-clade-only winning would support evolutionary relevance and efficient use of the token budget.
-   - Broad-to-narrow beating both endpoints and the static mixture would support a curriculum in which general biological features transfer before lineage-specific adaptation.
-   - Strong region-by-timescale interactions would support region-specific mixtures or curricula rather than one universal phylogenetic scope.
+- Separate phylogenetic breadth, species density, unique bases, target distance, and effective projected coverage rather than treating them as one timescale variable.
+- Compare primate, mammal, vertebrate, and animal scopes at matched model, optimizer, tokens, construction method, and checkpoints, reporting fixed-token and matched-exposure views.
+- At matched total compute, compare broad-only, target-clade-only, broad-to-narrow adaptation, and an interleaved mixture.
+- Measure region-by-timescale and endpoint-by-timescale interactions before selecting a whole-genome default or curriculum.
 
 </details>

--- a/docs/research/questions/latent-features.md
+++ b/docs/research/questions/latent-features.md
@@ -43,9 +43,6 @@ The next useful biological tiers are UTR, promoter/TSS-proximal, and annotated n
 <details>
 <summary>Related work</summary>
 
-- [Inside a genomic language model](https://marindna-latent-feature-atlas.gsbenegas.chatgpt.site) is the current visual synthesis of the project’s methods, layer organization, positive findings, negative results, and claim boundaries.
-  The [commit-pinned source](https://github.com/Open-Athena/marin-dna/blob/234f3073121d8de1f51a5e16e8637ac1986152e2/experiments/issue288_latent_feature_atlas/index.html) preserves the reviewed version.
-  It is a summary artifact, not independent evidence.
 - [Korsakova and Kelley, Learning monosemantic features in multitask DNA regulatory sequence models via sparse autoencoder decomposition](https://openreview.net/forum?id=AlLZnZX01x) trained TopK SAEs on early Borzoi layers and annotated features with repeats, motifs, and regulatory elements.
   Motifs specialized by depth, orientation, and flanking context, and larger dictionaries split concepts.
   This motivates layer panels, normalized activations, FWD/RC inspection, and context-aware interpretation.
@@ -55,9 +52,6 @@ The next useful biological tiers are UTR, promoter/TSS-proximal, and annotated n
 - [Language Modeling Materializes a World Model of Protein Biology](https://www.biorxiv.org/content/10.1101/2024.12.18.629098v1) reports concept splitting, decoder neighborhoods, and feature combinations in protein models.
   It motivates analyzing feature families and co-activation systems alongside individual IDs.
   The open question is whether the same organizational principles hold for genomic sequence and across reverse-complement views.
-- The fixed methodology treats biological labels and automated descriptions as discovery aids.
-  A strong interpretation requires corrected association evidence, sequence localization, paired or designed perturbations, orientation analysis, and independent contexts when the claim warrants it.
-  Causal intervention on the base model remains a higher bar than activation response alone.
 
 </details>
 
@@ -100,110 +94,11 @@ The next useful biological tiers are UTR, promoter/TSS-proximal, and annotated n
 <details>
 <summary>Possible directions</summary>
 
-### 1. Paired-variant protocol: current answer and extensions
-
-Reference and alternate sequences are a matched counterfactual pair, not two independent examples.
-This paired response is the default scientific unit for this question; single-sequence enrichment is supporting interpretation.
-[#424](https://github.com/Open-Athena/marin-dna/issues/424) established the current protocol:
-
-- retain reference activation, alternate activation, signed Δ, |Δ|, and inactive→active / active→inactive states for each orientation;
-- use signed Δ as the primary variant-effect quantity because threshold crossings miss graded splice effects and magnitude-only views erase informative direction for dense features such as the stop-codon feature;
-- use all eligible variants, outcome-independent feature-support requirements, complete-family BH correction, and effect-size reporting for association discovery; reserve genomic holdouts and block-bootstrap uncertainty for targeted robustness or causal follow-up;
-- preserve absolute activations so a background-locus feature can be distinguished from a variant-induced feature change.
-
-Still open:
-
-- [#429](https://github.com/Open-Athena/marin-dna/issues/429) has now frozen and tested the first spatial extension: reverse RC positions into genomic coordinates; preserve focal scoring; choose focal, ±15 bp local maximum, or local sum on validation blocks only; and report held-out profiles.
-  Local maximum decisively improves acceptor and stop-gain features, while donor-fifth-base and synonymous remain focal;
-- how to condition or stratify on substitution type, local annotation, repeat family, and labels when needed without turning the program into a general baseline bake-off;
-- the direct missense-versus-synonymous task is heavily phase-confounded: a discovery-fit codon-position score reaches held-out AUROC 0.927.
-  [#428](https://github.com/Open-Athena/marin-dna/issues/428) now replicates the three frozen SAE scores after matching within codon position and transcript-oriented substitution, but at conditional AUROC 0.590–0.603 rather than the pilot's 0.825–0.853; a fixed 31-bp local-sequence model reaches 0.760.
-  Treat these as stable but modest codon-context features.
-  CDS and splice variants remain the first substantive biological tier as well as the protocol proving ground; broaden beyond missense-versus-synonymous and do not spend the whole program trying to force an amino-acid interpretation.
-
-### 2. Bidirectionality and reverse complementation
-
-FWD and RC remain primary, separately reported views.
-[#424](https://github.com/Open-Athena/marin-dna/issues/424) found that same-ID rowwise invariance is uncommon: on held-out variants only 3.86% of adequately supported features had `|r| ≥ 0.05`.
-Nevertheless, signed same-ID mean won the global validation comparison and transferred best to held-out blocks because useful features can cover complementary strand contexts.
-
-Current decision:
-
-- use `(ΔFWD + ΔRC) / 2` as the primary aggregate for broad consequence-family screens, retain both component views, and report `max(|ΔFWD|, |ΔRC|)` as a sensitivity analysis; [#426](https://github.com/Open-Athena/marin-dna/issues/426) shows that max absolute may become the better endpoint for a narrower binary mutation-response question, but this must be declared per analysis rather than selected post hoc;
-- explicit coding-strand alignment is not a better reducer for the three selected coding IDs: aligned versus anti-aligned AUROC is 0.643/0.656 for f12658 and 0.632/0.629 for f13637, both below signed mean; f11064 coding-aligned absolute is 0.734 versus 0.806 for max absolute.
-  These features are not currently strict transcript-orientation features;
-- do not enforce same-ID RC consistency in the first SAE sweep;
-- begin with RC-balanced SAE training examples under the ordinary objective;
-- treat brute-force cross-ID matching as exploratory.
-  Stable pairs exist, but 13–14 of 70 discovery winners became constant on validation/test, demonstrating winner's curse.
-
-Still open:
-
-- whether mutual-nearest, support-stable cross-ID pairs preserve biological semantics across datasets;
-- whether set-level consistency is more appropriate than feature-index consistency;
-- when strand-specific biology should intentionally remain unaggregated.
-
-### 3. SAE quality and scaling
-
-Experiment [#426](https://github.com/Open-Athena/marin-dna/issues/426) completed the first coarse budget × layer comparison.
-It rejects two convenient shortcuts: the final layer is not globally best, and longer training / better reconstruction do not imply greater biological feature yield.
-Blocks 10/16 are the best starting points for broad consequence discovery, while block 19 remains valuable for narrower coding contrasts.
-The 25M arm is not an upper bound: later runs may scale up to eight billion activations when a biological endpoint, feature stability, or model-relevant reconstruction—not MSE alone—justifies the cost and the run receives its own compute authorization.
-
-[#431](https://github.com/Open-Athena/marin-dna/issues/431) adds a sharper failure mode: the [#426](https://github.com/Open-Athena/marin-dna/issues/426) and fresh 5M normalized exports both have negative FVE and JumpReLU L0 around 1,700, while the existing block-10/25M export reaches FVE 0.809 and L0 242.8.
-[#432](https://github.com/Open-Athena/marin-dna/issues/432) then showed that the healthier 25M checkpoint preserves the robust splice/stop features and exposes a narrow leucine codon-family response, but does not recover a broad or decoder-aligned synonymous feature.
-Reconstruction health appears useful for resolving specificity, yet still does not substitute for biological association and targeted causal evidence.
-
-SAE improvements should be evaluated by rerunning the fixed first/middle/final biological panels; the layer hypothesis does not prescribe a particular SAE recipe.
-
-1. Treat [#426](https://github.com/Open-Athena/marin-dna/issues/426)'s block-4/10/16/19 sweep as evidence that layer effects are task-specific, while using the fixed first/middle/final panel for general association mapping; do not infer a globally best layer from one outcome.
-2. Vary dictionary expansion, K/L0 or threshold sparsity, BatchTopK versus related architectures, and random seed, comparing FDR-controlled biological association yield and feature stability rather than reconstruction alone.
-3. Diagnose the 25M block-19 concentration (inactive fraction 0.568; top-1% activation share 0.748) before scaling that recipe; use larger activation budgets up to eight billion only when a measured bottleneck justifies them.
-4. Test whether RC-balanced SAE training or an explicit orientation objective changes invariant-feature yield.
-5. Retain reconstructed-model CE/KL degradation alongside FVE, cosine, L0, dead-feature, activation-concentration, and compute diagnostics; [#426](https://github.com/Open-Athena/marin-dna/issues/426) shows that even these health metrics are supporting evidence rather than the scientific endpoint.
-6. Normalize feature activations against a fixed human-reference corpus before comparing activation magnitudes or ranking features with different dynamic ranges and prevalence.
-7. Compare decoder-space neighborhoods and direction alignment across dictionaries, checkpoints, and seeds; measure biological yield for feature families as well as individual IDs.
-8. After robust individual features emerge, test whether co-activation modules capture higher-order motif or region grammar.
-
-The decisive research metrics are FDR-controlled biological association yield, feature and feature-family stability across seeds/checkpoints, motif/context coherence, FWD/RC behavior, and causal validation.
-Reuse fixed datasets and analysis definitions when comparing SAE recipes; preserve untouched contexts only for targeted robustness, transfer, or causal claims that require them.
-
-### 4. Biological follow-up
-
-The literature suggests the following prioritized **variant-response** inventory for short-context m5.1 analysis.
-Reference-sequence scans are useful both for naming and localizing Δ features and as a distinct annotation/segmentation application:
-
-- **Sequence and composition responses:** how substitutions perturb nucleotide, GC/CpG, homopolymer, low-complexity, and local compositional features.
-- **Repeats and mobile sequence:** variant responses stratified by repeat class, family, subfamily, and divergence/age—including endogenous retroviral/LTR, LINE/SINE, satellite, and simple-repeat sequence.
-  Audit both Δ-responsive feature IDs and their share of nonzero Δ slots and total |Δ| mass; reference activation capacity is a secondary diagnostic.
-- **Local regulatory variant grammar:** perturbations in 5′ and 3′ UTRs, TF and RBP motifs, motif orientation/flanking context, promoters/TSS, cCRE categories, and local motif combinations or spacing.
-- **Gene architecture and RNA variants:** splice donors/acceptors, polypyrimidine tracts, exon/intron boundaries, polyadenylation signals, ORF/intergenic sequence, and annotated tRNA, rRNA, miRNA, snoRNA, lncRNA, and other ncRNA classes.
-- **Coding variant effects:** codon phase/frame, start and stop signals, synonymous versus missense changes, frameshifts, premature stops, and amino-acid or protein-secondary-structure signals recoverable from coding DNA.
-- **Feature organization:** FWD/RC feature pairs or sets, broad-to-specific feature hierarchies, context-specialized members of one motif family, decoder-space neighborhoods, and compositional feature programs.
-
-The practical paired-variant ladder is: **CDS and splicing variants as the first biological step and substantive tier** → 5′/3′ UTR variants → promoter/TSS-proximal and annotated ncRNA variants → enhancer/cCRE variants.
-Enhancers are the hardest tier because their local sequence vocabulary is heterogeneous and cell-state dependent; claims about distal enhancer–promoter relationships remain out of scope for a 255 bp model.
-
-Applied follow-ups:
-
-- **Reference-sequence segmentation and gene annotation ([#440](https://github.com/Open-Athena/marin-dna/issues/440)):** Scan the human reference at base-pair resolution for features whose activation identifies local genomic states or sharply marks boundaries—for example exon versus intron, CDS versus 5′/3′ UTR, splice boundaries, promoter/TSS, intergenic sequence, and cCRE classes.
-  Evaluate both pointwise class association and boundary localization, keeping FWD/RC separate initially.
-  This is a standalone application of the learned feature inventory rather than a variant-effect endpoint; for the 255 bp m5.1 system it concerns local sequence annotation, not long-range regulatory interactions.
-- **CDS and splicing variants:** This is the first biological step, because known splice and genetic-code grammar provides unusually strong falsification tests while remaining central to variant effect prediction.
-  [#429](https://github.com/Open-Athena/marin-dna/issues/429) has held-out donor/acceptor/stop/synonymous leads, matched discovery-context perturbations, and a prospective hash-sampled test-context panel on which all five original-dictionary causal contrasts clear zero.
-  [#431](https://github.com/Open-Athena/marin-dna/issues/431) then showed that acceptor, donor, and stop semantics survive two independent dictionaries even when IDs permute, while synonymous/codon degeneracy does not survive either 5M dictionary or either exhaustive search.
-  [#432](https://github.com/Open-Athena/marin-dna/issues/432) confirmed the three robust semantics at 25M and found only a narrower leucine codon-family/local-degeneracy feature under exhaustive search, not general synonymous semantics.
-  Broader missense, start/stop-loss, splice-subclass, and real frameshift/indel panels remain separate follow-ups.
-  This tier remains scientifically important after the protocol is validated.
-- **Local regulatory variant ladder:** Find Δ features for 5′/3′ UTR variants first, then strand-aware promoter/TSS-proximal and annotated ncRNA variants, before the harder enhancer/cCRE tier.
-  Use FDR-controlled paired associations, spatial localization around the edit, motif/context inspection, and targeted mutagenesis at every stage; add independent-context replication when advancing a stronger mechanistic claim.
-- **Repeat response capacity:** At each tier, quantify repeat class/family/subfamily associations and the share of Δ-responsive feature IDs, nonzero Δ slots, total |Δ| mass, and decoder neighborhoods devoted to repeat-overlapping variants.
-  Reference-sequence capacity is supporting context.
-- **Regulatory interpretation:** [#421](https://github.com/Open-Athena/marin-dna/issues/421) now characterizes block-19 feature 219 and block-10 feature 11137 as broad, strand-reproducible, GC/CpG-conditioned accessibility/promoter-effect magnitude features.
-  Feature 11928's AlphaGenome association is tail-driven, but its Mendelian-label association is strand-consistent and should be compared with [#436](https://github.com/Open-Athena/marin-dna/issues/436)'s final-layer inventory.
-  Next resolve track-composition robustness, then use targeted perturbation for mechanism and review the signed/default-scorer phase.
-- **Curriculum and generalization:** Which features appeared or sharpened during the three-way to five-way continuation, and do they generalize across held-out human loci and homologous mammalian loci?
-- **Causality:** For a small preregistered set of robust features, do in-distribution ablation or clamping change downstream predictions in the biologically expected direction?
-- **Efficiency:** What is the cheapest correctness-equivalent extraction and SAE training recipe that preserves the scientific conclusions?
+- Extend the paired-variant inventory from CDS and splice variants to UTR, promoter/TSS-proximal, annotated ncRNA, and later enhancer/cCRE variants.
+- Keep reference, alternate, signed change, magnitude, and FWD/RC views; predeclare any aggregate and correct over the complete eligible feature family.
+- Test whether feature-family or set-level correspondence is more stable across orientations, SAE seeds, dictionaries, and checkpoints than same-ID matching.
+- Compare SAE recipes by corrected biological yield, feature-family stability, and reconstructed-model degradation rather than reconstruction alone.
+- Qualify reference-sequence annotation and boundary features against composition, repeat, and local-sequence controls.
+- Test causal interventions only for preregistered features that survive independent contexts and dictionaries.
 
 </details>

--- a/docs/research/questions/long-context.md
+++ b/docs/research/questions/long-context.md
@@ -46,10 +46,6 @@ Any comparison must match parameters, training tokens, and compute, align traini
 - [AlphaGenome](https://www.nature.com/articles/s41586-025-10014-0) predicts thousands of functional tracks from 1 Mb sequence using a multiscale supervised architecture.
   It demonstrates that long context and nucleotide-scale outputs can coexist through hierarchical computation.
   It does not test initialization from a short-context self-supervised gLM, so it is an architecture precedent rather than evidence for transfer.
-- [Can gLM pretraining improve human sequence-to-function modeling?](sequence-to-function.md) asks whether gLM pretraining improves sequence-to-function models.
-  Its controlled scratch-versus-pretrained benchmark is a natural first consumer of any local-to-global design, but accessibility context is much shorter than the full long-range question.
-- [Which genomic regions to train on, and how to find them?](training-regions.md) asks how long-window background sequence should be selected, sampled, or weighted.
-  This matters because uniformly weighted language modeling on long mammalian windows may devote most gradient mass to sequence outside the functional element of interest.
 
 </details>
 
@@ -66,40 +62,10 @@ Any comparison must match parameters, training tokens, and compute, align traini
 <details>
 <summary>Possible directions</summary>
 
-- **When can inference safely differ from training context?**
-  Start with matched checkpoints trained at 255, 511, and 1023 bp, compare crop and extension ladders, and separate score-construction effects from biological information gained or lost with the window.
-  Transfer one fixed probe across the ladder to test whether the same decision boundary survives changes in context.
-- **What long-range capability do we want first?**
-  Candidate tests should require distant context by construction—for example enhancer–promoter interactions, gene-level expression, long-range splicing regulation, or another task where masking distant sequence should measurably hurt.
-- **What context lengths define the useful regime?**
-  Compare a small ladder spanning the current local context through the expected biological scale, rather than testing only one large endpoint.
-- **How should a second-stage LM sample and weight sequence?**
-  Compare uniform long windows, functional-element-centered windows, and functional or conservation-aware loss weights.
-  How sensitive are the conclusions to incomplete and lineage-specific annotations?
-- **Does loss weighting damage likelihood interpretation?**
-  If the long-context model is trained with nonuniform per-base weights, which language-modeling and zero-shot variant scores remain comparable to the short-context model?
-- **How do we avoid forgetting local sequence grammar?**
-  Test freezing versus fine-tuning the local model, mixing short and long examples, and progressive context curricula.
-- **Should we preserve per-base embeddings or pool them?**
-  ARSENAL-style concatenation supplies a no-pooling baseline.
-  Compare it with mean/attention pooling, learned summary tokens, and multiple coarse tokens per chunk as context grows.
-- **How should local windows be tiled?**
-  ARSENAL uses center-aligned, mostly non-overlapping 350 bp chunks with special handling for the two sequence ends.
-  Compare overlap, stride, and blending schemes, and measure prediction or representation discontinuities at internal chunk boundaries explicitly.
-- **How does global information return to nucleotide resolution?**
-  Compare broadcasting a global embedding, cross-attention from local positions to coarse tokens, and local decoding with skip connections.
-- **Does end-to-end fine-tuning matter?**
-  ARSENAL’s released adapter freezes the local encoder by default.
-  A frozen local encoder is cheaper and gives a clean test of representation reuse, but joint training may be necessary for local features to expose information useful at the global level.
-- **What is the fair compute-matched comparison?**
-  Match parameter count where possible and report training tokens, FLOPs, peak memory, and wall time.
-  A longer sequence at the same number of examples is not a compute-matched intervention.
-- **Is the model using distant context?**
-  Evaluate with distance-stratified ablations: crop the input, mask or shuffle distal sequence, perturb the candidate interacting element, and measure performance as a function of distance.
-- **How should leakage controls change?**
-  Longer overlapping windows increase the chance that homologous or shifted sequence crosses train/test boundaries; update the similarity and locus-holdout rules before interpreting small gains.
-- **What is the smallest decisive first experiment?**
-  One option is a downstream task with known long-range dependence and five matched arms: short-context baseline, direct full-resolution extension, frozen ARSENAL-style per-base tiling, frozen-local pooled hierarchy, and jointly trained pooled hierarchy.
-  A second-stage LM arm should follow once that comparison establishes that the task and evaluation can detect useful long-range context.
+- Compare checkpoints trained at 255, 511, and 1023 bp with crop and extension ladders, and transfer one fixed probe across contexts.
+- Choose a task that requires distant sequence by construction and verify its dependence with distance-stratified cropping, masking, shuffling, or element perturbation.
+- At matched parameters, tokens, and compute, compare direct downstream extension with frozen per-base tiling, pooled local-to-global modeling, and joint local-to-global training.
+- Measure how window sampling, loss weighting, pooling, and tiling affect local grammar, nucleotide-resolution outputs, and likelihood interpretation.
+- Update locus and sequence-similarity leakage controls before using longer overlapping windows.
 
 </details>

--- a/docs/research/questions/retrieval-augmented-models.md
+++ b/docs/research/questions/retrieval-augmented-models.md
@@ -64,8 +64,6 @@ Online retrieval and index-cost work must then establish whether the approach is
 - [Protriever](https://proceedings.mlr.press/v267/weitzman25a.html) jointly trains a protein retriever and autoregressive reader and reports approximately 4.6 ms retrieval with a 12.6 GB compressed UniRef50 index.
   This is evidence that learned dense retrieval can be practical in proteins.
   Genomes are larger, repetitive non-coding sequence is common, and local orthology can be ambiguous, so the speed and index size do not transfer directly.
-- The practical observables are retrieval recall for true orthologs, sensitivity to paralogs and repeats, accuracy versus homolog count and context length, per-query latency, index memory, preprocessing cost, and degradation under stale or incomplete corpora.
-  None has been measured for MarinDNA.
 
 </details>
 
@@ -82,45 +80,11 @@ Online retrieval and index-cost work must then establish whether the approach is
 <details>
 <summary>Possible directions</summary>
 
-- **Scale the demonstrated recipe.**
-  The highest-priority axis is expanding the context beyond the current seven-species mammalian subset to more mammals and non-mammalian vertebrates.
-  Longer optimization and readers larger than 104M parameters are separate candidate axes because the current validation losses were still falling and the tested readers were small.
-  Measure each axis separately because one seed at each current size does not establish a scaling law.
-
-- **Target and architecture.**
-  Should the model directly generate a sequence of unaligned homologous sequences, as in PoET and EnhancAR, encode retrieved homologs separately and condition an autoregressive reader, or retrofit a strong pretrained single-sequence model with cross-attention, as in RAG-ESM?
-  How should it represent species identity, phylogenetic distance, arbitrary homolog order, variable sequence length, and reverse complements?
-
-- **What counts as useful retrieval?**
-  Does the reader need strict orthologs, or can paralogs and more remote functional analogs help?
-  How should we distinguish true evolutionary signal from repeats, low-complexity matches, assembly artifacts, and reference leakage?
-
-- **Retrieval backend.**
-  What is the best accuracy–cost tradeoff among direct lookup in a precomputed WGA, local sequence alignment against a genome corpus, dense embedding search, and a hybrid dense-retrieval-plus-alignment/reranking system?
-  Can a retriever be trained jointly with the gLM, as in Protriever, and does task-aware retrieval outperform generic homology?
-
-- **Embedding retrieval.**
-  What training objective and segment granularity would make a DNA embedding index recover local orthology across substitutions, indels, rearrangements, and large evolutionary distances?
-  How much recall against trusted WGA/orthology sets is required before dense retrieval improves the downstream reader?
-
-- **VEP.**
-  Does retrieval improve zero-shot performance on the existing Mendelian, complex-trait, saturation-genome-editing, and other SNV evaluations?
-  More importantly, can full-sequence autoregressive likelihoods produce calibrated and length-robust scores for insertions and deletions that alignment-column models cannot naturally score?
-
-- **Representations.**
-  Do retrieval-conditioned embeddings improve functional-element separation, frozen-embedding linear probes, and other sequence-function tasks, as the protein results from E1, RAG-ESM, and PoET-2 suggest, or does retrieval mainly improve likelihood-based VEP in DNA?
-  Which representation should be exported when the query is conditioned on a variable set of homologs, and is a causal objective sufficient or is a masked/dual objective needed?
-
-- **Deployment unit.**
-  Is retrieval performed online per query window, amortized and cached per locus, or entirely offline for a fixed reference genome?
-  The practical answer may differ for genome-wide precomputed VEP scores, interactive annotation of variants on a known reference, and scoring or generating arbitrary sequences.
-
-- **Practicality criteria.**
-  What index-build time, index size, memory footprint, p50/p95 retrieval latency, end-to-end throughput, cache hit rate, and dollar cost are acceptable?
-  Retrieval and reader inference should be profiled separately, with WGA lookup, local alignment, and dense retrieval compared at matched downstream accuracy.
-
-- **Evaluation hygiene.**
-  How should genomes, loci, homolog families, and retrieval corpora be split to prevent near-duplicate or allele leakage?
-  Comparisons intended to estimate the incremental retrieval effect should include a no-retrieval ablation, matched reader capacity, fixed corpus versions, retrieval traces, and performance stratified by alignment depth, genomic region, repeat content, evolutionary distance, and indel length.
+- Expand the fixed recipe beyond seven mammals, train longer, and test readers above 104M parameters as separate axes with repeated seeds.
+- Add matched no-retrieval, wrong-context, and order-ablation arms to estimate the incremental benefit and distinguish orthology from extra tokens.
+- Evaluate SNVs and indels across retrieval depth, evolutionary distance, region, repeat content, and reader size.
+- Compare precomputed whole-genome-alignment lookup, local alignment, dense retrieval, and hybrid reranking at matched downstream accuracy.
+- Measure retrieval recall, index build and memory cost, p50/p95 latency, reader throughput, and caching for fixed-reference and arbitrary-sequence use cases.
+- Split loci, genomes, and homolog families to prevent near-duplicate, allele, and reference leakage.
 
 </details>

--- a/docs/research/questions/sequence-to-function.md
+++ b/docs/research/questions/sequence-to-function.md
@@ -46,10 +46,6 @@ Gene expression is a later long-context question.
   It shows that multispecies data are not required for transfer, while leaving the benefit of additional evolutionary breadth open.
 - A [PlantCaduceus sequence-to-expression study](https://www.biorxiv.org/content/10.64898/2026.02.27.708524v2) and [PlantCAD2](https://pmc.ncbi.nlm.nih.gov/articles/PMC12425018/) report transfer across plant expression, accessibility, and abundance tasks.
   These broaden the positive precedent but do not isolate the architecture, objective, or data property that enables transfer.
-- [#236](https://github.com/Open-Athena/marin-dna/issues/236) defines the ChromBPNet-on-gLM-embeddings evaluation harness.
-  It is infrastructure rather than a completed experiment.
-- [What context sizes do genomic language models need for different biological tasks, and how should models acquire and use that context?](long-context.md) covers choosing and acquiring context for sequence-to-function models; [Can causal gLM checkpoints be cheaply adapted into bidirectional representation models?](bidirectional-models.md) covers causal-to-bidirectional conversion; [Which genomic regions to train on, and how to find them?](training-regions.md) covers the pretraining footprint.
-  These are coupled design axes that must be controlled rather than attributed to pretraining as one bundle.
 
 </details>
 
@@ -66,79 +62,10 @@ Gene expression is a later long-context question.
 <details>
 <summary>Possible directions</summary>
 
-### What is the decisive accessibility experiment?
-
-On identical chromosome splits and GM12878 functional data, compare at minimum:
-
-1. the standard one-hot ChromBPNet baseline;
-2. the same embedding-input architecture with a randomly initialized encoder;
-3. a frozen pretrained MarinDNA encoder;
-4. the same pretrained encoder fine-tuned end to end; and
-5. ARSENAL under the same evaluation protocol.
-
-- Is one-hot ChromBPNet the only relevant scratch baseline, or do we also need the exact gLM-plus-head architecture from random initialization to separate initialization from added capacity?
-- Does pretraining improve held-out accessibility profiles, caQTL/dsQTL variant effects, or both?
-  These are related but distinct outcomes and should not be collapsed into one verdict.
-- Are gains consistent across cell types and assays, or restricted to GM12878 DNase data that closely matches the pretraining and benchmark distributions?
-
-### When and why does transfer help?
-
-- How does the pretrained-versus-random-init gap change with 1%, 10%, and 100% of the functional training data?
-- Does pretraining primarily improve early optimization and convergence speed, or does it improve the final attainable solution after both arms are trained to convergence?
-- Which layers should be frozen, gradually unfrozen, or fully fine-tuned?
-  How much task-specific adaptation is needed before the original gLM representation is overwritten?
-- Does the benefit come from self-supervised learning itself, from enrichment of the pretraining corpus for regulatory sequence, from multispecies evolutionary signal, or from the motif-scale inductive bias?
-  Matched ablations should separate these factors rather than treating “pretraining” as one intervention.
-- Are per-nucleotide embeddings necessary, or can a cheaper pooled or hierarchical interface preserve the benefit?
-
-### Is bidirectionality important, and can we obtain it?
-
-- Within the ChromBPNet experiment, compare causal-only embeddings, FWD+RC concatenation, and a genuinely bidirectional conversion of the same MarinDNA checkpoint.
-  Keep the downstream head, functional labels, adaptation data, and compute matched.
-- Is FWD+RC concatenation sufficient because the ChromBPNet head can learn cross-flank interactions, or does integration within every gLM layer provide additional signal?
-- Can a completed causal checkpoint be cheaply adapted with full attention and masked next-token training, as proposed in [Can causal gLM checkpoints be cheaply adapted into bidirectional representation models?](bidirectional-models.md), or does representation transfer require a larger masked phase?
-- How much masked adaptation is required before the converted model behaves bidirectionally?
-  Compare no adaptation, parameter-efficient adaptation, and short full-parameter adaptation at the same sidecar budget.
-- Separate bidirectional information flow from the masked objective and from extra optimization.
-  Include a causal continued-pretraining arm and, if possible, a matched bidirectional architecture trained under alternative objectives.
-- Does bidirectionality help accessibility-track prediction, caQTL/dsQTL effects, gene-expression prediction, and representation probes equally, or only tasks where a position's interpretation strongly depends on both flanks?
-- Treat the source causal checkpoint and adapted bidirectional fork as separate artifacts.
-  Autoregressive generation in the adapted fork is not a decision gate.
-- Test directionality and evolutionary breadth factorially.
-  A human-only bidirectional model versus a multispecies causal model cannot reveal which ingredient caused a gain.
-
-### How much evolutionary breadth is useful?
-
-- Compare ARSENAL-style human-reference-only pretraining with human population variation and progressively broader primate, mammal, vertebrate, and animal corpora.
-  Which evolutionary timescale gives the strongest transfer to human accessibility and expression?
-- Hold the number of training tokens, functional-region composition, model size, and compute fixed.
-  Otherwise, a multispecies advantage could merely reflect more data or a denser functional training distribution.
-- Should the comparison use orthologous projections of the same human regulatory elements, each species' native annotations, whole-genome sequence, or matched mixtures?
-  These expose different biological information and should not be conflated.
-- Do closer species provide the best balance between alignable regulatory grammar and informative variation, while distant species dilute lineage-specific human regulation?
-  Is the optimal timescale different for promoters, enhancers, splice regions, and coding sequence?
-- Does explicit alignment or conservation information add value beyond training a single-sequence gLM on the same multispecies corpus?
-- Does evolutionary breadth improve full-data performance, label efficiency, cross-cell-type transfer, or variant-effect prediction most strongly?
-  A benefit confined to one regime is still useful but should be stated narrowly.
-
-### What constitutes fair evidence?
-
-- Hold downstream architecture, labels, chromosome splits, optimizer search, stopping rule, and augmentation fixed.
-  Train all arms to comparable convergence rather than giving the pretrained arm a privileged recipe.
-- Report both downstream-only compute and total compute including gLM pretraining.
-  The former measures amortized reuse; the latter measures whether pretraining is worthwhile for a single task.
-- Match parameter count where possible and report trainable versus frozen parameters, examples seen, FLOPs, peak memory, and wall time.
-- Test for sequence-similarity and locus leakage, especially when regulatory elements used for self-supervised pretraining overlap the genomic universe used for downstream supervision.
-- Predefine whether success means higher full-data accuracy, improved label efficiency, better out-of-distribution transfer, lower compute, or some combination.
-  A small gain on one metric should not silently become a general claim about transfer learning.
-
-### How should we progress from accessibility to gene expression?
-
-- What is the smallest gene-expression task with strong scratch baselines and enough long-range dependence to distinguish useful transfer from extra local capacity?
-- Should the gLM replace the local convolutional encoder in an AlphaGenome- or Borzoi-style model, feed a hierarchical long-context model, or first undergo long-context language-model adaptation?
-- Does accessibility pretraining provide an intermediate supervised stage between self-supervised gLM training and expression prediction, and if so, how do we distinguish the value of gLM initialization from ordinary supervised multitask transfer?
-- Does one gLM initialization improve accessibility, histone marks, TF binding, and expression together, or are task-specific pretrained models more effective?
-- For expression, should the primary readout be track correlation, gene-level expression, eQTL direction/causality, or perturbation response?
-  Improvements in average coverage prediction may not translate to better variant effects.
+- Run the matched accessibility comparison on identical chromosome splits and labels: one-hot ChromBPNet, the same encoder-and-head architecture from random initialization, frozen MarinDNA initialization, end-to-end MarinDNA fine-tuning, and ARSENAL.
+- Report accessibility profiles and caQTL/dsQTL effects separately, including full-data quality, label efficiency, unseen-cell or locus transfer, and downstream-only versus total compute.
+- Compare causal FWD/RC features with a genuinely bidirectional representation while holding the downstream head, adaptation data, and compute fixed.
+- If pretraining helps, isolate regulatory enrichment and evolutionary breadth with matched corpus ablations rather than changing data and directionality together.
+- Advance to gene expression only after the accessibility benchmark establishes a reproducible transfer gain and a long-range task with a strong scratch baseline.
 
 </details>

--- a/docs/research/questions/species-conditioning.md
+++ b/docs/research/questions/species-conditioning.md
@@ -39,20 +39,16 @@ Validation-loss improvement alone would not show that conditioning learned usefu
 <details>
 <summary>Related work</summary>
 
-- The [current MarinDNA preprocessor](https://github.com/Open-Athena/marin-dna/blob/cbb127b53b3d52421fae65cebedf2194c4ec84a3/src/marin_dna/levanter/batch_tokenizer.py#L63-L76) reads the sequence field and emits nucleotide IDs and loss weights without a taxon input.
-  This establishes the sequence-only baseline.
-  It does not determine whether a taxon input would improve representations or VEP.
-
-| Work | Setup and finding | Implication and remaining gap |
-|---|---|---|
-| [Species-aware DNA language models](https://doi.org/10.1186/s13059-024-03221-x) | A learned species token was prepended to short fungal regulatory sequences from 806 species. Species-aware models modestly improved motif reconstruction and several representation tasks. | Explicit taxon context can help short regulatory models. Held-out species required a hand-chosen proxy token, so unseen-species behavior remains unresolved. |
-| [LOL-EVE](https://openreview.net/pdf?id=WxHbIY90IS) | A causal promoter model conditions on clade, species, and proximal-gene embeddings and randomly drops control tags. It reports strong promoter-variant performance. | This supplies a practical hierarchy and dropout design. No matched ablation isolates the taxon tags from gene conditioning, data, and architecture. |
-| [Carbon](https://www.biorxiv.org/content/10.64898/2026.05.22.727119v1) | Released 3B and 8B autoregressive models mix species and gene-type tags into 50% of pretraining prompts. Tags leave overall sequence recovery essentially unchanged; a correct species tag improves recovery for low-resource eukaryote groups. Its VEP suite includes ClinVar, BRCA2, and TraitGym Mendelian, but does not cross VEP with conditioning. [Experiment #486](../experiments/486-carbon-species-conditioning.md) supplied that frozen-checkpoint comparison for Carbon-3B and found prompt-sensitive scores without an established macro-AUPRC difference. | Carbon and experiment #486 show that the checkpoint uses species context in some settings. An otherwise-matched tag-trained versus never-tag-trained model comparison is still needed to isolate the pretraining effect. |
-| [Evo 2](https://doi.org/10.1038/s41586-026-10176-5) | A large sequence-only model uses long DNA prompts to recover alternative genetic codes and species-shaped completion statistics. | Long context can make explicit tags redundant. The result does not show that a short-window model can infer taxon efficiently. |
-| [SynCodonLM](https://academic.oup.com/nar/article/54/5/gkag166/8496864) | Species-group embeddings produced similar average benchmark scores in small ablations, but the no-taxon model was less robust to synonymous perturbations and full-scale taxon IDs gave a small gain. | Taxon context may add coding priors while average gains remain small. The setup is restricted to CDS, codon tokens, and masked modeling. |
-| [CodonTransformer](https://doi.org/10.1038/s41467-025-58588-7) | Organism embeddings enable host-specific codon optimization across 164 organisms. | Taxon conditioning supports controllable generation when host identity is part of the task. It does not isolate benefits for a general genomic LM. |
-| [Nucleotide Transformer](https://doi.org/10.1038/s41592-024-02523-z), [DNABERT-2](https://openreview.net/forum?id=oMLQB4EZE1), and Evo 2 | These models pool multispecies sequence without explicit taxon tags and obtain useful representations or generation. | Sequence-only training is a strong baseline; a conditioning study must show added value at matched scale. |
-| [DNABERT-S](https://arxiv.org/abs/2402.08777) and [ProGen](https://doi.org/10.1038/s41587-022-01618-2) | Species identity is recoverable from DNA embeddings, and taxonomic control tags are effective for protein generation. | The label is learnable and usable for control, but neither result shows that supplying it improves the biological signal sought here. |
+- [Species-aware DNA language models](https://doi.org/10.1186/s13059-024-03221-x) prepends a learned species token to short fungal regulatory sequences and reports modest gains in motif reconstruction and representation tasks.
+  Held-out species required a hand-chosen proxy token, so unseen-species behavior remains unresolved.
+- [LOL-EVE](https://openreview.net/pdf?id=WxHbIY90IS) conditions a causal promoter model on clade, species, and proximal-gene embeddings with control-tag dropout.
+  No matched ablation isolates the taxon tags from gene conditioning, data, and architecture.
+- [Carbon](https://www.biorxiv.org/content/10.64898/2026.05.22.727119v1) supplies species and gene-type tags on half of pretraining examples.
+  Correct species tags improve sequence recovery for several low-resource eukaryote groups without changing the overall result, but the paper does not report tag-conditioned VEP ablations.
+- [Evo 2](https://doi.org/10.1038/s41586-026-10176-5) recovers species-shaped completion statistics from sequence-only long contexts, showing that explicit labels can become redundant.
+  The result does not establish whether short-window models infer taxon efficiently.
+- [SynCodonLM](https://academic.oup.com/nar/article/54/5/gkag166/8496864) finds similar average benchmark scores in small species-group ablations but lower robustness to synonymous perturbations without taxon context.
+  Its evidence is restricted to coding sequence, codon tokens, and masked modeling.
 
 </details>
 
@@ -75,29 +71,10 @@ Validation-loss improvement alone would not show that conditioning learned usefu
 <details>
 <summary>Possible directions</summary>
 
-- **Does it help at fixed compute and data?**
-  Compare models trained on the same examples, order, optimizer, seed, and token budget.
-  The primary contrast should be sequence-only versus correctly conditioned; a shuffled-label control can test whether any extra token/parameters alone explain the result.
-- **Species, clade, or hierarchy?**
-  Compare a leaf-species token with hierarchical rank tokens (for example class/order/family/genus/species) or a shared phylogenetic embedding.
-  A hierarchy may capture both universal and lineage-specific rules more efficiently than unrelated leaf embeddings.
-- **How should unseen species work?**
-  Candidate policies include an explicit unknown-taxon token, the nearest known clade, only the known prefix of the taxonomy path, or an embedding derived from phylogenetic distance.
-  SpeciesLM's proxy-token workaround should not be assumed to generalize.
-- **How redundant is the tag with sequence context?**
-  Measure the conditioning gain across context lengths and genomic regions.
-  Correct, null, and deliberately wrong tags at evaluation time would quantify how much the model actually uses the metadata.
-- **Can one model remain unconditional?**
-  Replace taxon tokens with fixed-position null tokens with probability $q$ during training, following the control-tag dropout idea used by LOL-EVE.
-  Sweep $q$; evaluate both correct-tag and null-tag inference.
-  Keeping fixed slots avoids conflating dropout with a positional shift.
-- **Is the model learning useful biology or a shortcut?**
-  Stratify language-modeling gains by coding/regulatory/background regions and by GC/repeat content.
-  Test whether conditioning improves conserved-versus-background likelihood gaps and human VEP after controlling for simple composition.
-- **Which outcomes decide the question?**
-  At minimum: held-out language-model loss on seen and unseen taxa, region-relevant LL gaps, zero-shot Mendelian/complex-trait VEP AUPRC, and frozen-embedding probes.
-  Correct-versus-wrong-tag sensitivity is a diagnostic, not the primary success metric.
-- **Where should the first experiment live?**
-  A short-window specialist with a known multi-species cohort is the cleanest first test; it avoids changing the data distribution and targets the regime in which taxon cannot always be inferred from long genomic context.
+- Compare otherwise-matched sequence-only and taxon-conditioned models on the same examples, order, optimizer, seed, and token budget, with shuffled-label and wrong-tag controls.
+- Compare leaf-species tokens with hierarchical clade tokens or phylogenetic embeddings, including a defined policy for unseen species.
+- Measure conditioning gains across context length and genomic region to test when sequence alone supplies enough taxonomic information.
+- Use tag dropout to retain an unconditional mode and control fixed prompt positions so dropout does not change sequence alignment.
+- Evaluate seen- and unseen-taxon language loss, functional-region gaps, VEP, and frozen probes after controlling for GC and repeat shortcuts.
 
 </details>

--- a/docs/research/questions/tokenization.md
+++ b/docs/research/questions/tokenization.md
@@ -51,8 +51,6 @@ We have no internal learned-tokenizer result and no evidence that a semantic cod
 <details>
 <summary>Related work</summary>
 
-- The current [MarinDNA batch tokenizer](https://github.com/Open-Athena/marin-dna/blob/c3021ec6926b9f8f329c06679fec1d10539d0389/snakemake/analysis/evals_v2/src/marin_dna_evals/levanter/batch_tokenizer.py#L19-L92) requires a one-to-one character/token mapping and aligns case-based weights to next-token targets.
-  This defines the operational baseline and exposes an implementation gap: compressed or variable-span tokenizers need a different preprocessing path even if the model loss remains unchanged.
 - [Carbon: Decoding the Language of Life](https://www.biorxiv.org/content/10.64898/2026.05.22.727119v1) surveys single-nucleotide, fixed k-mer, BPE, and vector-quantized approaches.
   In its matched 3B, 50B-token ablation, fixed 6-mers reached 43.25% sequence recovery versus 21.68% and 23.48% for 32k- and 50k-vocabulary BPE, and BRCA2 AUROC of 75.04% versus 63.40% and 66.51%.
   Its interpretation is that variable BPE boundaries are poorly aligned with causal DNA generation, while fixed 6-mers are neutral compression units.
@@ -80,50 +78,9 @@ We have no internal learned-tokenizer result and no evidence that a semantic cod
 <details>
 <summary>Possible directions</summary>
 
-### Evidence required to leave the baseline
-
-- What improvement would justify moving away from single nucleotides: downstream quality at matched training FLOPs, throughput at matched quality, longer useful context, or some combination?
-- How should comparisons account for both token budget and nucleotide exposure?
-  Report model tokens, raw bases, realized epochs, training FLOPs, peak memory, and wall-clock throughput.
-  Use bits per base rather than raw token cross-entropy when vocabulary size and bases per token differ.
-- Which base-sensitive capabilities are non-negotiable?
-  At minimum, compare likelihood-based VEP on permitted development chromosomes, generation/reconstruction fidelity, reverse-complement behavior, and sensitivity to substitutions and indels near token boundaries.
-
-### Semantic and noise-aware tokens
-
-- Can a tokenizer allocate short or specific codes to constrained sequence and coarser codes to weakly constrained background without using downstream labels at inference time?
-- How should "semantic" be measured?
-  Candidate observables include association with motifs and genomic annotations, stability across species and reverse complements, code reuse across sequence variants, and improved downstream performance after controlling for GC, repeats, and span length.
-- Does compressing unpredictable sequence remove genuine but unannotated biology?
-  Reconstruction error, code entropy, and downstream failures should be stratified by conservation, repeat class, and genomic region.
-- If a token such as a generic background code is lossy, what sequence does it decode to?
-  Lossy semantic codes still permit next-token training, but they change the modeled object and may make exact generation or nucleotide likelihoods unavailable.
-  This tradeoff must be explicit.
-
-### Using MarinDNA to build a tokenizer
-
-- Which existing checkpoint, layer, pooling rule, and span sizes produce useful inputs to a quantizer?
-- Should the first learned tokenizer quantize fixed-span hidden states, learn variable boundaries, or use a small encoder over local MarinDNA representations?
-- Can a lightweight VQ encoder-decoder reconstruct sequence accurately while collapsing biologically equivalent or weakly constrained spans into shared codes?
-- Are learned codes stable across random seeds, species, and checkpoints, or do code identities and boundaries drift too much to support a reusable pretokenized corpus?
-- Does initializing from MarinDNA representations add value over VQ trained directly on one-hot bases, random projections, fixed k-mers, or ordinary sequence clustering?
-
-### Candidate experiment ladder
-
-1. **Clean fixed-token replication.**
-   Compare character, 4-mer, 6-mer, and 8-mer tokenization on one fixed corpus with the same examples, uniform loss weighting, model family, optimizer, training FLOPs, and development evaluations.
-   Report both matched-compute and matched-base-exposure views.
-   This settles whether [#64](https://github.com/Open-Athena/marin-dna/issues/64) reproduces without the repeat-weighting confound.
-2. **Frozen-model VQ pilot.**
-   Use span representations from one released MarinDNA checkpoint to train a small VQ encoder-decoder, materialize discrete code sequences, and train a small causal model over those codes with ordinary next-token cross-entropy.
-   Include one-hot VQ and fixed-k-mer controls.
-3. **Semantic audit.**
-   Measure compression ratio, bits per base, reconstruction, code usage, annotation and motif enrichment, conservation, repeat/GC confounding, reverse-complement consistency, and boundary sensitivity before scaling the language model.
-4. **Matched downstream gate.**
-   Compare the best learned tokenizer with the single-base baseline at matched FLOPs on odd autosomes plus chromosome X for development.
-   Do not use even-autosome or chromosome-Y VEP labels during tokenizer selection.
-   Advance only if the tokenizer improves a preregistered downstream or efficiency target without a material loss in base-sensitive scoring.
-
-The learned-tokenizer direction should stop if codes mainly reproduce simple composition or repeat labels, if reconstruction failures concentrate in constrained bases, if codebooks are unstable, or if gains disappear against fixed-block controls at matched compute.
+- Replicate the character, fixed 4-mer, 6-mer, and 8-mer comparison with uniform weighting, matched compute, and matched base exposure.
+- Train a small causal model over fixed-span VQ codes derived from a frozen MarinDNA checkpoint, with one-hot VQ and fixed-k-mer controls.
+- Audit compression ratio, bits per base, reconstruction, code stability, reverse-complement and boundary behavior, and associations with annotations after controlling for GC and repeats.
+- Advance only if a learned tokenizer improves a preregistered quality or efficiency target without a material loss in substitution- and indel-sensitive scoring.
 
 </details>

--- a/docs/research/questions/training-regions.md
+++ b/docs/research/questions/training-regions.md
@@ -54,9 +54,6 @@ It should retain a background arm so gains on functional VEP can be weighed agai
   In genomic data, repeats, local composition, and phylogenetic redundancy may all produce high predictability without functional constraint.
 - [Self-paced learning](https://papers.nips.cc/paper_files/paper/2010/hash/e57c6b956a6521b28495f2886ca0977a-Abstract.html) introduces current small-loss examples first and anneals toward the full dataset, while [Selective Backprop](https://arxiv.org/abs/1910.00762) prioritizes current high-loss examples because low-loss gradients tend to be small.
   A permanent hard mask on the student's lowest-loss tokens changes the target distribution and can reinforce already-learned tokens; it is distinct from self-distillation and reducible-loss selection.
-- Conservation is a proxy for purifying constraint rather than a complete definition of function.
-  It misses lineage-specific and hard-to-align elements, while annotations miss unknown constrained sequence.
-  A useful observable is the joint coverage of evaluation loci, annotated classes, conservation tiers, and repeats under each proposed footprint.
 
 </details>
 
@@ -93,104 +90,11 @@ It should retain a background arm so gains on functional VEP can be weighed agai
 <details>
 <summary>Possible directions</summary>
 
-- Test whether annotation-free pretraining can recover functional sequence from likelihood.
-  Train 46M, 76M, and 128M models for matched token budgets on the complete nonrepeat sequence of about 20 animal genomes sampled broadly across orders, with no annotation-based locus filtering.
-  Use annotations and conservation only after training to label evaluation positions, measuring functional-versus-matched-background loss gaps and AUPRC from one-orientation loss and entropy, globally and for CDS, upstream, downstream, ncRNA, and enhancer.
-  Composition and local-predictability controls are needed to interpret the loss gaps.
-
-### What outcome are we optimizing?
-
-- Is there one corpus that transfers well across VEP, functional-region representations, sequence generation, genome annotation, and phylogenetic inference, or should MarinDNA maintain task-specific mixtures?
-- For VEP, should the primary decision metric be zero-shot AUPRC, frozen-embedding probes, functional/non-functional likelihood gaps, or a combination?
-  Improvements should be reported separately for Mendelian, complex-trait, coding, regulatory, conserved, and weakly conserved variants.
-- What evaluation would expose the cost of removing neutral sequence?
-  Candidate outcomes include phylogeny/species inference, mutation-spectrum prediction, regional composition, and held-out whole-genome likelihood, but these should not silently displace functional VEP as the primary task.
-
-### What should count as functional training sequence?
-
-- **Direct annotation:** genes, UTRs, ncRNAs, cCREs, experimentally measured regulatory elements.
-  How should incomplete, tissue-specific, and species-biased annotations be combined without letting well-annotated organisms dominate?
-- **Evolutionary constraint:** phyloP, phastCons, GERP, alignment depth, or a learned evolutionary-rate score.
-  Which phylogenetic timescale and window statistic best match each downstream task?
-  How much low-conservation sequence must remain to cover recent or rapidly evolving function?
-- **Cheap local alignment:** can `mmseqs2` hits be converted into robust local statistics—hit depth, taxonomic breadth, identity/coverage profiles, or deviations from a neutral model—that select functional windows without a precomputed WGA?
-  How should paralogs, synteny loss, fragmented hits, and repeats be handled?
-- **Learned single-sequence selection:** once a strong model exists, can a classifier or probe trained on annotations and/or evolutionary labels identify functional windows in a new genome from sequence alone?
-  What orthogonal evaluation prevents the selector from merely reproducing conservation or annotation bias?
-- **Frozen likelihood-derived selection:** can per-base loss or entropy from a small frozen model identify useful training tokens without annotations?
-  When a target or high-quality reference corpus exists, can a Rho-1-style reference model trained on that distribution provide a useful reducible-loss score?
-  Separately, can loss reduction between two same-corpus frozen model sizes identify tokens with high scale-dependent learnability?
-  Treat absolute predictability, target-distribution reducible loss, and same-corpus improvement with model scale as distinct signals.
-  Repeat status, GC content, local k-mer predictability, taxon, and homology density are necessary controls because each can create predictable sequence without implying functional constraint.
-- Should these sources be used as a union, an intersection, separate sampling strata, or continuous weights?
-
-### Filter, sample, or weight?
-
-- At equal training FLOPs, how do hard filtering, score-proportional sampling, per-base loss weighting, and a curriculum from enriched to whole-genome data compare?
-- For likelihood-derived selection experiments, keep repeat downweighting fixed across every arm and compute selection thresholds only among nonrepeat tokens.
-  This comparison tests how gradient mass is allocated within nonrepeat sequence, leaving repeat handling outside its scope.
-- Can the whole genome remain in the corpus while constrained/annotated bases receive most of the gradient?
-  Does this retain rare functional classes and useful neutral context without letting background dominate?
-- Should a window be selected because it contains some functional sequence, while the loss is applied only or preferentially to the functional bases?
-  How much flanking sequence is beneficial context rather than wasted loss?
-- Does causal next-token prediction, masked modeling, or another objective change the optimal sampling/weighting policy?
-
-### How do scale and data quantity change the answer?
-
-- Does the benefit of enrichment shrink with parameter count, token budget, or context length?
-- Run a small fixed-compute causal experiment comparing uniform nonrepeat loss, terminal-checkpoint loss or entropy as a soft weight, excess loss against a frozen target-distribution reference, and a scale-differential weight from frozen checkpoints.
-  Add direct conservation weighting on human sequence as an oracle positive control.
-  Keep repeat downweighting identical in every arm.
-  Match training compute and record the offline scoring cost separately.
-  Treat same-corpus improvement as a learnability heuristic rather than a direct Rho-1 analogue.
-  Teacher nucleotide probabilities would define a separate self-distillation objective and should not be conflated with loss-based token selection.
-  Use deterministic FWD scoring first and add an averaged-score sensitivity only if downstream outcomes justify the second inference pass.
-- Add compatible training-corpus exposure and homology-density covariates when they become available.
-  Test whether either explains the apparent association between likelihood-derived scores and conservation.
-- When a filtered corpus is smaller, are gains caused by better loci or simply by seeing the same loci for more epochs?
-  Both compute-matched and exposure/epoch-matched comparisons are needed.
-- Is there a curriculum in which constrained sequence is best early, but adding progressively broader genome sequence later improves generalization or prevents overfitting?
-- What is the minimum useful amount of low-conservation/background data at each scale?
-
-### How should repetitive elements be handled?
-
-- At several matched FLOP budgets, compare uniform loss with the current 100-fold repeat downweighting while holding footprint and sampling fixed.
-  This should measure whether repeat downweighting helps and how its effect changes with scale.
-- If uniform loss preserves language-modeling and downstream performance, remove repeat-specific loss weights.
-- Compare exclusion, deduplication, soft masking, family/age-aware sampling, and per-base loss downweighting rather than treating “repeat filtering” as one intervention.
-- Which repeat classes mostly create redundant or ambiguous alignment signal, and which carry regulatory, structural, or lineage-specific information?
-- Do repeats help species/phylogeny tasks while hurting functional VEP, and does that tradeoff change with scale?
-- Are repeat effects actually about biology, or about duplicated windows, assembly/masking heterogeneity, and train/test similarity leakage?
-
-### Candidate experiment ladder
-
-1. **Small controlled baseline.**
-   At one small MarinDNA scale and fixed context, compare:
-   - uniform whole-genome sampling with uniform loss;
-   - the current conservation-filtered footprint;
-   - whole-genome sampling with conservation/annotation-aware loss weights; and
-   - a matched mixture of annotated functional classes plus background.
-
-   Hold architecture, optimizer, number of training tokens, splits, and evaluation fixed.
-   Report unique loci, effective epochs, repeat content, region composition, and gradient/loss mass by stratum.
-
-2. **Disentangle selection from repetition.**
-   Add a data-size-matched whole-genome subset and an epoch/exposure-matched rerun of the enriched arm.
-   This separates “better sequence” from “more passes over less sequence.”
-
-3. **Task-stratified readout.**
-   Evaluate Mendelian and complex-trait VEP by consequence and conservation stratum, region-matched likelihood gaps, frozen-embedding probes, and at least one outcome expected to benefit from neutral/background sequence.
-
-4. **Scale and repeat-weighting interaction.**
-   Compare uniform loss with the current repeat downweighting at several model/token budgets while holding footprint, sampling, and objective fixed.
-   If uniform loss preserves likelihood and downstream performance, remove repeat-specific weighting.
-   [#87](https://github.com/Open-Athena/marin-dna/issues/87) first scoped this ablation.
-
-5. **Acquisition-method comparison.**
-   Once the target training distribution is clearer, compare WGA/conservation selection against direct annotation, `mmseqs2`-derived local evolutionary statistics, and a learned single-sequence selector on the same genomes and matched window budget.
-
-6. **Mixture frontier.**
-   Sweep the fraction of constrained/annotated, weakly conserved, neutral/background, and repetitive sequence rather than comparing only the endpoints.
-   The useful output is a task-by-scale Pareto frontier and a reproducible default mixture, not a universal declaration that one class of sequence “matters.”
+- Compare whole-genome, conservation-filtered, annotation-enriched, and functional-plus-background corpora at matched architecture, tokens, and evaluation, reporting unique loci and realized repetitions.
+- Separate locus selection, exposure frequency, and per-base loss weighting, including data-size- and epoch-matched controls.
+- Test terminal loss or entropy, target-distribution reducible loss, and same-corpus scale-differential loss as distinct selectors; control for repeats, GC, local predictability, training exposure, and homology density.
+- Measure the footprint tradeoff across Mendelian and complex-trait VEP, region-matched likelihood gaps, frozen probes, and at least one outcome expected to benefit from neutral sequence.
+- Ablate the current 100-fold repeat downweighting across model and token scales while holding footprint and sampling fixed.
+- Compare conservation or whole-genome alignment with direct annotation, cheap local alignment, and learned single-sequence selection only after the target distribution and leakage contract are fixed.
 
 </details>


### PR DESCRIPTION
Condense the 12 active question pages from 1,784 to 930 source lines while preserving the active set, priorities, accepted answers, and accepted experiment relationships. Related work now contains external work only, and possible directions contain curated tests instead of experiment plans and output menus.

Align experiment pages with the same guidance by moving figures after Findings, removing future directions from experiment #402, and compressing issue-level diagnostic detail from experiment #486.

Follow-up to #512.
