### PR TITLE
Use row-random validation cohorts

### DIFF
--- a/snakemake/vertebrate_projection_dataset/README.md
+++ b/snakemake/vertebrate_projection_dataset/README.md
@@ -199,7 +199,7 @@ Each configured region cohort first gets internal `train.parquet` and `validatio
 Parquet is the efficient projection, split, and card-count intermediate; it is not the published training format.
 
 For each cohort, validation selection considers only original-orientation rows after cohort filters and before reverse-complement augmentation.
-The selector hashes each stable biological row identity with the configured seed in Polars.
+The selector hashes each stable biological row identity with the configured seed and a stable region/species-scope cohort salt in Polars, so nested cohorts receive independent rankings.
 It takes exactly `validation_rows` lowest ranks without replacement: 16,384 rows in the full tier and one row in the smoke tier.
 Stable identity tie-breaks make membership independent of input row order.
 Selection is row-level and does not stratify by chromosome, species, alignment backend, or human anchor.
@@ -209,9 +209,9 @@ Every unselected original row remains in training.
 When reverse-complement augmentation is enabled, it applies only to those training originals; validation stays in original orientation and the reverse complement of every selected validation row is excluded from training.
 
 Each cohort writes three audit sidecars in addition to its Parquets.
-`validation_selection.tsv` records stable identities, selection ranks, the seed, and selection digests.
+`validation_selection.tsv` records stable identities, selection ranks, the seed, cohort salt, and selection digests.
 `validation_composition.tsv` reconciles eligible and selected counts by chromosome, species, and alignment backend.
-`split_summary.json` records the strategy, seed, source/train/validation counts, augmentation setting, and realized token count.
+`split_summary.json` records the strategy, seed, cohort salt, source/train/validation counts, augmentation setting, and realized token count.
 At 16,384 rows, validation has exactly 4,194,304 tokens including BOS.
 These audit sidecars remain in the pipeline results and are never copied into the Hugging Face artifact directory.
 

--- a/snakemake/vertebrate_projection_dataset/README.md
+++ b/snakemake/vertebrate_projection_dataset/README.md
@@ -73,7 +73,7 @@ Target-genome sequence extraction retains the v1 UCSC human and `gbdb` 2bit sour
 
 ## Projection contract
 
-The request table retains each original 255 bp human anchor for identity and splitting, and stores `[source_start + 127, source_start + 128)` as the only interval submitted to HAL or MAF.
+The request table retains each original 255 bp human anchor for identity and downstream row-random selection, and stores `[source_start + 127, source_start + 128)` as the only interval submitted to HAL or MAF.
 HAL receives all active anchors in one BED and runs one `halLiftover` job per mammal species.
 MultiZ reads each configured chromosome MAF once and emits candidates for all active non-mammal species.
 
@@ -96,19 +96,13 @@ Each HAL species contract reads one fragment Parquet and derives consistency, bo
 An assertion requires exactly one accepted or rejected row per input group.
 HAL contract rules reserve 10 GB to preserve worker memory headroom.
 
-Human, HAL, and MultiZ sequence extraction all use one compiled
-`twoBitToFa -bed` call per genome. BED6 strand is honored by `twoBitToFa`, and
-soft-masked case from the 2bit source is preserved. Sequence rules reserve 4 GB. Sequence
-combination, non-chromosome-18 training writes, QC aggregation, and inspection
-candidate selection use lazy streaming scans.
-Publication sharding retains the established deterministic eager shuffle for
-inputs of at most 100 million post-augmentation rows. Larger inputs use a
-deterministic hash sort and balanced partitioned NDJSON sink in Polars'
-streaming engine, allowing the sort to spill rather than materializing the
-entire publication cohort in RAM.
-The conservation-filtered anchor BED is compressed through a temporary plain
-file, fully decompressed to verify its row count, and atomically installed only
-after the gzip stream passes its CRC check.
+Human, HAL, and MultiZ sequence extraction all use one compiled `twoBitToFa -bed` call per genome.
+BED6 strand is honored by `twoBitToFa`, and soft-masked case from the 2bit source is preserved.
+Sequence rules reserve 4 GB.
+Sequence combination, row-random dataset split writes, QC aggregation, and inspection candidate selection use lazy streaming scans.
+Publication sharding retains the established deterministic eager shuffle for inputs of at most 100 million post-augmentation rows.
+Larger inputs use a deterministic hash sort and balanced partitioned NDJSON sink in Polars' streaming engine, allowing the sort to spill rather than materializing the entire publication cohort in RAM.
+The conservation-filtered anchor BED is compressed through a temporary plain file, fully decompressed to verify its row count, and atomically installed only after the gzip stream passes its CRC check.
 
 ## Runbook
 
@@ -201,31 +195,31 @@ Every HAL projection/extraction path also depends on the tier-specific local `me
 
 ## Splits and output datasets
 
-Each configured region cohort first gets internal `train.parquet` and
-`validation.parquet` files. Parquet is the efficient projection, split, and
-card-count intermediate; it is not the published training format.
+Each configured region cohort first gets internal `train.parquet` and `validation.parquet` files.
+Parquet is the efficient projection, split, and card-count intermediate; it is not the published training format.
 
-- training contains only non-chromosome-18 human source anchors and includes
-  the configured reverse-complement augmentation;
-- validation candidates are original-orientation rows from chromosome-18 human
-  source anchors;
-- the deterministic SHA-256 sampler first represents every eligible species,
-  then water-fills quotas as evenly as availability permits, up to 16,384 rows;
-  and
-- unsampled chromosome-18 rows and all chromosome-18 reverse complements are
-  discarded, never returned to training.
+For each cohort, validation selection considers only original-orientation rows after cohort filters and before reverse-complement augmentation.
+The selector hashes each stable biological row identity with the configured seed in Polars.
+It takes exactly `validation_rows` lowest ranks without replacement: 16,384 rows in the full tier and one row in the smoke tier.
+Stable identity tie-breaks make membership independent of input row order.
+Selection is row-level and does not stratify by chromosome, species, alignment backend, or human anchor.
+Chromosome 18 is an ordinary eligible chromosome.
+Different species projections from the same human anchor may occur on opposite sides of the split.
+Every unselected original row remains in training.
+When reverse-complement augmentation is enabled, it applies only to those training originals; validation stays in original orientation and the reverse complement of every selected validation row is excluded from training.
 
-Each cohort also writes `validation_selection.tsv`,
-`validation_species_counts.tsv`, and `split_summary.json`, including the seed,
-stable row IDs, per-species eligible/selected counts, and realized token count.
-At 16,384 rows, validation has exactly 4,194,304 tokens including BOS. These QC
-sidecars remain in the pipeline results and are never copied into the Hugging
-Face artifact directory.
+Each cohort writes three audit sidecars in addition to its Parquets.
+`validation_selection.tsv` records stable identities, selection ranks, the seed, and selection digests.
+`validation_composition.tsv` reconciles eligible and selected counts by chromosome, species, and alignment backend.
+`split_summary.json` records the strategy, seed, source/train/validation counts, augmentation setting, and realized token count.
+At 16,384 rows, validation has exactly 4,194,304 tokens including BOS.
+These audit sidecars remain in the pipeline results and are never copied into the Hugging Face artifact directory.
 
-The full tier additionally writes `datasets/cds_mammals_only/`, which applies
-the CDS label after the complete shared projection/acceptance pass and then
-retains only `human_reference` and `zoonomia_cactus` rows. The regular
-`datasets/cds/` cohort retains those identical training rows plus `ucsc_multiz100way`. Projection, acceptance, augmentation, and sampling algorithms are identical, and the mammals-only training rows are an exact subset of the combined arm. Validation is sampled independently within each cohort because their eligible species sets differ, so the realized validation rows, and therefore validation-loss levels, must not be compared between arms.
+The full tier additionally writes `datasets/cds_mammals_only/`, which applies the CDS label after the complete shared projection/acceptance pass and then retains only `human_reference` and `zoonomia_cactus` rows.
+The regular `datasets/cds/` cohort uses the same pre-split mammal rows and also includes `ucsc_multiz100way`.
+Before splitting, the mammals-only eligible rows are an exact subset of the combined arm.
+Each cohort selects validation independently because its eligible species set differs, so finalized training and validation rows are not guaranteed to preserve that subset relationship.
+The realized validation rows, and therefore validation-loss levels, must not be compared directly between arms.
 
 For Hugging Face, `all_hf_files` deterministically prepares the v2 center-1 datasets: shuffle each split, write 64 full-tier train shards (four in smoke) and one validation shard as JSONL, then zstd-compress them. On a dedicated HF worker, an explicitly supplied `PIPELINE_COMMIT_SHA` selects the matching producer/config namespace; the worker restores its producer manifest, source split Parquets, and active-species manifest through default Snakemake S3 storage. Local JSONL.zst artifacts are rebuilt on that worker and are never recovered through a separate issue-specific snapshot path.
 Each isolated `hf/<cohort>/` directory contains only:
@@ -253,12 +247,10 @@ The published encoding and layout are JSONL.zst; internal Parquet and every QC T
 
 The default DAG writes:
 
-- `qc/per_anchor.parquet`: mammal/non-mammal/total recovery, requested fraction,
-  recovered clades, deepest clade, and no-mapping count per anchor;
+- `qc/per_anchor.parquet`: mammal/non-mammal/total recovery, requested fraction, recovered clades, deepest clade, and no-mapping count per anchor;
 - `qc/per_anchor_scope.parquet`: recovery by anchor, backend, and clade;
 - `qc/rejection_counts.parquet`: explicit reasons including `no_mapping`;
-- `qc/aggregates.parquet`: region/split/backend/clade counts, median, q10/q25/
-  q75/q90, mean fraction, and fraction of anchors reaching the clade; and
+- `qc/aggregates.parquet`: region/backend/clade counts, median, q10/q25/q75/q90, mean fraction, and fraction of anchors reaching the clade; and
 - `qc/manual_inspection.md` plus accepted/rejected TSV samples.
 
 The full-dataset inspection sample deterministically includes several CDS and
@@ -275,10 +267,7 @@ broader CDS recovery is a biological expectation, not a per-anchor invariant.
 
 ## Tests
 
-Focused tests cover the exact center-base request, MAF gaps, fragmented blocks, reverse strands, coordinate
-conversion, duplicate and ambiguous mappings, bounds, case-preserving sequence
-orientation, manifest decisions, split allocation, mirroring checks, QC, and
-inspection sampling:
+Focused tests cover the exact center-base request, MAF gaps, fragmented blocks, reverse strands, coordinate conversion, duplicate and ambiguous mappings, bounds, case-preserving sequence orientation, manifest decisions, row-random split selection, mirroring checks, QC, and inspection sampling:
 
 ```bash
 uv run --locked --group dev pytest

--- a/snakemake/vertebrate_projection_dataset/config/HF_DATASET_CARD_TEMPLATE.md
+++ b/snakemake/vertebrate_projection_dataset/config/HF_DATASET_CARD_TEMPLATE.md
@@ -16,59 +16,49 @@ configs:
 
 Review status: **draft; do not upload until generated values are checked**.
 
-Human-anchored 255 bp vertebrate sequences from the Zoonomia 447-mammal Cactus
-alignment and UCSC hg38 MultiZ 100-way alignment for the `<region>` cohort.
+Human-anchored 255 bp vertebrate sequences from the Zoonomia 447-mammal Cactus alignment and UCSC hg38 MultiZ 100-way alignment for the `<region>` cohort.
 Source FASTA/2bit letter case is preserved.
 
 Non-human rows project only the central human nucleotide and extract the 255 bp target window centered on its unique mapped locus.
 
 Anchor eligibility uses the pipeline's pinned phyloP conservation filter.
-Sequence case is independent of that filter: lowercase bases preserve source
-repeat masking, uppercase bases preserve source non-repeat-masked sequence, and
-conservation scores never rewrite emitted characters or case.
+Sequence case is independent of that filter: lowercase bases preserve source repeat masking, uppercase bases preserve source non-repeat-masked sequence, and conservation scores never rewrite emitted characters or case.
 
-Produced by the
-[`vertebrate_projection_dataset` pipeline](https://github.com/Open-Athena/marin-dna/blob/<COMMIT_SHA>/snakemake/vertebrate_projection_dataset/README.md).
+Produced by the [`vertebrate_projection_dataset` pipeline](https://github.com/Open-Athena/marin-dna/blob/<COMMIT_SHA>/snakemake/vertebrate_projection_dataset/README.md).
 Replace `<COMMIT_SHA>` with the exact producing revision; never use a branch URL.
 
 ## Provenance
 
 - Human reference: hg38, one row per retained human anchor.
-- Mammals: `<ZOONOMIA_SPECIES_COUNT>` family-deduplicated targets from the
-  Zoonomia 447-mammal Cactus HAL.
-- Non-mammals: `<MULTIZ_SPECIES_COUNT>` family-deduplicated targets from the
-  UCSC hg38 MultiZ 100-way MAFs.
+- Mammals: `<ZOONOMIA_SPECIES_COUNT>` family-deduplicated targets from the Zoonomia 447-mammal Cactus HAL.
+- Non-mammals: `<MULTIZ_SPECIES_COUNT>` family-deduplicated targets from the UCSC hg38 MultiZ 100-way MAFs.
 - Species manifest revision: `<COMMIT_SHA>`.
 - Dataset revision: `<HF_REVISION_AFTER_UPLOAD>`.
 
 ## Splits
 
-- `train`: `<TRAIN_ROWS>` rows from non-chromosome-18 human source anchors;
-  configured reverse-complement augmentation may be present.
-- `validation`: `<VALIDATION_ROWS>` original-orientation rows sampled
-  deterministically from chromosome-18 human source anchors, capped at 16,384.
+- `train`: `<TRAIN_ROWS>` rows after removing the validation sample and applying the configured reverse-complement augmentation.
+- `validation`: `<VALIDATION_ROWS>` original-orientation rows sampled uniformly without replacement with seed `<VALIDATION_SEED>` before augmentation.
 - Validation tokens including one BOS per row: `<VALIDATION_TOKENS>`.
 - Validation seed: `<VALIDATION_SEED>`.
 
-Unsampled chromosome-18 rows and all chromosome-18 reverse complements are
-discarded. Split membership depends only on the human source interval.
+The split is row-level and does not stratify by chromosome, species, or human anchor.
+Different species projections from one human anchor may occur on opposite sides of the split.
+The reverse complement of a selected validation row is excluded from training.
 
 ## Species counts
 
-Replace this section with the generated backend/clade table and attach the
-generated per-species validation counts.
+Replace this section with the generated backend/clade table.
 
 ## Schema
 
-Replace this section with the generated schema. It includes stable row/anchor
-identity, 0-based half-open human and target coordinates, region, taxonomy,
-alignment backend, mapping provenance, sequence orientation, augmentation, and
-the 255 bp source-case-preserving sequence.
+Replace this section with the generated schema.
+It includes stable row/anchor identity, 0-based half-open human and target coordinates, region, taxonomy, alignment backend, mapping provenance, sequence orientation, augmentation, and the 255 bp source-case-preserving sequence.
 
 ## Pre-upload checklist
 
 - [ ] Commit-pinned pipeline URL resolves to the producing code.
-- [ ] Row, token, backend/clade, and per-species counts match generated files.
+- [ ] Row, token, backend/clade, selection, and validation-composition counts match generated files.
 - [ ] Coordinate/split/case assertions and focused tests passed.
 - [ ] QC breadth and rejection distributions were reviewed.
 - [ ] ZRS recovered multiple non-mammal clades.

--- a/snakemake/vertebrate_projection_dataset/config/config.yaml
+++ b/snakemake/vertebrate_projection_dataset/config/config.yaml
@@ -27,8 +27,8 @@ smoke_chroms: [chr7, chr18]
 smoke_mammals: [Mus_musculus, Loxodonta_africana]
 smoke_non_mammals: [galGal4, allMis1, xenTro7, danRer10, petMar2]
 
-validation_chrom: chr18
-validation_max_rows: 16384
+validation_rows: 16384
+smoke_validation_rows: 1
 validation_seed: 42
 add_rc: true
 publication_train_shards: 64

--- a/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/pipeline_io.py
+++ b/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/pipeline_io.py
@@ -42,7 +42,8 @@ from marin_dna_vertebrate_projection.qc import (
     write_projection_qc_tables_streaming,
 )
 from marin_dna_vertebrate_projection.split import (
-    assign_train_validation_splits,
+    VALIDATION_IDENTITY_COLUMNS,
+    select_uniform_validation_rows,
 )
 
 
@@ -342,16 +343,16 @@ def write_dataset_split_files(
     train_path: str | Path,
     validation_path: str | Path,
     selection_path: str | Path,
-    species_counts_path: str | Path,
+    composition_path: str | Path,
     summary_path: str | Path,
     *,
     region_label: str,
     species_scope: str = "all",
     add_rc: bool,
-    validation_chrom: str,
-    max_validation_rows: int,
+    validation_rows: int,
     seed: int,
 ) -> None:
+    """Write a uniform row-random split before reverse-complement augmentation."""
     assert species_scope in {"all", "mammals_only"}
     original = pl.scan_parquet(combined_path)
     if region_label != "all":
@@ -360,12 +361,41 @@ def write_dataset_split_files(
         original = original.filter(
             pl.col("alignment_source").is_in(["human_reference", "zoonomia_cactus"])
         )
-    original_rows = original.select(pl.len()).collect(engine="streaming").item()
-    assert original_rows > 0, (
-        f"empty dataset cohort: region={region_label}, scope={species_scope}"
+    schema = original.collect_schema()
+    assert "augmentation" not in schema
+    source_rows = int(original.select(pl.len()).collect(engine="streaming").item())
+    assert source_rows > validation_rows, (
+        f"validation requires {validation_rows} rows plus nonempty training data; "
+        f"region={region_label}, scope={species_scope}, source_rows={source_rows}"
     )
 
-    train_original = original.filter(pl.col("source_chrom") != validation_chrom)
+    selection = select_uniform_validation_rows(
+        original,
+        validation_rows=validation_rows,
+        seed=seed,
+    )
+    selected_keys = selection.select(*VALIDATION_IDENTITY_COLUMNS)
+    train_original = original.join(
+        selected_keys.lazy(),
+        on=list(VALIDATION_IDENTITY_COLUMNS),
+        how="anti",
+    )
+    validation = (
+        original.join(
+            selection.select(
+                *VALIDATION_IDENTITY_COLUMNS,
+                "selection_rank",
+            ).lazy(),
+            on=list(VALIDATION_IDENTITY_COLUMNS),
+            how="inner",
+        )
+        .sort("selection_rank")
+        .drop("selection_rank")
+        .with_columns(pl.lit("+").alias("augmentation"))
+        .collect(engine="streaming")
+    )
+    assert validation.height == validation_rows
+
     if add_rc:
         train = pl.concat(
             [
@@ -380,41 +410,76 @@ def write_dataset_split_files(
     else:
         train = train_original.with_columns(pl.lit("+").alias("augmentation"))
 
-    for path in [train_path, validation_path, selection_path, species_counts_path]:
+    for path in [
+        train_path,
+        validation_path,
+        selection_path,
+        composition_path,
+        summary_path,
+    ]:
         Path(path).parent.mkdir(parents=True, exist_ok=True)
     train.sink_parquet(train_path)
+    validation.write_parquet(validation_path)
+    selection.write_csv(selection_path, separator="\t")
 
-    candidates = (
-        original.filter(pl.col("source_chrom") == validation_chrom)
-        .collect(engine="streaming")
-        .with_columns(pl.lit("+").alias("augmentation"))
+    composition_frames: list[pl.DataFrame] = []
+    for dimension in ["source_chrom", "species", "alignment_source"]:
+        eligible = (
+            original.group_by(dimension)
+            .len(name="eligible_rows")
+            .collect(engine="streaming")
+        )
+        selected = validation.group_by(dimension).len(name="selected_rows")
+        composition_frames.append(
+            eligible.join(selected, on=dimension, how="left")
+            .with_columns(
+                pl.col("selected_rows").fill_null(0),
+                pl.lit(dimension).alias("dimension"),
+                pl.col(dimension).cast(pl.String).alias("value"),
+            )
+            .select("dimension", "value", "eligible_rows", "selected_rows")
+        )
+    pl.concat(composition_frames).sort("dimension", "value").write_csv(
+        composition_path,
+        separator="\t",
     )
-    result = assign_train_validation_splits(
-        candidates,
-        validation_chrom=validation_chrom,
-        max_validation_rows=max_validation_rows,
-        seed=seed,
-    )
-    assert result.train.is_empty()
-    result.validation.drop("row_id").write_parquet(validation_path)
-    result.selection_manifest.write_csv(selection_path, separator="\t")
-    result.species_counts.write_csv(species_counts_path, separator="\t")
-    train_rows = (
+
+    train_rows = int(
         pl.scan_parquet(train_path).select(pl.len()).collect(engine="streaming").item()
     )
+    train_original_rows = source_rows - validation_rows
+    expected_train_rows = train_original_rows * (2 if add_rc else 1)
+    assert train_rows == expected_train_rows
+    assert pl.read_parquet_schema(train_path) == pl.read_parquet_schema(validation_path)
+    assert set(validation["augmentation"].to_list()) == {"+"}
+    selected_train_rows = int(
+        pl.scan_parquet(train_path)
+        .join(
+            selected_keys.lazy(),
+            on=list(VALIDATION_IDENTITY_COLUMNS),
+            how="semi",
+        )
+        .select(pl.len())
+        .collect(engine="streaming")
+        .item()
+    )
+    assert selected_train_rows == 0
     Path(summary_path).write_text(
         json.dumps(
             {
+                "add_reverse_complements": add_rc,
+                "realized_token_count": validation_rows * (TARGET_LENGTH + 1),
                 "region_label": region_label,
-                "species_scope": species_scope,
                 "seed": seed,
-                "validation_chrom": validation_chrom,
+                "source_rows": source_rows,
+                "species_scope": species_scope,
+                "split_strategy": "uniform_row_random_before_reverse_complement",
+                "train_original_rows": train_original_rows,
                 "train_rows": train_rows,
-                "eligible_validation_rows": candidates.height,
-                "validation_rows": result.validation.height,
-                "realized_token_count": result.realized_token_count,
+                "validation_rows": validation_rows,
             },
             indent=2,
+            sort_keys=True,
         )
         + "\n"
     )
@@ -429,17 +494,9 @@ def write_qc_files(
     per_scope_path: str | Path,
     rejections_path: str | Path,
     aggregates_path: str | Path,
-    *,
-    validation_chrom: str,
 ) -> None:
-    anchors = read_anchor_catalog(anchors_path).with_columns(
-        pl.when(pl.col("source_chrom") == validation_chrom)
-        .then(pl.lit("validation"))
-        .otherwise(pl.lit("train"))
-        .alias("split")
-    )
     write_projection_qc_tables_streaming(
-        anchors,
+        read_anchor_catalog(anchors_path),
         accepted_path,
         rejected_paths,
         read_species_manifest(str(manifest_path)),
@@ -594,6 +651,7 @@ def write_dataset_card(
     hf_repo: str,
     region_label: str,
     species_scope: str,
+    validation_seed: int,
 ) -> None:
     """Write the reviewable HF README required before any upload."""
     assert len(pipeline_commit) == 40, "dataset cards require a commit-pinned SHA"
@@ -652,28 +710,26 @@ configs:
 
 # `{hf_repo}`
 
-Human-anchored 255 bp vertebrate sequences from {source_description}. This
-draft covers the `{region_label}` region cohort with `{species_scope}` species
-scope and preserves source FASTA/2bit letter case.
+Human-anchored 255 bp vertebrate sequences from {source_description}.
+This draft covers the `{region_label}` region cohort with `{species_scope}` species scope and preserves source FASTA/2bit letter case.
 
-Non-human rows project only the central human nucleotide and extract the 255 bp
-target window centered on its unique mapped locus.
+Non-human rows project only the central human nucleotide and extract the 255 bp target window centered on its unique mapped locus.
 
 Anchor eligibility uses the pipeline's pinned phyloP conservation filter.
-Sequence case is independent of that filter: lowercase bases preserve source
-repeat masking, uppercase bases preserve source non-repeat-masked sequence, and
-conservation scores never rewrite emitted characters or case.
+Sequence case is independent of that filter: lowercase bases preserve source repeat masking, uppercase bases preserve source non-repeat-masked sequence, and conservation scores never rewrite emitted characters or case.
 
 Produced by the [commit-pinned vertebrate projection pipeline]({pipeline_url}).
 
 ## Splits
 
-- `train`: {train_rows:,} rows; no chromosome-18 source anchors.
-- `validation`: {validation_rows:,} original-orientation chromosome-18 rows
-  ({validation_rows * 256:,} tokens including BOS).
+- `train`: {train_rows:,} rows after removing the validation sample and applying the configured reverse-complement augmentation.
+- `validation`: {validation_rows:,} original-orientation rows sampled uniformly without replacement with seed {validation_seed} before augmentation ({validation_rows * 256:,} tokens including BOS).
 
-The selected target manifest contains {selected.height:,} family-deduplicated
-projection targets; human reference rows are added separately once per anchor.
+The split is row-level and does not stratify by chromosome, species, or human anchor.
+Different species projections from one human anchor may occur on opposite sides of the split.
+The reverse complement of a selected validation row is excluded from training.
+
+The selected target manifest contains {selected.height:,} family-deduplicated projection targets; human reference rows are added separately once per anchor.
 
 | Projection backend | Clade | Selected species |
 |---|---|---:|

--- a/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/pipeline_io.py
+++ b/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/pipeline_io.py
@@ -43,6 +43,7 @@ from marin_dna_vertebrate_projection.qc import (
 )
 from marin_dna_vertebrate_projection.split import (
     VALIDATION_IDENTITY_COLUMNS,
+    build_validation_composition,
     select_uniform_validation_rows,
 )
 
@@ -369,10 +370,12 @@ def write_dataset_split_files(
         f"region={region_label}, scope={species_scope}, source_rows={source_rows}"
     )
 
+    selection_salt = f"region={region_label}|species_scope={species_scope}"
     selection = select_uniform_validation_rows(
         original,
         validation_rows=validation_rows,
         seed=seed,
+        selection_salt=selection_salt,
     )
     selected_keys = selection.select(*VALIDATION_IDENTITY_COLUMNS)
     train_original = original.join(
@@ -422,24 +425,7 @@ def write_dataset_split_files(
     validation.write_parquet(validation_path)
     selection.write_csv(selection_path, separator="\t")
 
-    composition_frames: list[pl.DataFrame] = []
-    for dimension in ["source_chrom", "species", "alignment_source"]:
-        eligible = (
-            original.group_by(dimension)
-            .len(name="eligible_rows")
-            .collect(engine="streaming")
-        )
-        selected = validation.group_by(dimension).len(name="selected_rows")
-        composition_frames.append(
-            eligible.join(selected, on=dimension, how="left")
-            .with_columns(
-                pl.col("selected_rows").fill_null(0),
-                pl.lit(dimension).alias("dimension"),
-                pl.col(dimension).cast(pl.String).alias("value"),
-            )
-            .select("dimension", "value", "eligible_rows", "selected_rows")
-        )
-    pl.concat(composition_frames).sort("dimension", "value").write_csv(
+    build_validation_composition(original, validation).write_csv(
         composition_path,
         separator="\t",
     )
@@ -471,6 +457,7 @@ def write_dataset_split_files(
                 "realized_token_count": validation_rows * (TARGET_LENGTH + 1),
                 "region_label": region_label,
                 "seed": seed,
+                "selection_salt": selection_salt,
                 "source_rows": source_rows,
                 "species_scope": species_scope,
                 "split_strategy": "uniform_row_random_before_reverse_complement",

--- a/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/publication.py
+++ b/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/publication.py
@@ -207,6 +207,9 @@ def validate_artifacts(
         )
         assert summary["selection_salt"] == selection_salt
         assert int(summary["validation_rows"]) == validation_rows
+        assert int(summary["realized_token_count"]) == validation_rows * (
+            TARGET_LENGTH + 1
+        )
         assert int(summary["train_rows"]) == source_rows["train"]
         assert int(summary["train_original_rows"]) + validation_rows == int(
             summary["source_rows"]

--- a/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/publication.py
+++ b/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/publication.py
@@ -18,6 +18,10 @@ from huggingface_hub.errors import RepositoryNotFoundError
 from huggingface_hub.hf_api import DatasetInfo
 
 from marin_dna_vertebrate_projection.contract import TARGET_LENGTH
+from marin_dna_vertebrate_projection.split import (
+    VALIDATION_IDENTITY_COLUMNS,
+    select_uniform_validation_rows,
+)
 
 
 @dataclass(frozen=True)
@@ -37,24 +41,20 @@ def _validate_record(
     *,
     expected_columns: frozenset[str],
     split: str,
-    validation_chrom: str,
 ) -> None:
     record = json.loads(raw)
     assert set(record) == expected_columns
     assert isinstance(record["sequence"], str)
     assert len(record["sequence"]) == TARGET_LENGTH
     assert record["augmentation"] in {"+", "-"}
-    if split == "train":
-        assert record["source_chrom"] != validation_chrom
-    else:
-        assert record["source_chrom"] == validation_chrom
+    if split == "validation":
         assert record["augmentation"] == "+"
 
 
 def _validate_shard(
-    task: tuple[Path, str, str, int, frozenset[str], str],
+    task: tuple[Path, str, str, int, frozenset[str]],
 ) -> ShardResult:
-    path, cohort, split, index, columns, validation_chrom = task
+    path, cohort, split, index, columns = task
     digest = hashlib.sha256()
     decompressor = zstd.ZstdDecompressor().decompressobj()
     first_line: bytes | None = None
@@ -89,7 +89,6 @@ def _validate_shard(
             record,
             expected_columns=columns,
             split=split,
-            validation_chrom=validation_chrom,
         )
     return ShardResult(
         cohort=cohort,
@@ -135,12 +134,18 @@ def validate_artifacts(
         ]
     )
     validation_shards = int(config["publication_validation_shards"])
-    validation_chrom = str(config["validation_chrom"])
+    validation_rows = int(
+        config["smoke_validation_rows"]
+        if tier == "smoke"
+        else config["validation_rows"]
+    )
+    validation_seed = int(config["validation_seed"])
+    add_reverse_complements = bool(config["add_rc"])
     assert len(cohorts) == len(set(cohorts))
     assert train_shards > 0 and validation_shards > 0
 
     expected_files: set[Path] = set()
-    tasks: list[tuple[Path, str, str, int, frozenset[str], str]] = []
+    tasks: list[tuple[Path, str, str, int, frozenset[str]]] = []
     cohort_metadata: dict[str, dict[str, object]] = {}
     forbidden_card_text = [
         "bolinas-dna",
@@ -148,6 +153,7 @@ def validate_artifacts(
         "0.01",
         "train.parquet",
         "validation.parquet",
+        "chromosome-18",
     ]
     for cohort in cohorts:
         card = artifact_root / cohort / "README.md"
@@ -161,27 +167,131 @@ def validate_artifacts(
         for forbidden in forbidden_card_text:
             assert forbidden not in card_text
 
-        train_source = source_root / cohort / "train.parquet"
-        validation_source = source_root / cohort / "validation.parquet"
+        cohort_root = source_root / cohort
+        train_source = cohort_root / "train.parquet"
+        validation_source = cohort_root / "validation.parquet"
         train_schema = pl.read_parquet_schema(train_source)
         assert train_schema == pl.read_parquet_schema(validation_source)
-        assert {"sequence", "augmentation", "source_chrom"} <= set(train_schema)
+        assert {
+            "sequence",
+            "augmentation",
+            *VALIDATION_IDENTITY_COLUMNS,
+        } <= set(train_schema)
         columns = frozenset(train_schema)
         source_rows = {
             split: int(
-                pl.scan_parquet(source_root / cohort / f"{split}.parquet")
+                pl.scan_parquet(cohort_root / f"{split}.parquet")
                 .select(pl.len())
                 .collect(engine="streaming")
                 .item()
             )
             for split in ["train", "validation"]
         }
-        assert source_rows["train"] > 0 and source_rows["validation"] > 0
+        assert source_rows["train"] > 0
+        assert source_rows["validation"] == validation_rows
+
+        summary = json.loads((cohort_root / "split_summary.json").read_text())
+        assert summary["split_strategy"] == (
+            "uniform_row_random_before_reverse_complement"
+        )
+        assert int(summary["seed"]) == validation_seed
+        assert int(summary["validation_rows"]) == validation_rows
+        assert int(summary["train_rows"]) == source_rows["train"]
+        assert int(summary["train_original_rows"]) + validation_rows == int(
+            summary["source_rows"]
+        )
+        assert bool(summary["add_reverse_complements"]) == add_reverse_complements
+
+        selection = pl.read_csv(
+            cohort_root / "validation_selection.tsv",
+            separator="\t",
+        )
+        assert selection.height == validation_rows
+        assert selection["row_id"].n_unique() == validation_rows
+        reconstructed_originals = pl.concat(
+            [
+                pl.scan_parquet(train_source)
+                .filter(pl.col("augmentation") == "+")
+                .drop("augmentation"),
+                pl.scan_parquet(validation_source).drop("augmentation"),
+            ],
+            how="vertical",
+        )
+        expected_selection = select_uniform_validation_rows(
+            reconstructed_originals,
+            validation_rows=validation_rows,
+            seed=validation_seed,
+        )
+        assert selection.columns == expected_selection.columns
+        assert selection.to_dicts() == expected_selection.to_dicts()
+        selected_keys = selection.select(*VALIDATION_IDENTITY_COLUMNS).lazy()
+        validation_matches = int(
+            pl.scan_parquet(validation_source)
+            .join(
+                selected_keys,
+                on=list(VALIDATION_IDENTITY_COLUMNS),
+                how="semi",
+            )
+            .select(pl.len())
+            .collect(engine="streaming")
+            .item()
+        )
+        train_matches = int(
+            pl.scan_parquet(train_source)
+            .join(
+                selected_keys,
+                on=list(VALIDATION_IDENTITY_COLUMNS),
+                how="semi",
+            )
+            .select(pl.len())
+            .collect(engine="streaming")
+            .item()
+        )
+        assert validation_matches == validation_rows
+        assert train_matches == 0
+
+        validation_augmentations = set(
+            pl.scan_parquet(validation_source)
+            .select("augmentation")
+            .unique()
+            .collect(engine="streaming")["augmentation"]
+            .to_list()
+        )
+        assert validation_augmentations == {"+"}
+        train_augmentation_counts = dict(
+            pl.scan_parquet(train_source)
+            .group_by("augmentation")
+            .len()
+            .collect(engine="streaming")
+            .iter_rows()
+        )
+        train_original_rows = int(summary["train_original_rows"])
+        expected_augmentation_counts = (
+            {"+": train_original_rows, "-": train_original_rows}
+            if add_reverse_complements
+            else {"+": train_original_rows}
+        )
+        assert train_augmentation_counts == expected_augmentation_counts
+
+        composition = pl.read_csv(
+            cohort_root / "validation_composition.tsv",
+            separator="\t",
+        )
+        assert set(composition["dimension"].to_list()) == {
+            "alignment_source",
+            "source_chrom",
+            "species",
+        }
+        for _dimension, group in composition.group_by("dimension"):
+            assert int(group["eligible_rows"].sum()) == int(summary["source_rows"])
+            assert int(group["selected_rows"].sum()) == validation_rows
+
         cohort_metadata[cohort] = {
             "source_rows": source_rows,
             "schema": {name: str(dtype) for name, dtype in train_schema.items()},
             "card_bytes": len(card_bytes),
             "card_sha256": hashlib.sha256(card_bytes).hexdigest(),
+            "split_summary": summary,
         }
         for split, count in [
             ("train", train_shards),
@@ -199,7 +309,6 @@ def validate_artifacts(
                         split,
                         index,
                         columns,
-                        validation_chrom,
                     )
                 )
 
@@ -241,13 +350,16 @@ def validate_artifacts(
             "schema": metadata["schema"],
             "card_bytes": metadata["card_bytes"],
             "card_sha256": metadata["card_sha256"],
+            "split_summary": metadata["split_summary"],
             "splits": split_manifests,
         }
     manifest: dict[str, object] = {
         "pipeline_commit": pipeline_commit,
         "config_sha256": config_sha256,
         "artifact_format": "JSONL.zst",
-        "validation_chrom": validation_chrom,
+        "split_strategy": "uniform_row_random_before_reverse_complement",
+        "validation_rows": validation_rows,
+        "validation_seed": validation_seed,
         "target_length": TARGET_LENGTH,
         "cohorts": manifest_cohorts,
     }

--- a/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/publication.py
+++ b/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/publication.py
@@ -20,6 +20,7 @@ from huggingface_hub.hf_api import DatasetInfo
 from marin_dna_vertebrate_projection.contract import TARGET_LENGTH
 from marin_dna_vertebrate_projection.split import (
     VALIDATION_IDENTITY_COLUMNS,
+    build_validation_composition,
     select_uniform_validation_rows,
 )
 
@@ -195,6 +196,16 @@ def validate_artifacts(
             "uniform_row_random_before_reverse_complement"
         )
         assert int(summary["seed"]) == validation_seed
+        expected_region_label = "cds" if cohort == "cds_mammals_only" else cohort
+        expected_species_scope = (
+            "mammals_only" if cohort == "cds_mammals_only" else "all"
+        )
+        assert summary["region_label"] == expected_region_label
+        assert summary["species_scope"] == expected_species_scope
+        selection_salt = (
+            f"region={expected_region_label}|species_scope={expected_species_scope}"
+        )
+        assert summary["selection_salt"] == selection_salt
         assert int(summary["validation_rows"]) == validation_rows
         assert int(summary["train_rows"]) == source_rows["train"]
         assert int(summary["train_original_rows"]) + validation_rows == int(
@@ -221,6 +232,7 @@ def validate_artifacts(
             reconstructed_originals,
             validation_rows=validation_rows,
             seed=validation_seed,
+            selection_salt=selection_salt,
         )
         assert selection.columns == expected_selection.columns
         assert selection.to_dicts() == expected_selection.to_dicts()
@@ -277,14 +289,12 @@ def validate_artifacts(
             cohort_root / "validation_composition.tsv",
             separator="\t",
         )
-        assert set(composition["dimension"].to_list()) == {
-            "alignment_source",
-            "source_chrom",
-            "species",
-        }
-        for _dimension, group in composition.group_by("dimension"):
-            assert int(group["eligible_rows"].sum()) == int(summary["source_rows"])
-            assert int(group["selected_rows"].sum()) == validation_rows
+        expected_composition = build_validation_composition(
+            reconstructed_originals,
+            pl.scan_parquet(validation_source),
+        )
+        assert composition.columns == expected_composition.columns
+        assert composition.to_dicts() == expected_composition.to_dicts()
 
         cohort_metadata[cohort] = {
             "source_rows": source_rows,

--- a/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/qc.py
+++ b/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/qc.py
@@ -49,7 +49,6 @@ def build_projection_qc_tables(
         "source_start",
         "source_end",
         "region_label",
-        "split",
     }
     missing = required_anchors - set(anchors.columns)
     assert not missing, f"QC anchors missing columns: {sorted(missing)}"
@@ -134,7 +133,6 @@ def build_projection_qc_tables(
                 {
                     "query_name": query_name,
                     "region_label": str(anchor["region_label"]),
-                    "split": str(anchor["split"]),
                     "rejection_reason": reason,
                     "count": count,
                 }
@@ -152,7 +150,6 @@ def build_projection_qc_tables(
                 {
                     "query_name": query_name,
                     "region_label": str(anchor["region_label"]),
-                    "split": str(anchor["split"]),
                     "backend": backend,
                     "clade": clade,
                     "requested_species": requested,
@@ -167,7 +164,6 @@ def build_projection_qc_tables(
     rejection_schema = {
         "query_name": pl.String,
         "region_label": pl.String,
-        "split": pl.String,
         "rejection_reason": pl.String,
         "count": pl.Int64,
     }
@@ -177,7 +173,7 @@ def build_projection_qc_tables(
         else pl.DataFrame(schema=rejection_schema)
     )
     aggregates = (
-        per_anchor_scope.group_by("region_label", "split", "backend", "clade")
+        per_anchor_scope.group_by("region_label", "backend", "clade")
         .agg(
             n_anchors=pl.len(),
             mean_recovered_species=pl.col("recovered_species").mean(),
@@ -189,7 +185,7 @@ def build_projection_qc_tables(
             mean_recovered_fraction=pl.col("recovered_fraction").mean(),
             fraction_anchors_reaching_clade=pl.col("reached_clade").mean(),
         )
-        .sort("region_label", "split", "backend", "clade")
+        .sort("region_label", "backend", "clade")
     )
     return ProjectionQcTables(
         per_anchor=per_anchor,
@@ -221,7 +217,6 @@ def write_projection_qc_tables_streaming(
         "source_start",
         "source_end",
         "region_label",
-        "split",
     ]
     missing = set(required_anchors) - set(anchors.columns)
     assert not missing, f"QC anchors missing columns: {sorted(missing)}"
@@ -321,7 +316,7 @@ def write_projection_qc_tables_streaming(
     Path(per_anchor_path).parent.mkdir(parents=True, exist_ok=True)
     per_anchor.sink_parquet(per_anchor_path)
 
-    anchor_scope_base = anchors.select("query_name", "region_label", "split").lazy()
+    anchor_scope_base = anchors.select("query_name", "region_label").lazy()
     scopes = targets.group_by("backend", "clade").len(name="requested_species")
     scope_frames: list[pl.LazyFrame] = []
     for scope in scopes.sort("backend", "clade").to_dicts():
@@ -357,7 +352,7 @@ def write_projection_qc_tables_streaming(
     Path(per_scope_path).parent.mkdir(parents=True, exist_ok=True)
     per_scope.sink_parquet(per_scope_path)
 
-    anchor_labels = anchors.select("query_name", "region_label", "split").lazy()
+    anchor_labels = anchors.select("query_name", "region_label").lazy()
     explicit_rejections = (
         rejected.group_by("query_name", "rejection_reason")
         .agg(pl.len().cast(pl.Int64).alias("count"))
@@ -365,7 +360,6 @@ def write_projection_qc_tables_streaming(
         .select(
             "query_name",
             "region_label",
-            "split",
             "rejection_reason",
             "count",
         )
@@ -376,7 +370,6 @@ def write_projection_qc_tables_streaming(
         .select(
             "query_name",
             "region_label",
-            "split",
             pl.lit("no_mapping").alias("rejection_reason"),
             pl.col("no_mapping_count").alias("count"),
         )
@@ -389,7 +382,7 @@ def write_projection_qc_tables_streaming(
     Path(aggregates_path).parent.mkdir(parents=True, exist_ok=True)
     (
         pl.scan_parquet(per_scope_path)
-        .group_by("region_label", "split", "backend", "clade")
+        .group_by("region_label", "backend", "clade")
         .agg(
             n_anchors=pl.len(),
             mean_recovered_species=pl.col("recovered_species").mean(),
@@ -401,6 +394,6 @@ def write_projection_qc_tables_streaming(
             mean_recovered_fraction=pl.col("recovered_fraction").mean(),
             fraction_anchors_reaching_clade=pl.col("reached_clade").mean(),
         )
-        .sort("region_label", "split", "backend", "clade")
+        .sort("region_label", "backend", "clade")
         .sink_parquet(aggregates_path)
     )

--- a/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/split.py
+++ b/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/split.py
@@ -12,6 +12,11 @@ VALIDATION_IDENTITY_COLUMNS = (
     "species",
     "alignment_source",
 )
+VALIDATION_COMPOSITION_DIMENSIONS = (
+    "source_chrom",
+    "species",
+    "alignment_source",
+)
 _SELECTION_HASH = "selection_hash"
 
 
@@ -31,9 +36,15 @@ def validation_identity_expression() -> pl.Expr:
     )
 
 
-def validation_selection_hash(seed: int) -> pl.Expr:
+def validation_selection_hash(seed: int, selection_salt: str) -> pl.Expr:
     """Return the seeded uniform hash used to rank original-orientation rows."""
-    return validation_identity_expression().hash(seed=seed).alias(_SELECTION_HASH)
+    return (
+        pl.concat_str(
+            pl.lit(selection_salt), validation_identity_expression(), separator="\t"
+        )
+        .hash(seed=seed)
+        .alias(_SELECTION_HASH)
+    )
 
 
 def select_uniform_validation_rows(
@@ -41,6 +52,7 @@ def select_uniform_validation_rows(
     *,
     validation_rows: int,
     seed: int,
+    selection_salt: str,
 ) -> pl.DataFrame:
     """Select an order-invariant uniform sample without replacement.
 
@@ -49,6 +61,7 @@ def select_uniform_validation_rows(
     orientation rows because validation selection precedes augmentation.
     """
     assert validation_rows > 0
+    assert selection_salt
     lazy = rows.lazy() if isinstance(rows, pl.DataFrame) else rows
     schema = lazy.collect_schema()
     missing = set(VALIDATION_IDENTITY_COLUMNS) - set(schema.names())
@@ -60,7 +73,7 @@ def select_uniform_validation_rows(
     selected = (
         lazy.select(
             *VALIDATION_IDENTITY_COLUMNS,
-            validation_selection_hash(seed),
+            validation_selection_hash(seed, selection_salt),
         )
         .bottom_k(
             validation_rows,
@@ -85,17 +98,61 @@ def select_uniform_validation_rows(
             ),
             pl.Series(
                 "selection_digest",
-                [_stable_digest(f"{seed}\t{identity}") for identity in identities],
+                [
+                    _stable_digest(f"{seed}\t{selection_salt}\t{identity}")
+                    for identity in identities
+                ],
             ),
             pl.lit(seed, dtype=pl.Int64).alias("seed"),
+            pl.lit(selection_salt).alias("selection_salt"),
         )
         .with_row_index("selection_rank", offset=1)
         .select(
             "row_id",
             *VALIDATION_IDENTITY_COLUMNS,
             "seed",
+            "selection_salt",
             "selection_rank",
             _SELECTION_HASH,
             "selection_digest",
         )
     )
+
+
+def build_validation_composition(
+    eligible_rows: pl.DataFrame | pl.LazyFrame,
+    selected_rows: pl.DataFrame | pl.LazyFrame,
+) -> pl.DataFrame:
+    """Summarize exact eligible and selected counts for split auditing."""
+    eligible_lazy = (
+        eligible_rows.lazy()
+        if isinstance(eligible_rows, pl.DataFrame)
+        else eligible_rows
+    )
+    selected_lazy = (
+        selected_rows.lazy()
+        if isinstance(selected_rows, pl.DataFrame)
+        else selected_rows
+    )
+    frames: list[pl.DataFrame] = []
+    for dimension in VALIDATION_COMPOSITION_DIMENSIONS:
+        eligible_counts = (
+            eligible_lazy.group_by(dimension)
+            .len(name="eligible_rows")
+            .collect(engine="streaming")
+        )
+        selected_counts = (
+            selected_lazy.group_by(dimension)
+            .len(name="selected_rows")
+            .collect(engine="streaming")
+        )
+        frames.append(
+            eligible_counts.join(selected_counts, on=dimension, how="left")
+            .with_columns(
+                pl.col("selected_rows").fill_null(0),
+                pl.lit(dimension).alias("dimension"),
+                pl.col(dimension).cast(pl.String).alias("value"),
+            )
+            .select("dimension", "value", "eligible_rows", "selected_rows")
+        )
+    return pl.concat(frames).sort("dimension", "value")

--- a/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/split.py
+++ b/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/split.py
@@ -1,199 +1,101 @@
-"""Deterministic chromosome-18 train/validation split construction."""
-
-from __future__ import annotations
+"""Deterministic uniform row-random validation selection."""
 
 import hashlib
-from dataclasses import dataclass
 
 import polars as pl
 
+VALIDATION_IDENTITY_COLUMNS = (
+    "query_name",
+    "source_chrom",
+    "source_start",
+    "source_end",
+    "species",
+    "alignment_source",
+)
+_SELECTION_HASH = "selection_hash"
 
-@dataclass(frozen=True)
-class DatasetSplits:
-    """Split frames plus persisted validation selection metadata."""
 
-    train: pl.DataFrame
-    validation: pl.DataFrame
-    selection_manifest: pl.DataFrame
-    species_counts: pl.DataFrame
-    realized_token_count: int
+def _identity_value(row: dict[str, object]) -> str:
+    return "\t".join(str(row[column]) for column in VALIDATION_IDENTITY_COLUMNS)
 
 
 def _stable_digest(value: str) -> str:
     return hashlib.sha256(value.encode()).hexdigest()
 
 
-def add_stable_row_ids(rows: pl.DataFrame) -> pl.DataFrame:
-    """Add reproducible row IDs from biological identity fields."""
-    required = {
-        "query_name",
-        "source_chrom",
-        "source_start",
-        "source_end",
-        "species",
-        "alignment_source",
-    }
-    missing = required - set(rows.columns)
-    assert not missing, f"rows missing ID columns: {sorted(missing)}"
-    with_augmentation = (
-        rows
-        if "augmentation" in rows.columns
-        else rows.with_columns(pl.lit("+").alias("augmentation"))
+def validation_identity_expression() -> pl.Expr:
+    """Return the stable biological row identity used at the split boundary."""
+    return pl.concat_str(
+        [pl.col(column).cast(pl.String) for column in VALIDATION_IDENTITY_COLUMNS],
+        separator="\t",
     )
-    identity = [
-        "query_name",
-        "source_chrom",
-        "source_start",
-        "source_end",
-        "species",
-        "alignment_source",
-        "augmentation",
-    ]
-    ids = [
-        _stable_digest("\t".join(str(row[column]) for column in identity))[:24]
-        for row in with_augmentation.select(identity).to_dicts()
-    ]
-    result = with_augmentation.with_columns(pl.Series("row_id", ids))
-    assert result["row_id"].n_unique() == result.height, (
+
+
+def validation_selection_hash(seed: int) -> pl.Expr:
+    """Return the seeded uniform hash used to rank original-orientation rows."""
+    return validation_identity_expression().hash(seed=seed).alias(_SELECTION_HASH)
+
+
+def select_uniform_validation_rows(
+    rows: pl.DataFrame | pl.LazyFrame,
+    *,
+    validation_rows: int,
+    seed: int,
+) -> pl.DataFrame:
+    """Select an order-invariant uniform sample without replacement.
+
+    Selection is row-level. Species projections from the same human anchor may
+    fall on opposite sides of the split. The input must contain only original-
+    orientation rows because validation selection precedes augmentation.
+    """
+    assert validation_rows > 0
+    lazy = rows.lazy() if isinstance(rows, pl.DataFrame) else rows
+    schema = lazy.collect_schema()
+    missing = set(VALIDATION_IDENTITY_COLUMNS) - set(schema.names())
+    assert not missing, f"dataset rows missing identity columns: {sorted(missing)}"
+    assert "augmentation" not in schema, (
+        "validation selection must precede reverse-complement augmentation"
+    )
+
+    selected = (
+        lazy.select(
+            *VALIDATION_IDENTITY_COLUMNS,
+            validation_selection_hash(seed),
+        )
+        .bottom_k(
+            validation_rows,
+            by=[_SELECTION_HASH, *VALIDATION_IDENTITY_COLUMNS],
+        )
+        .collect(engine="streaming")
+        .sort(_SELECTION_HASH, *VALIDATION_IDENTITY_COLUMNS)
+    )
+    assert selected.height == validation_rows, (
+        f"validation requires {validation_rows} rows, found {selected.height}"
+    )
+    assert selected.select(*VALIDATION_IDENTITY_COLUMNS).is_unique().all(), (
         "biological row identity is not unique"
     )
-    return result
 
-
-def _allocate_species_quotas(
-    availability: dict[str, int], max_rows: int
-) -> dict[str, int]:
-    """Water-fill quotas so unconstrained species differ by at most one row."""
-    assert max_rows >= 0
-    if not availability:
-        return {}
-    species = sorted(availability)
-    assert all(availability[name] > 0 for name in species)
-    assert max_rows >= len(species), (
-        f"validation cap {max_rows} cannot represent {len(species)} species"
-    )
-    target = min(max_rows, sum(availability.values()))
-    quotas = {name: 1 for name in species}
-    remaining = target - len(species)
-    while remaining > 0:
-        eligible = [name for name in species if quotas[name] < availability[name]]
-        assert eligible, "quota allocation exhausted availability too early"
-        for name in eligible:
-            if remaining == 0:
-                break
-            quotas[name] += 1
-            remaining -= 1
-    return quotas
-
-
-def assign_train_validation_splits(
-    rows: pl.DataFrame,
-    *,
-    validation_chrom: str = "chr18",
-    max_validation_rows: int = 16_384,
-    seed: int = 42,
-    bases_per_sequence: int = 255,
-) -> DatasetSplits:
-    """Apply the source-chromosome split and stratified validation cap.
-
-    All chromosome-18 rows leave training before sampling.  Only original
-    orientation rows (``augmentation == '+'``) are eligible for validation;
-    unsampled chromosome-18 rows and their reverse complements are discarded.
-    """
-    assert max_validation_rows > 0
-    assert bases_per_sequence > 0
-    required = {"query_name", "source_chrom", "species"}
-    missing = required - set(rows.columns)
-    assert not missing, f"dataset rows missing columns: {sorted(missing)}"
-    with_ids = rows if "row_id" in rows.columns else add_stable_row_ids(rows)
-    if "augmentation" not in with_ids.columns:
-        with_ids = with_ids.with_columns(pl.lit("+").alias("augmentation"))
-    assert with_ids["row_id"].n_unique() == with_ids.height
-    assert set(with_ids["augmentation"].unique().to_list()) <= {"+", "-"}
-
-    train = with_ids.filter(pl.col("source_chrom") != validation_chrom)
-    candidates = with_ids.filter(
-        (pl.col("source_chrom") == validation_chrom) & (pl.col("augmentation") == "+")
-    )
-    availability = {
-        str(species): int(count)
-        for species, count in candidates.group_by("species").len().iter_rows()
-    }
-    quotas = _allocate_species_quotas(availability, max_validation_rows)
-
-    selected_rows: list[dict[str, object]] = []
-    selection_rows: list[dict[str, object]] = []
-    for species in sorted(quotas):
-        species_rows = candidates.filter(pl.col("species") == species).to_dicts()
-        ranked = sorted(
-            species_rows,
-            key=lambda row: _stable_digest(f"{seed}\t{row['row_id']}"),
+    identities = [_identity_value(row) for row in selected.to_dicts()]
+    return (
+        selected.with_columns(
+            pl.Series(
+                "row_id",
+                [_stable_digest(identity)[:24] for identity in identities],
+            ),
+            pl.Series(
+                "selection_digest",
+                [_stable_digest(f"{seed}\t{identity}") for identity in identities],
+            ),
+            pl.lit(seed, dtype=pl.Int64).alias("seed"),
         )
-        for rank, row in enumerate(ranked[: quotas[species]], start=1):
-            digest = _stable_digest(f"{seed}\t{row['row_id']}")
-            selected_rows.append(row)
-            selection_rows.append(
-                {
-                    "row_id": str(row["row_id"]),
-                    "query_name": str(row["query_name"]),
-                    "species": species,
-                    "seed": seed,
-                    "species_rank": rank,
-                    "selection_digest": digest,
-                }
-            )
-
-    validation = (
-        pl.DataFrame(selected_rows, schema=with_ids.schema)
-        if selected_rows
-        else pl.DataFrame(schema=with_ids.schema)
-    )
-    selection_schema = {
-        "row_id": pl.String,
-        "query_name": pl.String,
-        "species": pl.String,
-        "seed": pl.Int64,
-        "species_rank": pl.Int64,
-        "selection_digest": pl.String,
-    }
-    selection_manifest = (
-        pl.DataFrame(selection_rows, schema=selection_schema)
-        if selection_rows
-        else pl.DataFrame(schema=selection_schema)
-    )
-    species_counts = pl.DataFrame(
-        [
-            {
-                "species": species,
-                "eligible_rows": availability[species],
-                "selected_rows": quotas[species],
-            }
-            for species in sorted(quotas)
-        ],
-        schema={
-            "species": pl.String,
-            "eligible_rows": pl.Int64,
-            "selected_rows": pl.Int64,
-        },
-    )
-
-    assert (train["source_chrom"] != validation_chrom).all()
-    assert (validation["source_chrom"] == validation_chrom).all()
-    assert (validation["augmentation"] == "+").all()
-    assert set(train["row_id"].to_list()).isdisjoint(validation["row_id"].to_list())
-    assert set(train["query_name"].to_list()).isdisjoint(
-        validation["query_name"].to_list()
-    )
-    assert set(validation["species"].to_list()) == set(availability)
-    assert validation.height == min(candidates.height, max_validation_rows)
-    if candidates.height >= max_validation_rows:
-        assert validation.height == max_validation_rows
-
-    realized_token_count = validation.height * (bases_per_sequence + 1)
-    return DatasetSplits(
-        train=train.sort("row_id"),
-        validation=validation.sort("row_id"),
-        selection_manifest=selection_manifest.sort("species", "species_rank"),
-        species_counts=species_counts,
-        realized_token_count=realized_token_count,
+        .with_row_index("selection_rank", offset=1)
+        .select(
+            "row_id",
+            *VALIDATION_IDENTITY_COLUMNS,
+            "seed",
+            "selection_rank",
+            _SELECTION_HASH,
+            "selection_digest",
+        )
     )

--- a/snakemake/vertebrate_projection_dataset/tests/test_pipeline_io.py
+++ b/snakemake/vertebrate_projection_dataset/tests/test_pipeline_io.py
@@ -241,6 +241,7 @@ def test_dataset_card_distinguishes_anchor_filter_from_repeat_mask_case(
         hf_repo="marin-dna/vertebrate-v1-cds",
         region_label="cds",
         species_scope="all",
+        validation_seed=42,
     )
 
     text = " ".join(card.read_text().split())
@@ -257,4 +258,7 @@ def test_dataset_card_distinguishes_anchor_filter_from_repeat_mask_case(
     assert "Sequence case is independent of that filter" in text
     assert "project only the central human nucleotide" in text
     assert "conservation scores never rewrite emitted characters or case" in text
+    assert "sampled uniformly without replacement with seed 42" in text
+    assert "does not stratify by chromosome, species, or human anchor" in text
+    assert "reverse complement of a selected validation row is excluded" in text
     assert "loss weight" not in text

--- a/snakemake/vertebrate_projection_dataset/tests/test_publication.py
+++ b/snakemake/vertebrate_projection_dataset/tests/test_publication.py
@@ -119,6 +119,33 @@ def test_validate_artifacts_reconciles_rows_and_rejects_sidecars(
         )
 
 
+def test_validate_artifacts_rejects_tampered_composition(tmp_path: Path) -> None:
+    artifact_dir, source_dir, config_path = _fixture(tmp_path)
+    composition_path = source_dir / "all/validation_composition.tsv"
+    composition = pl.read_csv(composition_path, separator="\t")
+    rows = composition.to_dicts()
+    chrom_indices = [
+        index for index, row in enumerate(rows) if row["dimension"] == "source_chrom"
+    ]
+    assert len(chrom_indices) == 2
+    first, second = chrom_indices
+    rows[first]["eligible_rows"] = int(rows[first]["eligible_rows"]) + 1
+    rows[second]["eligible_rows"] = int(rows[second]["eligible_rows"]) - 1
+    pl.DataFrame(rows, schema=composition.schema).write_csv(
+        composition_path, separator="\t"
+    )
+    with pytest.raises(AssertionError):
+        publication.validate_artifacts(
+            artifact_dir,
+            source_dir,
+            tmp_path / "manifest.json",
+            config_path=config_path,
+            pipeline_commit=PIPELINE_COMMIT,
+            config_sha256=CONFIG_SHA256,
+            workers=1,
+        )
+
+
 def test_upload_rejects_unexpected_remote_file_before_subprocess(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/snakemake/vertebrate_projection_dataset/tests/test_publication.py
+++ b/snakemake/vertebrate_projection_dataset/tests/test_publication.py
@@ -8,18 +8,25 @@ import polars as pl
 import pytest
 import zstandard as zstd
 from marin_dna_vertebrate_projection import publication
+from marin_dna_vertebrate_projection.pipeline_io import write_dataset_split_files
 
 PIPELINE_COMMIT = "a" * 40
 CONFIG_SHA256 = "b" * 64
 
 
-def _frame(source_chrom: str, rows: int) -> pl.DataFrame:
+def _frame(rows: int) -> pl.DataFrame:
     return pl.DataFrame(
         {
             "query_name": [f"anchor_{index}" for index in range(rows)],
-            "source_chrom": [source_chrom] * rows,
+            "source_chrom": [
+                "chr1" if index % 2 == 0 else "chr18" for index in range(rows)
+            ],
+            "source_start": [index * 255 for index in range(rows)],
+            "source_end": [(index + 1) * 255 for index in range(rows)],
+            "species": ["Homo sapiens"] * rows,
+            "alignment_source": ["human_reference"] * rows,
+            "region_label": ["cds"] * rows,
             "sequence": ["ACgt" + "A" * 251] * rows,
-            "augmentation": ["+"] * rows,
         }
     )
 
@@ -40,13 +47,28 @@ def _fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
         "publication_train_shards: 2\n"
         "publication_smoke_train_shards: 1\n"
         "publication_validation_shards: 1\n"
-        "validation_chrom: chr18\n"
+        "validation_rows: 2\n"
+        "smoke_validation_rows: 1\n"
+        "validation_seed: 42\n"
+        "add_rc: false\n"
     )
-    train = _frame("chr1", 5)
-    validation = _frame("chr18", 2)
     (source_dir / "all").mkdir(parents=True)
-    train.write_parquet(source_dir / "all/train.parquet")
-    validation.write_parquet(source_dir / "all/validation.parquet")
+    combined = source_dir / "combined.parquet"
+    _frame(7).write_parquet(combined)
+    write_dataset_split_files(
+        combined,
+        source_dir / "all/train.parquet",
+        source_dir / "all/validation.parquet",
+        source_dir / "all/validation_selection.tsv",
+        source_dir / "all/validation_composition.tsv",
+        source_dir / "all/split_summary.json",
+        region_label="all",
+        add_rc=False,
+        validation_rows=2,
+        seed=42,
+    )
+    train = pl.read_parquet(source_dir / "all/train.parquet")
+    validation = pl.read_parquet(source_dir / "all/validation.parquet")
     card = artifact_dir / "all/README.md"
     card.parent.mkdir(parents=True)
     card.write_text(

--- a/snakemake/vertebrate_projection_dataset/tests/test_publication.py
+++ b/snakemake/vertebrate_projection_dataset/tests/test_publication.py
@@ -146,6 +146,26 @@ def test_validate_artifacts_rejects_tampered_composition(tmp_path: Path) -> None
         )
 
 
+def test_validate_artifacts_rejects_tampered_realized_token_count(
+    tmp_path: Path,
+) -> None:
+    artifact_dir, source_dir, config_path = _fixture(tmp_path)
+    summary_path = source_dir / "all/split_summary.json"
+    summary = json.loads(summary_path.read_text())
+    summary["realized_token_count"] = int(summary["realized_token_count"]) + 1
+    summary_path.write_text(json.dumps(summary))
+    with pytest.raises(AssertionError):
+        publication.validate_artifacts(
+            artifact_dir,
+            source_dir,
+            tmp_path / "manifest.json",
+            config_path=config_path,
+            pipeline_commit=PIPELINE_COMMIT,
+            config_sha256=CONFIG_SHA256,
+            workers=1,
+        )
+
+
 def test_upload_rejects_unexpected_remote_file_before_subprocess(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/snakemake/vertebrate_projection_dataset/tests/test_qc.py
+++ b/snakemake/vertebrate_projection_dataset/tests/test_qc.py
@@ -61,7 +61,6 @@ def test_qc_reports_recovery_breadth_and_missing_reasons() -> None:
             "source_start": [0, 0],
             "source_end": [255, 255],
             "region_label": ["cds", "enhancer"],
-            "split": ["train", "validation"],
         }
     )
     accepted = pl.DataFrame(
@@ -121,7 +120,6 @@ def test_streaming_qc_matches_recovery_contract(tmp_path: Path) -> None:
             "source_start": [0, 0],
             "source_end": [255, 255],
             "region_label": ["cds", "enhancer"],
-            "split": ["train", "validation"],
         }
     )
     accepted = pl.DataFrame(

--- a/snakemake/vertebrate_projection_dataset/tests/test_split.py
+++ b/snakemake/vertebrate_projection_dataset/tests/test_split.py
@@ -39,16 +39,42 @@ def _rows() -> pl.DataFrame:
 
 def test_uniform_selection_is_reproducible_under_row_reordering() -> None:
     rows = _rows()
-    forward = select_uniform_validation_rows(rows, validation_rows=8, seed=42)
+    forward = select_uniform_validation_rows(
+        rows,
+        validation_rows=8,
+        seed=42,
+        selection_salt="region=cds|species_scope=all",
+    )
     reverse = select_uniform_validation_rows(
         rows.reverse(),
         validation_rows=8,
         seed=42,
+        selection_salt="region=cds|species_scope=all",
     )
     assert forward.equals(reverse)
     assert forward.height == 8
     assert forward["row_id"].n_unique() == 8
     assert forward["selection_rank"].to_list() == list(range(1, 9))
+
+
+def test_cohort_salt_decouples_nested_cohort_samples() -> None:
+    rows = _rows()
+    combined = select_uniform_validation_rows(
+        rows,
+        validation_rows=8,
+        seed=42,
+        selection_salt="region=cds|species_scope=all",
+    )
+    mammals_only = select_uniform_validation_rows(
+        rows,
+        validation_rows=8,
+        seed=42,
+        selection_salt="region=cds|species_scope=mammals_only",
+    )
+    assert set(combined["row_id"]) != set(mammals_only["row_id"])
+    assert (
+        combined["selection_hash"].to_list() != mammals_only["selection_hash"].to_list()
+    )
 
 
 def test_uniform_selection_precedes_augmentation() -> None:
@@ -57,6 +83,7 @@ def test_uniform_selection_precedes_augmentation() -> None:
             _rows().with_columns(pl.lit("+").alias("augmentation")),
             validation_rows=8,
             seed=42,
+            selection_salt="region=cds|species_scope=all",
         )
 
 
@@ -92,6 +119,7 @@ def test_streaming_split_writes_random_schema_matched_outputs(tmp_path: Path) ->
     assert set(validation["augmentation"]) == {"+"}
     assert "row_id" not in validation.columns
     assert selection.height == 8
+    assert set(selection["selection_salt"]) == {"region=cds|species_scope=all"}
 
     selected_keys = set(selection.select(*VALIDATION_IDENTITY_COLUMNS).iter_rows())
     train_keys = set(train.select(*VALIDATION_IDENTITY_COLUMNS).iter_rows())
@@ -117,6 +145,7 @@ def test_streaming_split_writes_random_schema_matched_outputs(tmp_path: Path) ->
         "realized_token_count": 8 * 256,
         "region_label": "cds",
         "seed": 42,
+        "selection_salt": "region=cds|species_scope=all",
         "source_rows": 30,
         "species_scope": "all",
         "split_strategy": "uniform_row_random_before_reverse_complement",

--- a/snakemake/vertebrate_projection_dataset/tests/test_split.py
+++ b/snakemake/vertebrate_projection_dataset/tests/test_split.py
@@ -1,111 +1,72 @@
-from __future__ import annotations
-
 import json
 from pathlib import Path
 
 import polars as pl
+import pytest
 from marin_dna_vertebrate_projection.pipeline_io import (
     write_dataset_split_files,
 )
 from marin_dna_vertebrate_projection.split import (
-    add_stable_row_ids,
-    assign_train_validation_splits,
+    VALIDATION_IDENTITY_COLUMNS,
+    select_uniform_validation_rows,
 )
 
 
 def _rows() -> pl.DataFrame:
     rows: list[dict[str, object]] = []
-    for species in ["Homo sapiens", "Mus musculus", "Gallus gallus"]:
-        for index in range(3):
+    species_sources = [
+        ("Homo sapiens", "human_reference"),
+        ("Mus musculus", "zoonomia_cactus"),
+        ("Gallus gallus", "ucsc_multiz100way"),
+    ]
+    chromosomes = ["chr1", "chr18", "chr2"]
+    for index in range(10):
+        for species, alignment_source in species_sources:
             rows.append(
                 {
-                    "query_name": f"chr18_{index}",
-                    "source_chrom": "chr18",
+                    "query_name": f"anchor_{index}",
+                    "source_chrom": chromosomes[index % len(chromosomes)],
                     "source_start": index * 255,
                     "source_end": (index + 1) * 255,
                     "species": species,
-                    "alignment_source": "human_reference"
-                    if species == "Homo sapiens"
-                    else "zoonomia_cactus",
-                    "augmentation": "+",
+                    "alignment_source": alignment_source,
+                    "region_label": "cds",
                     "sequence": "A" * 255,
                 }
             )
-        rows.append(
-            {
-                "query_name": "chr18_0",
-                "source_chrom": "chr18",
-                "source_start": 0,
-                "source_end": 255,
-                "species": species,
-                "alignment_source": "human_reference"
-                if species == "Homo sapiens"
-                else "zoonomia_cactus",
-                "augmentation": "-",
-                "sequence": "T" * 255,
-            }
-        )
-        rows.append(
-            {
-                "query_name": "chr1_0",
-                "source_chrom": "chr1",
-                "source_start": 0,
-                "source_end": 255,
-                "species": species,
-                "alignment_source": "human_reference"
-                if species == "Homo sapiens"
-                else "zoonomia_cactus",
-                "augmentation": "+",
-                "sequence": "C" * 255,
-            }
-        )
     return pl.DataFrame(rows)
 
 
-def test_chr18_split_is_species_stratified_and_drops_rc_candidates() -> None:
-    result = assign_train_validation_splits(_rows(), max_validation_rows=5, seed=7)
-    assert result.train.height == 3
-    assert result.validation.height == 5
-    assert set(result.validation["species"].to_list()) == {
-        "Homo sapiens",
-        "Mus musculus",
-        "Gallus gallus",
-    }
-    assert set(result.validation["augmentation"].to_list()) == {"+"}
-    assert result.species_counts["selected_rows"].sort().to_list() == [1, 2, 2]
-    assert result.realized_token_count == 5 * 256
-    assert result.selection_manifest.height == result.validation.height
-
-
-def test_split_selection_is_reproducible_under_row_reordering() -> None:
-    rows = add_stable_row_ids(_rows())
-    forward = assign_train_validation_splits(rows, max_validation_rows=5, seed=11)
-    reverse = assign_train_validation_splits(
-        rows.reverse(), max_validation_rows=5, seed=11
+def test_uniform_selection_is_reproducible_under_row_reordering() -> None:
+    rows = _rows()
+    forward = select_uniform_validation_rows(rows, validation_rows=8, seed=42)
+    reverse = select_uniform_validation_rows(
+        rows.reverse(),
+        validation_rows=8,
+        seed=42,
     )
-    assert forward.selection_manifest.equals(reverse.selection_manifest)
+    assert forward.equals(reverse)
+    assert forward.height == 8
+    assert forward["row_id"].n_unique() == 8
+    assert forward["selection_rank"].to_list() == list(range(1, 9))
 
 
-def test_all_chr18_original_rows_are_retained_when_below_cap() -> None:
-    rows = _rows().filter(pl.col("augmentation") == "+")
-    result = assign_train_validation_splits(rows, max_validation_rows=20, seed=42)
-    assert result.validation.height == 9
-    assert result.realized_token_count == 9 * 256
+def test_uniform_selection_precedes_augmentation() -> None:
+    with pytest.raises(AssertionError, match="must precede"):
+        select_uniform_validation_rows(
+            _rows().with_columns(pl.lit("+").alias("augmentation")),
+            validation_rows=8,
+            seed=42,
+        )
 
 
-def test_streaming_split_writes_schema_matched_outputs(tmp_path: Path) -> None:
-    combined = (
-        _rows()
-        .filter(pl.col("augmentation") == "+")
-        .drop("augmentation")
-        .with_columns(pl.lit("cds").alias("region_label"))
-    )
+def test_streaming_split_writes_random_schema_matched_outputs(tmp_path: Path) -> None:
     combined_path = tmp_path / "combined.parquet"
-    combined.write_parquet(combined_path)
+    _rows().write_parquet(combined_path)
     train_path = tmp_path / "train.parquet"
     validation_path = tmp_path / "validation.parquet"
     selection_path = tmp_path / "selection.tsv"
-    counts_path = tmp_path / "counts.tsv"
+    composition_path = tmp_path / "composition.tsv"
     summary_path = tmp_path / "summary.json"
 
     write_dataset_split_files(
@@ -113,45 +74,63 @@ def test_streaming_split_writes_schema_matched_outputs(tmp_path: Path) -> None:
         train_path,
         validation_path,
         selection_path,
-        counts_path,
+        composition_path,
         summary_path,
         region_label="cds",
         add_rc=True,
-        validation_chrom="chr18",
-        max_validation_rows=5,
-        seed=7,
+        validation_rows=8,
+        seed=42,
     )
 
     train = pl.read_parquet(train_path)
     validation = pl.read_parquet(validation_path)
+    selection = pl.read_csv(selection_path, separator="\t")
     assert train.schema == validation.schema
-    assert train.height == 6
+    assert train.height == 44
     assert set(train["augmentation"]) == {"+", "-"}
-    assert validation.height == 5
+    assert validation.height == 8
     assert set(validation["augmentation"]) == {"+"}
     assert "row_id" not in validation.columns
-    assert pl.read_csv(selection_path, separator="\t").height == 5
-    assert pl.read_csv(counts_path, separator="\t").height == 3
-    assert json.loads(summary_path.read_text())["train_rows"] == 6
+    assert selection.height == 8
+
+    selected_keys = set(selection.select(*VALIDATION_IDENTITY_COLUMNS).iter_rows())
+    train_keys = set(train.select(*VALIDATION_IDENTITY_COLUMNS).iter_rows())
+    validation_keys = set(validation.select(*VALIDATION_IDENTITY_COLUMNS).iter_rows())
+    assert validation_keys == selected_keys
+    assert train_keys.isdisjoint(selected_keys)
+    assert set(train["source_chrom"]) & set(validation["source_chrom"])
+    assert set(train["query_name"]) & set(validation["query_name"])
+
+    composition = pl.read_csv(composition_path, separator="\t")
+    assert set(composition["dimension"]) == {
+        "alignment_source",
+        "source_chrom",
+        "species",
+    }
+    for _dimension, group in composition.group_by("dimension"):
+        assert group["eligible_rows"].sum() == 30
+        assert group["selected_rows"].sum() == 8
+
+    summary = json.loads(summary_path.read_text())
+    assert summary == {
+        "add_reverse_complements": True,
+        "realized_token_count": 8 * 256,
+        "region_label": "cds",
+        "seed": 42,
+        "source_rows": 30,
+        "species_scope": "all",
+        "split_strategy": "uniform_row_random_before_reverse_complement",
+        "train_original_rows": 22,
+        "train_rows": 44,
+        "validation_rows": 8,
+    }
 
 
-def test_mammals_only_scope_filters_multiz_after_region_selection(
+def test_mammals_only_scope_filters_multiz_before_random_selection(
     tmp_path: Path,
 ) -> None:
-    combined = (
-        _rows()
-        .filter(pl.col("augmentation") == "+")
-        .drop("augmentation")
-        .with_columns(
-            pl.lit("cds").alias("region_label"),
-            pl.when(pl.col("species") == "Gallus gallus")
-            .then(pl.lit("ucsc_multiz100way"))
-            .otherwise(pl.col("alignment_source"))
-            .alias("alignment_source"),
-        )
-    )
     combined_path = tmp_path / "combined.parquet"
-    combined.write_parquet(combined_path)
+    _rows().write_parquet(combined_path)
     train_path = tmp_path / "train.parquet"
     validation_path = tmp_path / "validation.parquet"
     summary_path = tmp_path / "summary.json"
@@ -161,21 +140,40 @@ def test_mammals_only_scope_filters_multiz_after_region_selection(
         train_path,
         validation_path,
         tmp_path / "selection.tsv",
-        tmp_path / "counts.tsv",
+        tmp_path / "composition.tsv",
         summary_path,
         region_label="cds",
         species_scope="mammals_only",
         add_rc=True,
-        validation_chrom="chr18",
-        max_validation_rows=4,
+        validation_rows=4,
         seed=7,
     )
 
     train = pl.read_parquet(train_path)
     validation = pl.read_parquet(validation_path)
     assert set(train["species"]) == {"Homo sapiens", "Mus musculus"}
-    assert set(validation["species"]) == {"Homo sapiens", "Mus musculus"}
+    assert set(validation["species"]) <= {"Homo sapiens", "Mus musculus"}
     assert "ucsc_multiz100way" not in set(train["alignment_source"])
     summary = json.loads(summary_path.read_text())
     assert summary["region_label"] == "cds"
     assert summary["species_scope"] == "mammals_only"
+    assert summary["source_rows"] == 20
+    assert summary["train_original_rows"] == 16
+
+
+def test_split_requires_training_rows_after_validation(tmp_path: Path) -> None:
+    combined_path = tmp_path / "combined.parquet"
+    _rows().head(3).write_parquet(combined_path)
+    with pytest.raises(AssertionError, match="nonempty training"):
+        write_dataset_split_files(
+            combined_path,
+            tmp_path / "train.parquet",
+            tmp_path / "validation.parquet",
+            tmp_path / "selection.tsv",
+            tmp_path / "composition.tsv",
+            tmp_path / "summary.json",
+            region_label="cds",
+            add_rc=True,
+            validation_rows=3,
+            seed=42,
+        )

--- a/snakemake/vertebrate_projection_dataset/tests/test_storage_integration.py
+++ b/snakemake/vertebrate_projection_dataset/tests/test_storage_integration.py
@@ -113,6 +113,13 @@ def test_hf_only_dag_closes_from_clean_storage_backed_workdir(tmp_path: Path) ->
             source = storage / base / f"datasets/{cohort}/{split}.parquet"
             source.parent.mkdir(parents=True, exist_ok=True)
             source.write_bytes(b"fixture")
+        for audit_name in [
+            "validation_selection.tsv",
+            "validation_composition.tsv",
+            "split_summary.json",
+        ]:
+            audit_path = storage / base / f"datasets/{cohort}/{audit_name}"
+            audit_path.write_text("fixture\n")
 
     output = _run_snakemake(
         workdir,

--- a/snakemake/vertebrate_projection_dataset/workflow/rules/common.smk
+++ b/snakemake/vertebrate_projection_dataset/workflow/rules/common.smk
@@ -25,6 +25,10 @@ PIPELINE_VERSION = str(config["pipeline_version"])
 HF_REPO_PREFIX = f"vertebrate-{PIPELINE_VERSION}"
 TIER = str(config["tier"])
 assert TIER in {"smoke", "full"}
+VALIDATION_ROWS = int(
+    config["smoke_validation_rows"] if TIER == "smoke" else config["validation_rows"]
+)
+assert VALIDATION_ROWS > 0
 PIPELINE_COMMIT = resolve_pipeline_commit()
 PIPELINE_CONFIG_SHA256 = hash_pipeline_config(config)
 RESULTS = (

--- a/snakemake/vertebrate_projection_dataset/workflow/rules/dataset.smk
+++ b/snakemake/vertebrate_projection_dataset/workflow/rules/dataset.smk
@@ -1,4 +1,4 @@
-"""QC tables, chromosome-18 splits, cards, and opt-in HF upload targets."""
+"""QC tables, row-random splits, cards, and opt-in HF upload targets."""
 
 from marin_dna_vertebrate_projection.pipeline_io import (
     write_dataset_card,
@@ -58,7 +58,6 @@ rule projection_qc:
             output.per_scope,
             output.rejections,
             output.aggregates,
-            validation_chrom=str(config["validation_chrom"]),
         )
 
 
@@ -97,7 +96,7 @@ rule dataset_splits:
         train=f"{RESULTS}/datasets/{{region}}/train.parquet",
         validation=f"{RESULTS}/datasets/{{region}}/validation.parquet",
         selection=f"{RESULTS}/datasets/{{region}}/validation_selection.tsv",
-        counts=f"{RESULTS}/datasets/{{region}}/validation_species_counts.tsv",
+        composition=f"{RESULTS}/datasets/{{region}}/validation_composition.tsv",
         summary=f"{RESULTS}/datasets/{{region}}/split_summary.json",
     wildcard_constraints:
         region=COHORT_RE,
@@ -110,13 +109,12 @@ rule dataset_splits:
             output.train,
             output.validation,
             output.selection,
-            output.counts,
+            output.composition,
             output.summary,
             region_label=dataset_region_label(wildcards.region),
             species_scope=dataset_species_scope(wildcards.region),
             add_rc=bool(config["add_rc"]),
-            validation_chrom=str(config["validation_chrom"]),
-            max_validation_rows=int(config["validation_max_rows"]),
+            validation_rows=VALIDATION_ROWS,
             seed=int(config["validation_seed"]),
         )
 
@@ -226,6 +224,7 @@ rule dataset_card:
             hf_repo=params.repo,
             region_label=params.region,
             species_scope=params.scope,
+            validation_seed=int(config["validation_seed"]),
         )
 
 
@@ -238,6 +237,15 @@ rule hf_artifact_manifest:
         ),
         validation_source=expand(
             f"{RESULTS}/datasets/{{region}}/validation.parquet", region=COHORTS
+        ),
+        split_selection=expand(
+            f"{RESULTS}/datasets/{{region}}/validation_selection.tsv", region=COHORTS
+        ),
+        split_composition=expand(
+            f"{RESULTS}/datasets/{{region}}/validation_composition.tsv", region=COHORTS
+        ),
+        split_summary=expand(
+            f"{RESULTS}/datasets/{{region}}/split_summary.json", region=COHORTS
         ),
         train=local(
             expand(


### PR DESCRIPTION
Replace chromosome-18 validation with an independent uniform 16,384-row sample from each original-orientation cohort before reverse-complement augmentation.
The smoke tier samples one row per cohort.
Selected identities are removed from training, their reverse complements are excluded, and chromosome, species, alignment backend, and human anchor are not stratification boundaries.

Use a seeded, cohort-salted Polars identity hash and streaming bottom-k so membership is stable across input order without requiring the entire cohort in memory.
Persist selection, composition, and split-summary sidecars, and make publication validation reconstruct the original cohort and recompute the exact sample and composition before upload.

Projection QC is now split-independent, and the workflow and card documentation reflect that species projections from one human anchor may cross the row-level split.

Validated with 221 pipeline tests, the 79-job smoke dry-run, and repository-wide pre-commit checks.

Part of #473.