### PR TITLE
[research] Record online loss-selection findings

### DIFF
--- a/docs/research/experiments/515-online-loss-selection.md
+++ b/docs/research/experiments/515-online-loss-selection.md
@@ -1,0 +1,80 @@
+# Online loss selection and teacher distillation for CDS continuation
+
+> [!NOTE]
+> **TL;DR:** In one shallow exp58 animal-CDS continuation, current- or teacher-loss-ranked half-token objectives sharply reduced Mendelian missense-plus-splicing AUPRC, while pure final-checkpoint teacher KL exceeded uniform CE at step 200; one seed and privileged later-lineage supervision limit the inference.
+
+## Findings
+
+Hard selection by token loss did not improve this continuation.
+After 100 arm-local steps, all three current-student loss-ranked halves and the frozen-teacher lowest-loss half were significantly worse than the shared bridge.
+Randomly retaining half of eligible targets remained above the bridge but underperformed uniform CE, providing no compelling benefit from sparse gradients alone.
+
+Pure full-distribution teacher KL and uniform CE were the strongest objectives at the first gate.
+After both arms resumed to 200 arm-local steps, teacher KL reached 0.183331 pooled missense-plus-splicing AUPRC versus 0.170727 for uniform CE.
+Their paired difference was 0.012604 AUPRC with a two-sided match-group permutation p-value of 0.019549.
+
+Neither arm changed significantly from step 100 to step 200 after Holm correction.
+The evidence therefore distinguishes the two objectives at the step-200 evaluation within this run, but does not establish a reliable upward or downward trajectory for either arm.
+
+## Evidence
+
+No held-out language-model validation loss was evaluated.
+Only training loss was logged, so the accepted findings rest on downstream variant-effect prediction.
+
+The experiment initialized a 256-base, no-BOS Qwen3 model from exp58-animals step 1,000 and used its pinned animal-CDS corpus.
+Lowercase repeat targets were excluded, while repeat bases remained visible as context.
+A shared 100-step uniform-CE bridge was followed by seven independent 100-step objective forks, each with fresh AdamW and scheduler state, a 20-step warmup to 1e-3, and a constant 1e-3 learning rate thereafter.
+The uniform and teacher-KL arms later resumed their complete step-100 states for another 100 steps without a second warmup.
+
+The primary evaluation pooled 5,800 missense and 3,190 splicing records from the pinned Mendelian-traits train split.
+The 8,990 records formed 899 matched groups with one positive and nine negatives per group.
+
+| Checkpoint | Pooled | Missense | Splicing |
+|---|---:|---:|---:|
+| Shared bridge | 0.156796 | 0.126489 | 0.219649 |
+| Uniform CE, step 100 | 0.175704 | 0.139221 | 0.249623 |
+| Random-50 CE, step 100 | 0.161681 | 0.127705 | 0.234459 |
+| Student-low-50 CE, step 100 | 0.110347 | 0.100109 | 0.133439 |
+| Student-middle-50 CE, step 100 | 0.109192 | 0.100417 | 0.128960 |
+| Student-high-50 CE, step 100 | 0.108288 | 0.105148 | 0.115249 |
+| Teacher KL, step 100 | 0.177410 | 0.142064 | 0.246134 |
+| Teacher-low-50 CE, step 100 | 0.129372 | 0.118574 | 0.149306 |
+| Uniform CE, step 200 | 0.170727 | 0.132595 | 0.247808 |
+| Teacher KL, step 200 | **0.183331** | **0.148211** | **0.254956** |
+
+_Exact AUPRC at each completed evaluation; pooled missense plus splicing is primary._
+
+At step 100, one-sided paired match-group swap tests compared each nonuniform objective with the bridge using 20,000 permutations and Holm correction across six comparisons.
+Random-50 and teacher KL each had adjusted p_worse = 1.0.
+The four loss-ranked half-token objectives each had adjusted p_worse = 0.000300.
+
+At step 200, the two-sided paired teacher-KL-versus-uniform test used the same match-group unit and 20,000 permutations.
+Teacher KL exceeded uniform by 0.012604 AUPRC with p = 0.019549.
+The step-200-minus-step-100 changes were -0.004977 for uniform and +0.005921 for teacher KL; their Holm-adjusted two-sided p-values were both 0.563772.
+
+Every arm processed the same number and order of input rows through step 100.
+The two resumed arms used byte-identical plan prefixes through step 200 and restored model, optimizer, scheduler, selector, data-position, and random-number-generator state.
+Teacher KL required a frozen-teacher forward pass and averaged 28.88 seconds per added step, compared with 22.17 seconds for uniform CE.
+The comparison therefore matches processed input rather than wall time or accelerator compute.
+
+## Limitations
+
+- One paired training seed was evaluated.
+  The permutation p-values quantify uncertainty across matched evaluation records within this run, not variation across training seeds.
+- The teacher is the final step-16,999 checkpoint from the student's own training lineage.
+  Its soft targets provide privileged later-lineage supervision, so the KL result is not evidence for token selection alone.
+- The seven forks changed training objectives and reset optimizer state.
+  The experiment does not isolate selection masks from all other objective-transition effects.
+- The endpoint used the Mendelian-traits train split and excluded synonymous variants.
+  The result may not generalize beyond missense and splicing prediction.
+- The model, animal-CDS corpus, repeat exclusion, 256-base context, and shallow continuation are specific to exp58.
+  No RefSeq-corpus replication was run.
+- Matching processed input did not match training compute because teacher KL was slower per step.
+
+## Related questions
+
+- [Which genomic regions to train on, and how to find them?](../questions/training-regions.md)
+
+## Research record
+
+- [Experiment issue #515](https://github.com/Open-Athena/marin-dna/issues/515)

--- a/docs/research/experiments/515-online-loss-selection.md
+++ b/docs/research/experiments/515-online-loss-selection.md
@@ -23,7 +23,8 @@ Only training loss was logged, so the accepted findings rest on downstream varia
 
 The experiment initialized a 256-base, no-BOS Qwen3 model from exp58-animals step 1,000 and used its pinned animal-CDS corpus.
 Lowercase repeat targets were excluded, while repeat bases remained visible as context.
-A shared 100-step uniform-CE bridge was followed by seven independent 100-step objective forks, each with fresh AdamW and scheduler state, a 20-step warmup to 1e-3, and a constant 1e-3 learning rate thereafter.
+The shared 100-step uniform-CE bridge used fresh AdamW and a linear warmup from 1e-5 to 1e-3.
+Seven independent 100-step objective forks each reset AdamW and scheduler state, used a 20-step warmup to 1e-3, and held the learning rate constant at 1e-3 thereafter.
 The uniform and teacher-KL arms later resumed their complete step-100 states for another 100 steps without a second warmup.
 
 The primary evaluation pooled 5,800 missense and 3,190 splicing records from the pinned Mendelian-traits train split.
@@ -42,7 +43,7 @@ The 8,990 records formed 899 matched groups with one positive and nine negatives
 | Uniform CE, step 200 | 0.170727 | 0.132595 | 0.247808 |
 | Teacher KL, step 200 | **0.183331** | **0.148211** | **0.254956** |
 
-_Exact AUPRC at each completed evaluation; pooled missense plus splicing is primary._
+_AUPRC rounded to six decimals at each completed evaluation; pooled missense plus splicing is primary._
 
 At step 100, one-sided paired match-group swap tests compared each nonuniform objective with the bridge using 20,000 permutations and Holm correction across six comparisons.
 Random-50 and teacher KL each had adjusted p_worse = 1.0.

--- a/docs/research/experiments/515-online-loss-selection.md
+++ b/docs/research/experiments/515-online-loss-selection.md
@@ -63,8 +63,8 @@ The comparison therefore matches processed input rather than wall time or accele
   The permutation p-values quantify uncertainty across matched evaluation records within this run, not variation across training seeds.
 - The teacher is the final step-16,999 checkpoint from the student's own training lineage.
   Its soft targets provide privileged later-lineage supervision, so the KL result is not evidence for token selection alone.
-- The seven forks changed training objectives and reset optimizer state.
-  The experiment does not isolate selection masks from all other objective-transition effects.
+- Every fork, including uniform CE, reset optimizer and scheduler state and repeated the same warmup.
+  The result is specific to a high-learning-rate objective transition rather than uninterrupted exp58 training.
 - The endpoint used the Mendelian-traits train split and excluded synonymous variants.
   The result may not generalize beyond missense and splicing prediction.
 - The model, animal-CDS corpus, repeat exclusion, 256-base context, and shallow continuation are specific to exp58.

--- a/docs/research/questions/training-regions.md
+++ b/docs/research/questions/training-regions.md
@@ -1,7 +1,7 @@
 # Which genomic regions to train on, and how to find them?
 
 > [!NOTE]
-> **TL;DR:** Targeted or conservation-selected corpora often improve functional prediction at current scales, while loss or entropy from a trained model is a practical conservation proxy; a five-checkpoint loss slope did not improve conservation ranking, and no causal benefit from likelihood-derived weighting or repeat downweighting has been established.
+> **TL;DR:** Targeted or conservation-selected corpora often improve functional prediction at current scales, and absolute loss or entropy can proxy conservation; in one shallow CDS continuation, hard loss-ranked half-token objectives harmed Mendelian VEP while full teacher KL beat uniform CE at step 200, but replicated evidence for a default objective change remains absent.
 
 ## Question
 
@@ -32,6 +32,12 @@ One orientation preserved the aggregate classification result at half the infere
 The inference-only audit did not test whether any score improves training and could not separate training exposure or homology effects.
 The [likelihood-dynamics experiment](../experiments/489-likelihood-dynamics.md) found conservation ranking by 21B tokens and terminal loss outperforming the five-checkpoint loss slope in every region.
 Its trajectory groups remain descriptive, and neither score was tested as a training selector.
+
+The [online loss-selection experiment](../experiments/515-online-loss-selection.md) supplied a first causal downstream test in one exp58 animal-CDS continuation.
+Hard masks retaining the current student's low-, middle-, or high-loss half, and a frozen final teacher's lowest-loss half, were all significantly worse than the shared bridge after 100 arm-local steps.
+Pure full-distribution teacher KL reached 0.183331 pooled Mendelian missense-plus-splicing AUPRC at step 200 versus 0.170727 for uniform CE, with a paired within-run p-value of 0.019549.
+The KL arm used privileged later-lineage supervision and more compute per processed input, and neither arm's step-100-to-step-200 change was significant after correction.
+This one seed argues against hard half-token loss ranking in the tested setting and makes teacher distillation a replication candidate rather than a default objective.
 
 The leading hypothesis is that increasing the density of constrained or correctly annotated sequence improves functional-VEP sample efficiency at fixed compute.
 Whole-genome data may become more useful at larger scale, under weighting that prevents easy background from dominating, or for mutation-process, repeat, phylogeny, and regional-context tasks.
@@ -84,6 +90,8 @@ It should retain a background arm so gains on functional VEP can be weighed agai
   FWD-only and RC-only classification AUPRC was nearly identical, while their imperfect endpoint per-base agreement limits a single pass as an exact replacement for averaged weights.
 - [Likelihood-derived token rankings through m1.3 training](../experiments/489-likelihood-dynamics.md) measured one 1B lineage at five cumulative-token checkpoints across five genomic regions, finding that loss and entropy ranked conservation by the earliest checkpoint while terminal loss outperformed a five-checkpoint loss slope globally and in every region.
   The trajectory groups differed in conservation and functional-region composition, but remain descriptive and do not establish a training benefit.
+- [Online loss selection and teacher distillation for CDS continuation](../experiments/515-online-loss-selection.md) compared seven objective forks from one exp58 animal-CDS bridge.
+  All four loss-ranked half-token objectives harmed Mendelian missense-plus-splicing AUPRC, while pure final-checkpoint teacher KL beat uniform CE at step 200 within the paired evaluation records; one seed, privileged later-lineage supervision, and unmatched per-step compute limit the inference.
 
 </details>
 
@@ -93,6 +101,7 @@ It should retain a background arm so gains on functional VEP can be weighed agai
 - Compare whole-genome, conservation-filtered, annotation-enriched, and functional-plus-background corpora at matched architecture, tokens, and evaluation, reporting unique loci and realized repetitions.
 - Separate locus selection, exposure frequency, and per-base loss weighting, including data-size- and epoch-matched controls.
 - Test terminal loss or entropy, target-distribution reducible loss, and same-corpus scale-differential loss as distinct selectors; control for repeats, GC, local predictability, training exposure, and homology density.
+- Replicate pure teacher KL against uniform CE across training seeds and matched compute, and separate soft-target distillation from the advantage of a later checkpoint in the same lineage.
 - Measure the footprint tradeoff across Mendelian and complex-trait VEP, region-matched likelihood gaps, frozen probes, and at least one outcome expected to benefit from neutral sequence.
 - Ablate the current 100-fold repeat downweighting across model and token scales while holding footprint and sampling fixed.
 - Compare conservation or whole-genome alignment with direct annotation, cheap local alignment, and learned single-sequence selection only after the target distribution and leakage contract are fixed.

--- a/docs/research/questions/training-regions.md
+++ b/docs/research/questions/training-regions.md
@@ -1,7 +1,7 @@
 # Which genomic regions to train on, and how to find them?
 
 > [!NOTE]
-> **TL;DR:** Targeted or conservation-selected corpora often improve functional prediction at current scales, and absolute loss or entropy can proxy conservation; in one shallow CDS continuation, hard loss-ranked half-token objectives harmed Mendelian VEP while full teacher KL beat uniform CE at step 200, but replicated evidence for a default objective change remains absent.
+> **TL;DR:** Targeted or conservation-selected corpora often improve functional prediction at current scales, and absolute loss or entropy can proxy conservation; hard loss-ranked token selection failed in one shallow CDS continuation, while same-lineage teacher distillation outperformed uniform once and repeat downweighting remains untested.
 
 ## Question
 
@@ -26,18 +26,10 @@ Uniform loss is the simpler prior.
 If removing repeat-specific weights preserves performance at the scales and tasks we care about, we should remove them.
 This would eliminate a special-case training heuristic and make likelihoods easier to interpret.
 
-The [conservation and repeat predictability experiment](../experiments/478-conservation-repeat-predictability.md) found that, among nonrepeat human CDS, upstream, and downstream positions, absolute loss and entropy ranked conservation increasingly well with model scale and dominated same-corpus loss deltas at comparable FWD scoring compute.
-Controlled scale-dependent loss reduction remained associated with conservation, but it is distinct from target-distribution reducible loss.
-One orientation preserved the aggregate classification result at half the inference compute without preserving the exact per-base ranking.
-The inference-only audit did not test whether any score improves training and could not separate training exposure or homology effects.
-The [likelihood-dynamics experiment](../experiments/489-likelihood-dynamics.md) found conservation ranking by 21B tokens and terminal loss outperforming the five-checkpoint loss slope in every region.
-Its trajectory groups remain descriptive, and neither score was tested as a training selector.
-
-The [online loss-selection experiment](../experiments/515-online-loss-selection.md) supplied a first causal downstream test in one exp58 animal-CDS continuation.
-Hard masks retaining the current student's low-, middle-, or high-loss half, and a frozen final teacher's lowest-loss half, were all significantly worse than the shared bridge after 100 arm-local steps.
-Pure full-distribution teacher KL reached 0.183331 pooled Mendelian missense-plus-splicing AUPRC at step 200 versus 0.170727 for uniform CE, with a paired within-run p-value of 0.019549.
-The KL arm used privileged later-lineage supervision and more compute per processed input, and neither arm's step-100-to-step-200 change was significant after correction.
-This one seed argues against hard half-token loss ranking in the tested setting and makes teacher distillation a replication candidate rather than a default objective.
+Across the [conservation-predictability](../experiments/478-conservation-repeat-predictability.md) and [likelihood-dynamics](../experiments/489-likelihood-dynamics.md) experiments, absolute loss and entropy ranked conservation better than same-corpus loss deltas or a five-checkpoint loss slope, but these inference results did not establish training value and could not separate exposure or homology effects.
+The [online loss-selection experiment](../experiments/515-online-loss-selection.md) found that this predictive signal did not transfer to hard selection: current-student loss halves and a frozen teacher's low-loss half harmed Mendelian missense-plus-splicing prediction in one shallow animal-CDS continuation.
+Full-distribution distillation from the final same-lineage checkpoint outperformed uniform CE within the paired run, but used privileged later-lineage supervision and more compute.
+With one seed, the result argues against hard half-token ranking in this setting but does not support a default-objective change.
 
 The leading hypothesis is that increasing the density of constrained or correctly annotated sequence improves functional-VEP sample efficiency at fixed compute.
 Whole-genome data may become more useful at larger scale, under weighting that prevents easy background from dominating, or for mutation-process, repeat, phylogeny, and regional-context tasks.
@@ -101,7 +93,6 @@ It should retain a background arm so gains on functional VEP can be weighed agai
 - Compare whole-genome, conservation-filtered, annotation-enriched, and functional-plus-background corpora at matched architecture, tokens, and evaluation, reporting unique loci and realized repetitions.
 - Separate locus selection, exposure frequency, and per-base loss weighting, including data-size- and epoch-matched controls.
 - Test terminal loss or entropy, target-distribution reducible loss, and same-corpus scale-differential loss as distinct selectors; control for repeats, GC, local predictability, training exposure, and homology density.
-- Replicate pure teacher KL against uniform CE across training seeds and matched compute, and separate soft-target distillation from the advantage of a later checkpoint in the same lineage.
 - Measure the footprint tradeoff across Mendelian and complex-trait VEP, region-matched likelihood gaps, frozen probes, and at least one outcome expected to benefit from neutral sequence.
 - Ablate the current 100-fold repeat downweighting across model and token scales while holding footprint and sampling fixed.
 - Compare conservation or whole-genome alignment with direct annotation, cheap local alignment, and learned single-sequence selection only after the target distribution and leakage contract are fixed.


### PR DESCRIPTION
Record the accepted interpretation of #515 in one experiment page and update the training-regions synthesis.

The experiment page captures the complete step-100 gate and step-200 uniform-versus-teacher-KL comparison, including AUPRCs, paired p-values, the learning-rate and resume contract, and the main limitations. It explicitly records that held-out LM validation loss was not evaluated, only one training seed was used, the teacher supplies privileged later-lineage supervision, and per-step compute was not matched.

No experiment runner, checkpoints, logbook, or untracked experiment files are included.

Part of #515