### PR TITLE
[research] Record negative short-window clustering result

### DIFF
--- a/docs/research/experiments/521-linclust-conservation.md
+++ b/docs/research/experiments/521-linclust-conservation.md
@@ -1,0 +1,78 @@
+# Anchor-free clustering of mammalian genome windows
+
+> [!NOTE]
+> **TL;DR:** Symmetric clustering of independently tiled 255 or 511 bp mammalian genome windows did not provide a viable conservation selector: candidate generation missed many known homologs, exhaustive alignment exposed a separate short-window recovery ceiling, alternative seed graphs lost precision or recall, and monolithic Linclust crashed on the exact 298.5-million-window panel.
+
+## Findings
+
+Do not continue tuning or scaling the tested anchor-free short-window clustering recipe.
+On projected human, mouse, and armadillo controls, the strongest scalable Linclust setting remained a high-precision under-clusterer.
+It recovered 54.9% of known cross-species pairs and 46.1% of exact three-species anchors in a five-million-window genomic background while leaving 4.84 million clusters.
+Four independent hash shifts raised recall by only 1.3 percentage points for approximately four times the clustering work, and denser one-pass seed sampling did not improve recall.
+
+The missed pairs were not solely a Linclust prefilter problem.
+An exhaustive no-prefilter graph recovered 71.9% of known pairs at 100% observed pair precision on the bounded 255 bp fixture, leaving 28.1% unrecovered even with only an E-value acceptance threshold.
+On the 123 anchors shared between window-length fixtures, the same exhaustive control recovered 71.3% of pairs at 255 bp but only 37.7% at 511 bp.
+Longer windows around a projected center therefore diluted rather than strengthened the homologous signal in this construction.
+
+The alternative scalable recipes did not yield a useful precision-recall tradeoff.
+A source-aware seed graph reached 70.1% recall in a one-million-window background, but strict precision fell to 50.9% and 45.6% of truth records shared components with genomic decoys.
+Exhaustive alignment of its bounded truth-containing components removed all observed decoy pairs but reduced global recall to 52.3%, below Linclust.
+DECIPHER Clusterize formed giant mixed components and contaminated every truth record in the one-million-window comparison.
+
+The exact 20-order panel retained 298,524,220 of 469,611,559 candidate 255 bp windows, totaling 76,123,676,100 retained bases.
+MMseqs2 18.8cc5c `kmermatcher` segfaulted on this monolithic database with both the measured 148-seed recipe and a 64-seed retry that planned one in-memory split.
+The latter reached a sampled 325,828,228 KiB RSS while approximately 192 GiB of host memory remained available, so its failure was not a host out-of-memory event.
+No full-panel assignments or direct phyloP metrics were produced.
+
+These results do not rule out a materially different method that uses positional or syntenic evidence, an anchor genome, or another candidate representation.
+They do show that more hash shifts, denser short-seed sampling, broader alignment of the same candidates, a longer centered window, or another monolithic Linclust run is not justified by this experiment.
+
+## Evidence
+
+The primary bounded fixture contained 128 projected human, mouse, and armadillo anchors with three sequences and three known cross-species pairs per anchor.
+It was injected into balanced, independently sampled real-genome backgrounds so true-pair recovery and genomic-decoy contamination could be measured separately.
+
+| Scalable approach | Background | True-pair recall | Strict precision | Exact anchors | Candidate time | Peak RSS |
+|---|---:|---:|---:|---:|---:|---:|
+| Linclust, automatic k17, 148 seeds | 5,000,000 | 54.9% | 99.1% | 46.1% | 157.78 s | 12.6 GiB |
+| Four Linclust hash shifts | 5,000,000 | 56.2% | 97.7% | 47.7% | 641.90 s | Not aggregated |
+| Linclust, automatic k17, 239 seeds | 5,000,000 | 53.4% | 97.6% | 44.5% | 184.24 s | 19.4 GiB |
+| Source-aware k19 seed graph | 1,000,000 | 70.1% | 50.9% | 33.6% | 362.39 s | 25.6 GiB |
+
+The 148-seed Linclust arm produced 4,841,534 clusters in the five-million-window background.
+This refuted the expectation that clustering would approach the number of sequences divided by the number of species: independently sampled genome tiles usually have no sampled orthologous partner and therefore remain singletons.
+
+The exhaustive controls separated candidate loss from accepted-alignment loss.
+Removing the k-mer prefilter raised recall from 35.4% to 46.6% at the original 0.50 identity and 0.80 coverage gate.
+Relaxing coverage raised it further, but only the E-value-only graph reached 71.9% recall, still with 100% observed precision.
+Changing minimum identity from 0.40 to 0.30 at 0.50 coverage changed no pairs, identifying coverage and short-window alignability rather than identity as the operative acceptance limits.
+
+The 20-genome run used exactly one selected assembly from each of 20 mammalian orders and all retained tiles from each assembly.
+Both paid full-panel attempts completed database creation before failing in `kmermatcher` seed-list generation.
+The five on-demand panel attempts, including setup and workflow corrections, used an estimated $8.11 of EC2 compute and all workers were terminated.
+
+## Limitations
+
+- The truth fixture used projected human, mouse, and armadillo loci.
+  It measures recovery of known homologous groups rather than direct classification of phyloP-defined conservation.
+- The bounded fixture contained 128 anchors, and five anchors had to be replaced in the 511 bp construction because expansion introduced ambiguity or majority-masked sequence.
+- The independently sampled genomic background is appropriate for measuring collisions and singleton behavior but rarely includes the exact cross-species counterpart of a background window.
+- The full 20-genome clustering did not complete, so the experiment produced no whole-panel cluster statistics or held-out human phyloP evaluation.
+- The scaling failure applies to MMseqs2 18.8cc5c and the tested monolithic nucleotide Linclust recipes.
+  It does not establish that every sharded, distributed, or position-aware clustering algorithm must fail.
+- No genomic language model was trained on a clustering-derived footprint.
+  The experiment evaluates conservation-candidate recovery, not downstream training utility.
+- The raw S3 inputs and outputs were deleted after the negative disposition to stop ongoing storage charges.
+  Commit-pinned code, configurations, tests, manifests, metrics, run details, and the complete logbook remain public, but the deleted artifacts can no longer be inspected byte-for-byte at their published S3 locations.
+
+## Related questions
+
+- [Which genomic regions to train on, and how to find them?](../questions/training-regions.md)
+
+## Research record
+
+- [Experiment issue #521](https://github.com/Open-Athena/marin-dna/issues/521)
+- [Complete standalone workflow at the final code snapshot](https://github.com/Open-Athena/marin-dna/tree/e02d1637dc41f886ffdc5dd071228314f2a58631/snakemake/analysis/linclust_conservation)
+- [Final append-only experiment logbook](https://github.com/Open-Athena/marin-dna/blob/efdd8e2b7c96230851d315cdbeaf1dd51fbb2fb1/.agents/logbooks/linclust-conservation.md)
+- [Commit-pinned code index and artifact disposition](https://github.com/Open-Athena/marin-dna/issues/521#issuecomment-5427008645)

--- a/docs/research/experiments/521-linclust-conservation.md
+++ b/docs/research/experiments/521-linclust-conservation.md
@@ -1,7 +1,7 @@
 # Anchor-free clustering of mammalian genome windows
 
 > [!NOTE]
-> **TL;DR:** Symmetric clustering of independently tiled 255 bp mammalian genome windows, plus a bounded 511 bp projected-center diagnostic, did not provide a viable conservation selector: candidate generation missed many known homologs, the tested exhaustive MMseqs2 control still missed 28.1% of projected pairs, alternative seed graphs lost precision or recall, and monolithic Linclust crashed on the exact 298.5-million-window panel.
+> **TL;DR:** Symmetric clustering of independently tiled 255 bp mammalian genome windows, plus a bounded 511 bp projected-center diagnostic, did not provide a viable conservation selector: recovery was inadequate, monolithic Linclust crashed on the exact 298.5-million-window panel, and the single-database workflow had no path to all-animal or all-eukaryote scale.
 
 ## Findings
 
@@ -25,6 +25,11 @@ The exact 20-order panel retained 298,524,220 of 469,611,559 candidate 255 bp wi
 MMseqs2 18.8cc5c `kmermatcher` segfaulted on this monolithic database with both the measured 148-seed recipe and a 64-seed retry that planned one in-memory split.
 The latter reached a sampled 325,828,228 KiB RSS while approximately 192 GiB of host memory remained available, so its failure was not a host out-of-memory event.
 No full-panel assignments or direct phyloP metrics were produced.
+
+Scalability was a separate negative result from recovery quality.
+The workflow placed every retained window in one MMseqs2 database and had no distributed sequence-ID sharding or cross-shard reconciliation.
+The 20-mammal proof of concept already failed in that architecture.
+This implementation therefore did not provide a path to all-animal or all-eukaryote coverage; supporting those scopes would require a different system architecture and validation of global cluster semantics across partitions.
 
 These results do not rule out a materially different method that uses positional or syntenic evidence, an anchor genome, or another candidate representation.
 They do show that more hash shifts, denser short-seed sampling, broader alignment of the same candidates, a longer centered window, or another monolithic Linclust run is not justified by this experiment.
@@ -50,6 +55,7 @@ Relaxing coverage raised it further, but only the E-value-only graph reached 71.
 Changing minimum identity from 0.40 to 0.30 at 0.50 coverage changed no pairs, identifying coverage rather than identity as the operative acceptance limit within this MMseqs2 control.
 
 The 20-genome run used exactly one selected assembly from each of 20 mammalian orders and all retained tiles from each assembly.
+The rule constructed one MMseqs2 database from every retained tile and had no sharding or reconciliation stage.
 Both paid full-panel attempts completed database creation before failing in `kmermatcher` seed-list generation.
 The five on-demand panel attempts, including setup and workflow corrections, used an estimated $8.11 of EC2 compute and all workers were terminated.
 

--- a/docs/research/experiments/521-linclust-conservation.md
+++ b/docs/research/experiments/521-linclust-conservation.md
@@ -1,7 +1,7 @@
 # Anchor-free clustering of mammalian genome windows
 
 > [!NOTE]
-> **TL;DR:** Symmetric clustering of independently tiled 255 or 511 bp mammalian genome windows did not provide a viable conservation selector: candidate generation missed many known homologs, exhaustive alignment exposed a separate short-window recovery ceiling, alternative seed graphs lost precision or recall, and monolithic Linclust crashed on the exact 298.5-million-window panel.
+> **TL;DR:** Symmetric clustering of independently tiled 255 bp mammalian genome windows, plus a bounded 511 bp projected-center diagnostic, did not provide a viable conservation selector: candidate generation missed many known homologs, the tested exhaustive MMseqs2 control still missed 28.1% of projected pairs, alternative seed graphs lost precision or recall, and monolithic Linclust crashed on the exact 298.5-million-window panel.
 
 ## Findings
 
@@ -13,6 +13,7 @@ Four independent hash shifts raised recall by only 1.3 percentage points for app
 The missed pairs were not solely a Linclust prefilter problem.
 An exhaustive no-prefilter graph recovered 71.9% of known pairs at 100% observed pair precision on the bounded 255 bp fixture, leaving 28.1% unrecovered even with only an E-value acceptance threshold.
 On the 123 anchors shared between window-length fixtures, the same exhaustive control recovered 71.3% of pairs at 255 bp but only 37.7% at 511 bp.
+The 511 bp experiment was limited to a 384-sequence projected-center diagnostic and did not tile whole genomes.
 Longer windows around a projected center therefore diluted rather than strengthened the homologous signal in this construction.
 
 The alternative scalable recipes did not yield a useful precision-recall tradeoff.
@@ -46,7 +47,7 @@ This refuted the expectation that clustering would approach the number of sequen
 The exhaustive controls separated candidate loss from accepted-alignment loss.
 Removing the k-mer prefilter raised recall from 35.4% to 46.6% at the original 0.50 identity and 0.80 coverage gate.
 Relaxing coverage raised it further, but only the E-value-only graph reached 71.9% recall, still with 100% observed precision.
-Changing minimum identity from 0.40 to 0.30 at 0.50 coverage changed no pairs, identifying coverage and short-window alignability rather than identity as the operative acceptance limits.
+Changing minimum identity from 0.40 to 0.30 at 0.50 coverage changed no pairs, identifying coverage rather than identity as the operative acceptance limit within this MMseqs2 control.
 
 The 20-genome run used exactly one selected assembly from each of 20 mammalian orders and all retained tiles from each assembly.
 Both paid full-panel attempts completed database creation before failing in `kmermatcher` seed-list generation.
@@ -57,7 +58,10 @@ The five on-demand panel attempts, including setup and workflow corrections, use
 - The truth fixture used projected human, mouse, and armadillo loci.
   It measures recovery of known homologous groups rather than direct classification of phyloP-defined conservation.
 - The bounded fixture contained 128 anchors, and five anchors had to be replaced in the 511 bp construction because expansion introduced ambiguity or majority-masked sequence.
+- The 511 bp experiment contained 384 projected-center sequences and did not tile or cluster whole genomes.
 - The independently sampled genomic background is appropriate for measuring collisions and singleton behavior but rarely includes the exact cross-species counterpart of a background window.
+- The 71.9% result is the observed recovery limit for MMseqs2 18.8cc5c no-prefilter search with E-value at most 0.001, masking, and set-cover clustering on one 128-anchor fixture.
+  No other aligner or looser E-value threshold was tested, so this is not a general ceiling for aligning 255 bp sequences.
 - The full 20-genome clustering did not complete, so the experiment produced no whole-panel cluster statistics or held-out human phyloP evaluation.
 - The scaling failure applies to MMseqs2 18.8cc5c and the tested monolithic nucleotide Linclust recipes.
   It does not establish that every sharded, distributed, or position-aware clustering algorithm must fail.
@@ -73,6 +77,3 @@ The five on-demand panel attempts, including setup and workflow corrections, use
 ## Research record
 
 - [Experiment issue #521](https://github.com/Open-Athena/marin-dna/issues/521)
-- [Complete standalone workflow at the final code snapshot](https://github.com/Open-Athena/marin-dna/tree/e02d1637dc41f886ffdc5dd071228314f2a58631/snakemake/analysis/linclust_conservation)
-- [Final append-only experiment logbook](https://github.com/Open-Athena/marin-dna/blob/efdd8e2b7c96230851d315cdbeaf1dd51fbb2fb1/.agents/logbooks/linclust-conservation.md)
-- [Commit-pinned code index and artifact disposition](https://github.com/Open-Athena/marin-dna/issues/521#issuecomment-5427008645)

--- a/docs/research/questions/training-regions.md
+++ b/docs/research/questions/training-regions.md
@@ -1,7 +1,7 @@
 # Which genomic regions to train on, and how to find them?
 
 > [!NOTE]
-> **TL;DR:** Targeted or conservation-selected corpora often improve functional prediction at current scales, and absolute loss or entropy can proxy conservation; hard loss-ranked token selection failed in one shallow CDS continuation, while same-lineage teacher distillation outperformed uniform once and repeat downweighting remains untested.
+> **TL;DR:** Targeted or conservation-selected corpora often improve functional prediction at current scales, and absolute loss or entropy can proxy conservation; hard loss-ranked token selection and anchor-free clustering of short mammalian genome windows both failed as practical selectors, while same-lineage teacher distillation outperformed uniform once and repeat downweighting remains untested.
 
 ## Question
 
@@ -30,6 +30,11 @@ Across the [conservation-predictability](../experiments/478-conservation-repeat-
 The [online loss-selection experiment](../experiments/515-online-loss-selection.md) found that this predictive signal did not transfer to hard selection: current-student loss halves and a frozen teacher's low-loss half harmed Mendelian missense-plus-splicing prediction in one shallow animal-CDS continuation.
 Full-distribution distillation from the final same-lineage checkpoint outperformed uniform CE within the paired run, but used privileged later-lineage supervision and more compute.
 With one seed, the result argues against hard half-token ranking in this setting but does not support a default-objective change.
+
+The [anchor-free clustering experiment](../experiments/521-linclust-conservation.md) did not recover a viable conservation selector from independently tiled mammalian genomes.
+On a projected three-species control in a five-million-window background, the best scalable Linclust recipe recovered 54.9% of known pairs at 99.1% strict precision, while an exhaustive no-prefilter control still recovered only 71.9%.
+Extending windows from 255 to 511 bp reduced matched-anchor exhaustive recall, alternative seed and graph recipes traded away precision or recall, and monolithic Linclust segfaulted on the exact 298.5-million-window 20-genome panel.
+This argues against further tuning of unordered short-window clustering for this purpose, while leaving targeted local alignment and methods with positional, syntenic, or anchor evidence as distinct directions.
 
 The leading hypothesis is that increasing the density of constrained or correctly annotated sequence improves functional-VEP sample efficiency at fixed compute.
 Whole-genome data may become more useful at larger scale, under weighting that prevents easy background from dominating, or for mutation-process, repeat, phylogeny, and regional-context tasks.
@@ -84,6 +89,8 @@ It should retain a background arm so gains on functional VEP can be weighed agai
   The trajectory groups differed in conservation and functional-region composition, but remain descriptive and do not establish a training benefit.
 - [Online loss selection and teacher distillation for CDS continuation](../experiments/515-online-loss-selection.md) compared seven objective forks from one exp58 animal-CDS bridge.
   All four loss-ranked half-token objectives harmed Mendelian missense-plus-splicing AUPRC, while pure final-checkpoint teacher KL beat uniform CE at step 200 within the paired evaluation records; one seed, privileged later-lineage supervision, and unmatched per-step compute limit the inference.
+- [Anchor-free clustering of mammalian genome windows](../experiments/521-linclust-conservation.md) tested Linclust, exhaustive alignment controls, longer windows, hash ensembles, denser seeds, DECIPHER, and a source-aware seed graph against projected homology.
+  The tested symmetric short-window recipes missed too many known pairs or admitted too many genomic decoys, and monolithic Linclust failed at the exact 20-genome scale, so this path was stopped without a phyloP selector or training run.
 
 </details>
 
@@ -95,6 +102,7 @@ It should retain a background arm so gains on functional VEP can be weighed agai
 - Test terminal loss or entropy, target-distribution reducible loss, and same-corpus scale-differential loss as distinct selectors; control for repeats, GC, local predictability, training exposure, and homology density.
 - Measure the footprint tradeoff across Mendelian and complex-trait VEP, region-matched likelihood gaps, frozen probes, and at least one outcome expected to benefit from neutral sequence.
 - Ablate the current 100-fold repeat downweighting across model and token scales while holding footprint and sampling fixed.
-- Compare conservation or whole-genome alignment with direct annotation, cheap local alignment, and learned single-sequence selection only after the target distribution and leakage contract are fixed.
+- Compare conservation or whole-genome alignment with direct annotation, targeted local alignment, and learned single-sequence selection only after the target distribution and leakage contract are fixed.
+- Do not revisit symmetric clustering of independently tiled 255 or 511 bp whole genomes without materially new positional, syntenic, or candidate-representation evidence.
 
 </details>

--- a/docs/research/questions/training-regions.md
+++ b/docs/research/questions/training-regions.md
@@ -103,6 +103,6 @@ It should retain a background arm so gains on functional VEP can be weighed agai
 - Measure the footprint tradeoff across Mendelian and complex-trait VEP, region-matched likelihood gaps, frozen probes, and at least one outcome expected to benefit from neutral sequence.
 - Ablate the current 100-fold repeat downweighting across model and token scales while holding footprint and sampling fixed.
 - Compare conservation or whole-genome alignment with direct annotation, targeted local alignment, and learned single-sequence selection only after the target distribution and leakage contract are fixed.
-- Do not revisit symmetric clustering of independently tiled 255 or 511 bp whole genomes without materially new positional, syntenic, or candidate-representation evidence.
+- Do not revisit symmetric clustering of independently tiled 255 bp whole genomes without materially new positional, syntenic, or candidate-representation evidence; the bounded 511 bp projected-center diagnostic provides no reason to lengthen the window.
 
 </details>

--- a/docs/research/questions/training-regions.md
+++ b/docs/research/questions/training-regions.md
@@ -34,6 +34,7 @@ With one seed, the result argues against hard half-token ranking in this setting
 The [anchor-free clustering experiment](../experiments/521-linclust-conservation.md) did not recover a viable conservation selector from independently tiled mammalian genomes.
 On a projected three-species control in a five-million-window background, the best scalable Linclust recipe recovered 54.9% of known pairs at 99.1% strict precision, while an exhaustive no-prefilter control still recovered only 71.9%.
 Extending windows from 255 to 511 bp reduced matched-anchor exhaustive recall, alternative seed and graph recipes traded away precision or recall, and monolithic Linclust segfaulted on the exact 298.5-million-window 20-genome panel.
+The workflow placed every retained tile in one database and lacked distributed sharding or cross-shard reconciliation, so it supplied no path from the mammalian proof of concept to all-animal or all-eukaryote coverage.
 This argues against further tuning of unordered short-window clustering for this purpose, while leaving targeted local alignment and methods with positional, syntenic, or anchor evidence as distinct directions.
 
 The leading hypothesis is that increasing the density of constrained or correctly annotated sequence improves functional-VEP sample efficiency at fixed compute.
@@ -90,7 +91,7 @@ It should retain a background arm so gains on functional VEP can be weighed agai
 - [Online loss selection and teacher distillation for CDS continuation](../experiments/515-online-loss-selection.md) compared seven objective forks from one exp58 animal-CDS bridge.
   All four loss-ranked half-token objectives harmed Mendelian missense-plus-splicing AUPRC, while pure final-checkpoint teacher KL beat uniform CE at step 200 within the paired evaluation records; one seed, privileged later-lineage supervision, and unmatched per-step compute limit the inference.
 - [Anchor-free clustering of mammalian genome windows](../experiments/521-linclust-conservation.md) tested Linclust, exhaustive alignment controls, longer windows, hash ensembles, denser seeds, DECIPHER, and a source-aware seed graph against projected homology.
-  The tested symmetric short-window recipes missed too many known pairs or admitted too many genomic decoys, and monolithic Linclust failed at the exact 20-genome scale, so this path was stopped without a phyloP selector or training run.
+  The tested symmetric short-window recipes missed too many known pairs or admitted too many genomic decoys, and the single-database workflow failed at the exact 20-genome scale without a distributed path to all animals or eukaryotes, so this path was stopped without a phyloP selector or training run.
 
 </details>
 


### PR DESCRIPTION
Record symmetric clustering of independently tiled mammalian genome windows as a negative result and update the accepted answer on training-region selection.
The interpretation stops further tuning or scaling of this recipe while distinguishing position- or synteny-aware methods as a different research direction.

The bounded projected-homology controls found 54.9% true-pair recall at 99.1% strict precision for the strongest scalable Linclust arm, 71.9% observed recovery under the tested exhaustive MMseqs2 control at 255 bp, and lower matched-anchor recovery at 511 bp.
Alternative seed and graph methods traded away precision or recall.
Monolithic MMseqs2 Linclust then segfaulted on the exact 298.5-million-window 20-genome panel without producing assignments or phyloP metrics.
The tested workflow constructed one database from all retained tiles and had no distributed sharding or cross-shard reconciliation, so it did not supply a scalable path from 20 mammals to all-animal or all-eukaryote coverage.

The experimental workflow remains on its permanent branch and is not included here.
Its code and final logbook are commit-pinned from the research record; the negative run's S3 artifacts were deleted after preservation to stop ongoing storage charges.

Fixes #521
