### PR TITLE
Register issue 517 terminal VEP models

### DIFF
--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -1316,6 +1316,28 @@ models:
     window_size: 256
     datasets: [mendelian_traits]
 
+  # Issue #517 functional specialists at their terminal checkpoints.
+  - name: exp517-cds-step-4999
+    gcs_path: gs://marin-us-east5/MarinDNA/exp517_functional_specialists/checkpoints/dna-exp517-0p25b-cds-v1/2026.08.24/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits, sge]
+  - name: exp517-utr3-step-4999
+    gcs_path: gs://marin-us-east5/MarinDNA/exp517_functional_specialists/checkpoints/dna-exp517-0p25b-utr3-v1/2026.08.24/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits]
+  - name: exp517-tss_region-step-4999
+    gcs_path: gs://marin-us-east5/MarinDNA/exp517_functional_specialists/checkpoints/dna-exp517-0p25b-tss_region-v1/2026.08.24/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits]
+  - name: exp517-ncrna-step-4999
+    gcs_path: gs://marin-us-east5/MarinDNA/exp517_functional_specialists/checkpoints/dna-exp517-0p25b-ncrna-v1/2026.08.24/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits]
+  - name: exp517-enhancer-step-4999
+    gcs_path: gs://marin-us-east5/MarinDNA/exp517_functional_specialists/checkpoints/dna-exp517-0p25b-enhancer-v1/2026.08.24/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits]
+
 inference:
   batch_size: 128       # Was 64 with output_hidden_states=True keeping all
                         # 19+2 layers' activations alive (~2.6 GB at L=256,


### PR DESCRIPTION
Register the five issue #517 step-4,999 checkpoints in the canonical evals_v2 model registry.
CDS is scoped to Mendelian Traits, Complex Traits, and SGE.
The 3′ UTR, TSS-region, ncRNA, and enhancer specialists are scoped to Mendelian and Complex Traits.

The locked evals_v2 suite passes with 416 tests and 5 skips.
The development-only issue config dry-runs as 5 model downloads, 11 score cells, 11 metric cells, and one terminal home-rank analysis.
Experiment execution remains on the permanent branch in #518.

Part of #517.