### PR TITLE
Add Marin-style automatic Claude PR review

### DIFF
--- a/.agents/skills/maintain-vendored-skills/references/manifest.json
+++ b/.agents/skills/maintain-vendored-skills/references/manifest.json
@@ -35,6 +35,17 @@
       "deviations": [
         "Use Open-Athena/marin-dna in the pinned-logbook permalink example."
       ]
+    },
+    {
+      "name": "review-pr",
+      "deviations": [
+        "Vendored from marin-community/marin@e9e77ee6d9603aa2fe665a3f0e0a2db7ed950fda, which post-dates this manifest's pinned commit.",
+        "Enumerate MarinDNA's quotable AGENTS.md rules for the compliance agents and route figure and Snakemake checks to the local area skills.",
+        "Check PR prose against writing-style plus communicate-on-github instead of Marin's writing-style alone.",
+        "Validate findings from all four review agents, not only the bug agents.",
+        "Require the robot prefix on every posted comment and use Open-Athena/marin-dna permalinks.",
+        "Drop Marin's stats-logging step (no log_stats.py sink here)."
+      ]
     }
   ],
   "local": [

--- a/.agents/skills/maintain-vendored-skills/references/manifest.json
+++ b/.agents/skills/maintain-vendored-skills/references/manifest.json
@@ -49,7 +49,7 @@
     {
       "name": "review-pr",
       "deviations": [
-        "Vendored from marin-community/marin@e9e77ee6d9603aa2fe665a3f0e0a2db7ed950fda, which post-dates this manifest's pinned commit.",
+        "Rewrite the description for MarinDNA CI and local invocation.",
         "Enumerate MarinDNA's quotable AGENTS.md rules for the compliance agents and route figure and Snakemake checks to the local area skills.",
         "Check PR prose against writing-style plus communicate-on-github instead of Marin's writing-style alone.",
         "Validate findings from all four review agents, not only the bug agents.",

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: review-pr
-description: Multi-agent correctness and CLAUDE.md-compliance review of a pull request. Run only when explicitly requested or from CI; `--comment` posts findings as inline PR comments.
+description: Multi-agent correctness and AGENTS.md-compliance review of a pull request. Run only when explicitly requested or from CI; `--comment` posts findings as inline PR comments.
 allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), mcp__github_inline_comment__create_inline_comment
 ---
 
 Provide a code review for the given pull request: `/review-pr [--comment] <PR>`.
 
-Adapted from marin-community/marin's `.agents/skills/review-pr/SKILL.md`. The review pipeline and the high-signal policy are unchanged; the repo-specific parts (what counts as a quotable CLAUDE.md rule, comment conventions, permalink format) are marin-dna's.
+Adapted from marin-community/marin's `.agents/skills/review-pr/SKILL.md`.
+The review pipeline and the high-signal policy are unchanged; the repo-specific parts are derived from `AGENTS.md` and the local skills named below.
+When `AGENTS.md` or those skills change, re-sync this file (see `maintain-vendored-skills` for the vendor comparison workflow).
 
 **Agent assumptions (applies to all agents and subagents):**
 - All tools are functional. Do not test tools or make exploratory calls.
@@ -20,73 +22,98 @@ Follow these steps precisely:
    - The PR does not need code review (e.g. a dependabot bump, a trivial obviously-correct change)
    - Claude has already commented on this PR (check `gh pr view <PR> --comments`) AND a re-review was not explicitly requested. When a maintainer explicitly requests a re-review, always proceed even if a prior review exists.
 
-   If any condition is true, stop. Note: still review agent-authored PRs (`codex/*` and `claude/*` branches, the `agent-generated` label).
+   If any condition is true, stop.
+   Note: still review agent-authored PRs (`codex/*` and `claude/*` branches, the `agent-generated` label).
 
 2. Launch a haiku agent to return file paths (not contents) for all relevant guidance files:
-   - The root `CLAUDE.md` and `AGENTS.md`
-   - `snakemake/<pipeline>/README.md` for every pipeline directory containing files modified by the PR (CLAUDE.md requires the README to be updated in the same PR as a behaviour change)
-   - Any `CLAUDE.md` or `AGENTS.md` in directories (and parent directories) containing files modified by the PR
+   - The root `AGENTS.md` (`CLAUDE.md` is a symlink to it)
+   - Any `AGENTS.md` or `CLAUDE.md` in directories (and parent directories) containing files modified by the PR
+   - The owning project's `README.md` for every Snakemake project that contains a modified file (`AGENTS.md` requires the README to be updated when user-visible behaviour changes)
+   - Area skills that govern the modified files: `.agents/skills/plot-research-results/SKILL.md` when the PR changes figures or plotting code, and `.agents/skills/develop-snakemake-pipelines/SKILL.md` when it changes files under a Snakemake project
+   - `.agents/skills/writing-style/SKILL.md`, `.agents/skills/writing-style/pull-requests.md`, and `.agents/skills/communicate-on-github/SKILL.md` (for step 3)
 
-3. Launch an opus agent to view the PR and return a summary of the changes. The same agent checks the PR title and description against the **GitHub Communication** section of `CLAUDE.md` and returns any problems it finds:
+3. Launch an opus agent to view the PR and return a summary of the changes.
+   The same agent checks the PR title and description against `writing-style/pull-requests.md` and `communicate-on-github` and returns any problems it finds, for example:
 
-   - an issue-closing keyword (`fixes #N`, `closes #N`, `resolves #N`) in the *title* — it belongs in the body;
-   - code referenced by bare path or branch link instead of a commit-pinned permalink (`blob/<sha>/path#Lx-Ly`);
+   - a title over 72 characters, a non-imperative title, or a conventional-commit prefix;
+   - code or artifacts referenced by bare path or moving branch link instead of an immutable `blob/<sha>/path#Lx-Ly` URL;
    - logs over ~40 lines, large tables, or code dumps not wrapped in `<details><summary>…</summary>…</details>`;
-   - experimental results (tables, leaderboards, per-genome stats) placed in a README instead of the tracking issue.
+   - a body that buries what-the-change-does under inventory or boilerplate instead of leading with it.
 
+   Flag only concrete violations of those two files.
    A terse, plain body for a small change is correct — do not flag brevity or the absence of markdown.
 
-4. Launch 4 agents in parallel to independently review the changes. Each returns a list of issues; each issue includes a description and the reason it was flagged (e.g. "CLAUDE.md adherence", "bug").
+4. Launch 4 agents in parallel to independently review the changes.
+   Each returns a list of issues; each issue includes a description and the reason it was flagged (e.g. "AGENTS.md adherence", "bug").
 
-   Agents 1 + 2: CLAUDE.md compliance opus agents. Audit changes for compliance. When evaluating a file, only consider guidance files that share its path or are parents. The `CLAUDE.md` rules concrete enough to quote, and therefore in scope:
+   Agents 1 + 2: AGENTS.md compliance opus agents.
+   Audit changes for compliance.
+   When evaluating a file, only consider guidance files that share its path or are parents, plus the area skills from step 2.
+   The `AGENTS.md` rules concrete enough to quote, and therefore in scope:
 
-   - **Coordinates.** 0-based, half-open everywhere inside our code; conversion to/from 1-based closed formats (GTF, VCF, SAM, `pyfaidx.get_seq()`, samtools region strings) happens only at the tool boundary.
-   - **Logic lives in a package, not in rule files.** `run:` blocks in `Snakefile`/`.smk` files are thin glue calling into a library. No new `.py` script files under `snakemake/` *except* inside a workflow's own `src/` package (e.g. `snakemake/analysis/evals_v2/src/marin_dna_evals/`) — AGENTS.md: "Put maintained Python in the owning project's `src/` package".
-   - **Tests.** A new non-trivial function in `src/marin_dna/` with no test.
-   - **Type annotations** on every parameter and return value in `src/marin_dna/`, Python 3.11+ syntax (`list[str]`, `X | None`).
-   - **Pipeline README** not updated when the PR changes that pipeline's behaviour.
-   - **Plots.** Figure-level seaborn functions; capless SE error bars; independent twin y-axes for non-level-comparable metrics.
-   - **Scope.** Unrelated code in other pipelines or library modules removed or rewritten.
+   - **Coordinates.** 0-based, half-open genomic coordinates internally; conversion to/from 1-based or closed formats (GTF, VCF, SAM, `pyfaidx.get_seq()`, samtools-style region strings) at the tool boundary, with any deviation stated.
+   - **Project boundaries.** Maintained Python lives in the owning project's `src/` package; the root `src/marin_dna/` package stays limited to lightweight genomic primitives and must not depend on training frameworks, Snakemake, W&B, plotting libraries, or pipeline-specific clients.
+   - **Tests.** Non-trivial maintained behaviour in any changed project's owning package with no test; data pipelines missing contract assertions (schemas, row counts, value ranges, sequence lengths, coordinate bounds, build or strand consistency).
+   - **Type annotations** on parameters and return values in every changed project's `src/` package, using current built-in generic and union syntax.
+   - **Workflow README** not updated when the PR changes that workflow's user-visible behaviour, configuration, outputs, or operating procedure.
+   - **Markdown prose** hard-wrapped at a fixed column or carrying multiple sentences per source line.
+   - **Figures.** Judge changed plotting code against `plot-research-results`; flag only concrete violations of that skill.
+   - **Lifecycle.** Experiment-only or one-off content woven into `main`-bound framework code instead of staying on its permanent branch.
 
-   Agents 3 + 4: opus bug agents (parallel). Scan for obvious bugs, security issues, and incorrect logic within the changed code. Focus only on the diff without reading extra context. Flag only significant bugs you can validate from the diff alone; ignore nitpicks and likely false positives. Bioinformatics bugs that deserve extra suspicion: off-by-one at interval boundaries, strand handling, reference-build or chromosome-name mismatches (`chr1` vs `1`), silent NaN propagation, and parallel arrays whose lengths are never checked.
+   Agents 3 + 4: opus bug agents (parallel).
+   Scan for obvious bugs, security issues, and incorrect logic within the changed code.
+   Focus only on the diff without reading extra context.
+   Flag only significant bugs you can validate from the diff alone; ignore nitpicks and likely false positives.
+   Bioinformatics bugs that deserve extra suspicion: off-by-one at interval boundaries, strand handling, reference-build or chromosome-name mismatches (`chr1` vs `1`), silent NaN propagation, and parallel arrays whose lengths are never checked.
 
    **CRITICAL: We only want HIGH SIGNAL issues.** Flag issues where:
    - The code will fail to compile or parse (syntax errors, type errors, missing imports, unresolved references)
    - The code will definitely produce wrong results regardless of inputs (clear logic errors)
-   - Clear, unambiguous CLAUDE.md violations where you can quote the exact rule being broken
+   - Clear, unambiguous AGENTS.md violations where you can quote the exact rule being broken
 
    Do NOT flag:
    - Code style or quality concerns
    - Potential issues that depend on specific inputs or state
    - Subjective suggestions or improvements
 
-   If you are not certain an issue is real, do not flag it. False positives erode trust.
+   If you are not certain an issue is real, do not flag it.
+   False positives erode trust.
 
    Tell each subagent the PR title and description for author-intent context.
 
-   **marin-dna-specific:** duplication between pipeline modules inside `src/marin_dna/` is intentional (CLAUDE.md: "Duplication beats premature abstraction *within* the library"). Do not flag copy/paste or DRY concerns if behaviour is correct. Liberal `assert`s for invariants are house style, not a smell. Experiment directories and one-off `scripts/` are deliberately not library-quality; hold them to correctness, not structure.
+   **marin-dna-specific:** duplicating unstable logic across projects is intentional until a genuinely shared abstraction has emerged (`AGENTS.md`, Project Boundaries) — do not flag copy/paste or DRY concerns if behaviour is correct.
+   Liberal `assert`s for data contracts are required house style, not a smell.
+   Experiment branches and one-off scripts are held to correctness, not structure.
 
-5. For each issue from agents 3 and 4, launch a parallel subagent to validate it. Give the subagent the PR title, description, and issue description. It must confirm with high confidence that the issue is real — e.g. for "variable is not defined", verify that in the code; for a CLAUDE.md issue, verify the rule is scoped to this file and actually violated. Use opus subagents throughout — for both bugs/logic and CLAUDE.md violations.
+5. For each issue from step 4 — from all four agents, compliance and bug alike — launch a parallel subagent to validate it.
+   Give the subagent the PR title, description, and issue description.
+   It must confirm with high confidence that the issue is real — e.g. for "variable is not defined", verify that in the code; for an AGENTS.md issue, verify the rule is scoped to this file and actually violated.
+   Use opus subagents throughout.
 
-6. Filter out any issues not validated in step 5. The remainder is the high-signal review list.
+6. Filter out any issues not validated in step 5.
+   The remainder is the high-signal review list.
 
 7. Output a summary of the review findings to the terminal:
    - If issues were found, list each issue with a brief description.
-   - If no issues were found, state: "No issues found. Checked for bugs and CLAUDE.md compliance."
+   - If no issues were found, state: "No issues found. Checked for bugs and AGENTS.md compliance."
    - Separately, report any PR-description problems from step 3.
 
-   If `--comment` argument was NOT provided, stop here. Do not post any GitHub comments.
+   If `--comment` argument was NOT provided, stop here.
+   Do not post any GitHub comments.
 
-   If `--comment` IS provided and step 3 found PR-description problems, post **one** top-level comment with `gh pr comment` (prefixed `🤖`, not inline) naming the specific problems and the concrete fix (e.g. "move `fixes #131` from the title into the body"). This is independent of the code review — post it whether or not code issues were found, but skip it when the description is fine.
+   If `--comment` IS provided and step 3 found PR-description problems, post **one** top-level comment with `gh pr comment` (prefixed `🤖`, not inline) naming the specific problems and the concrete fix.
+   This is independent of the code review — post it whether or not code issues were found, but skip it when the description is fine.
 
    If `--comment` IS provided and NO code issues were found, post the no-issues summary comment (format below) using `gh pr comment` and stop.
 
    If `--comment` IS provided and code issues were found, continue to step 8.
 
-8. Draft the list of comments you plan to leave. For your own review only — do not post it anywhere.
+8. Draft the list of comments you plan to leave.
+   For your own review only — do not post it anywhere.
 
-9. Post inline comments for each issue using `mcp__github_inline_comment__create_inline_comment` with `confirmed: true`. For each comment:
-   - Begin the body with `🤖` (CLAUDE.md: agent comments on PRs and issues must begin with it)
+9. Post inline comments for each issue using `mcp__github_inline_comment__create_inline_comment` with `confirmed: true`.
+   For each comment:
+   - Begin the body with `🤖` (`communicate-on-github`: every agent-authored issue or PR comment begins with it)
    - Provide a brief description of the issue
    - For small, self-contained fixes, include a committable suggestion block
    - For larger fixes (6+ lines, structural changes, or changes spanning multiple locations), describe the issue and suggested fix without a suggestion block
@@ -99,26 +126,27 @@ Use this list when evaluating issues in steps 4 and 5 (these are false positives
 - Pre-existing issues
 - Something that appears to be a bug but is actually correct
 - Pedantic nitpicks that a senior engineer would not flag
-- Issues that a linter will catch — ruff, mypy, snakefmt run in the Quality workflow (do not run them to verify)
-- General code quality concerns (e.g. general security issues) unless explicitly required in CLAUDE.md
-- Issues mentioned in CLAUDE.md but explicitly silenced in the code (e.g. via a lint ignore comment)
+- Issues that a linter will catch — ruff, mypy, snakefmt run via pre-commit in the Quality workflow (do not run them to verify)
+- General code quality concerns (e.g. general security issues) unless explicitly required in AGENTS.md
+- Issues mentioned in AGENTS.md but explicitly silenced in the code (e.g. via a lint ignore comment)
 
 Notes:
 
-- Use the gh CLI to interact with GitHub (fetch pull requests, create comments). Do not use web fetch.
+- Use the gh CLI to interact with GitHub (fetch pull requests, create comments).
+  Do not use web fetch.
 - Create a todo list before starting.
-- You must cite and link each issue in inline comments (e.g. when referring to CLAUDE.md, include a permalink to it, ideally with line numbers).
+- You must cite and link each issue in inline comments (e.g. when referring to AGENTS.md, include a permalink to it, ideally with line numbers).
 - If no issues are found and `--comment` is provided, post a comment with exactly this format:
 
 ---
 
 ## 🤖 Code review
 
-No issues found. Checked for bugs and CLAUDE.md compliance.
+No issues found. Checked for bugs and AGENTS.md compliance.
 
 ---
 
-- When linking to code in inline comments, follow this format precisely, otherwise the Markdown preview won't render: https://github.com/Open-Athena/marin-dna/blob/<full-40-char-sha>/CLAUDE.md#L10-L15
+- When linking to code in inline comments, follow this format precisely, otherwise the Markdown preview won't render: https://github.com/Open-Athena/marin-dna/blob/<full-40-char-sha>/AGENTS.md#L10-L15
   - Requires the full git sha. Commands like `https://github.com/owner/repo/blob/$(git rev-parse HEAD)/foo/bar` will not work, since your comment is rendered directly as Markdown.
   - Repo name must be `Open-Athena/marin-dna`.
   - `#` after the file name; line range format is `L[start]-L[end]`.

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: review-pr
+description: Multi-agent correctness and CLAUDE.md-compliance review of a pull request. Run only when explicitly requested or from CI; `--comment` posts findings as inline PR comments.
+allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), mcp__github_inline_comment__create_inline_comment
+---
+
+Provide a code review for the given pull request: `/review-pr [--comment] <PR>`.
+
+Adapted from marin-community/marin's `.agents/skills/review-pr/SKILL.md`. The review pipeline and the high-signal policy are unchanged; the repo-specific parts (what counts as a quotable CLAUDE.md rule, comment conventions, permalink format) are marin-dna's.
+
+**Agent assumptions (applies to all agents and subagents):**
+- All tools are functional. Do not test tools or make exploratory calls.
+- Only call a tool if it is required to complete the task.
+
+Follow these steps precisely:
+
+1. Launch a haiku agent to check if any of the following are true:
+   - The PR is closed
+   - The PR is a draft
+   - The PR does not need code review (e.g. a dependabot bump, a trivial obviously-correct change)
+   - Claude has already commented on this PR (check `gh pr view <PR> --comments`) AND a re-review was not explicitly requested. When a maintainer explicitly requests a re-review, always proceed even if a prior review exists.
+
+   If any condition is true, stop. Note: still review agent-authored PRs (`codex/*` and `claude/*` branches, the `agent-generated` label).
+
+2. Launch a haiku agent to return file paths (not contents) for all relevant guidance files:
+   - The root `CLAUDE.md` and `AGENTS.md`
+   - `snakemake/<pipeline>/README.md` for every pipeline directory containing files modified by the PR (CLAUDE.md requires the README to be updated in the same PR as a behaviour change)
+   - Any `CLAUDE.md` or `AGENTS.md` in directories (and parent directories) containing files modified by the PR
+
+3. Launch an opus agent to view the PR and return a summary of the changes. The same agent checks the PR title and description against the **GitHub Communication** section of `CLAUDE.md` and returns any problems it finds:
+
+   - an issue-closing keyword (`fixes #N`, `closes #N`, `resolves #N`) in the *title* — it belongs in the body;
+   - code referenced by bare path or branch link instead of a commit-pinned permalink (`blob/<sha>/path#Lx-Ly`);
+   - logs over ~40 lines, large tables, or code dumps not wrapped in `<details><summary>…</summary>…</details>`;
+   - experimental results (tables, leaderboards, per-genome stats) placed in a README instead of the tracking issue.
+
+   A terse, plain body for a small change is correct — do not flag brevity or the absence of markdown.
+
+4. Launch 4 agents in parallel to independently review the changes. Each returns a list of issues; each issue includes a description and the reason it was flagged (e.g. "CLAUDE.md adherence", "bug").
+
+   Agents 1 + 2: CLAUDE.md compliance opus agents. Audit changes for compliance. When evaluating a file, only consider guidance files that share its path or are parents. The `CLAUDE.md` rules concrete enough to quote, and therefore in scope:
+
+   - **Coordinates.** 0-based, half-open everywhere inside our code; conversion to/from 1-based closed formats (GTF, VCF, SAM, `pyfaidx.get_seq()`, samtools region strings) happens only at the tool boundary.
+   - **Logic lives in a package, not in rule files.** `run:` blocks in `Snakefile`/`.smk` files are thin glue calling into a library. No new `.py` script files under `snakemake/` *except* inside a workflow's own `src/` package (e.g. `snakemake/analysis/evals_v2/src/marin_dna_evals/`) — AGENTS.md: "Put maintained Python in the owning project's `src/` package".
+   - **Tests.** A new non-trivial function in `src/marin_dna/` with no test.
+   - **Type annotations** on every parameter and return value in `src/marin_dna/`, Python 3.11+ syntax (`list[str]`, `X | None`).
+   - **Pipeline README** not updated when the PR changes that pipeline's behaviour.
+   - **Plots.** Figure-level seaborn functions; capless SE error bars; independent twin y-axes for non-level-comparable metrics.
+   - **Scope.** Unrelated code in other pipelines or library modules removed or rewritten.
+
+   Agents 3 + 4: opus bug agents (parallel). Scan for obvious bugs, security issues, and incorrect logic within the changed code. Focus only on the diff without reading extra context. Flag only significant bugs you can validate from the diff alone; ignore nitpicks and likely false positives. Bioinformatics bugs that deserve extra suspicion: off-by-one at interval boundaries, strand handling, reference-build or chromosome-name mismatches (`chr1` vs `1`), silent NaN propagation, and parallel arrays whose lengths are never checked.
+
+   **CRITICAL: We only want HIGH SIGNAL issues.** Flag issues where:
+   - The code will fail to compile or parse (syntax errors, type errors, missing imports, unresolved references)
+   - The code will definitely produce wrong results regardless of inputs (clear logic errors)
+   - Clear, unambiguous CLAUDE.md violations where you can quote the exact rule being broken
+
+   Do NOT flag:
+   - Code style or quality concerns
+   - Potential issues that depend on specific inputs or state
+   - Subjective suggestions or improvements
+
+   If you are not certain an issue is real, do not flag it. False positives erode trust.
+
+   Tell each subagent the PR title and description for author-intent context.
+
+   **marin-dna-specific:** duplication between pipeline modules inside `src/marin_dna/` is intentional (CLAUDE.md: "Duplication beats premature abstraction *within* the library"). Do not flag copy/paste or DRY concerns if behaviour is correct. Liberal `assert`s for invariants are house style, not a smell. Experiment directories and one-off `scripts/` are deliberately not library-quality; hold them to correctness, not structure.
+
+5. For each issue from agents 3 and 4, launch a parallel subagent to validate it. Give the subagent the PR title, description, and issue description. It must confirm with high confidence that the issue is real — e.g. for "variable is not defined", verify that in the code; for a CLAUDE.md issue, verify the rule is scoped to this file and actually violated. Use opus subagents throughout — for both bugs/logic and CLAUDE.md violations.
+
+6. Filter out any issues not validated in step 5. The remainder is the high-signal review list.
+
+7. Output a summary of the review findings to the terminal:
+   - If issues were found, list each issue with a brief description.
+   - If no issues were found, state: "No issues found. Checked for bugs and CLAUDE.md compliance."
+   - Separately, report any PR-description problems from step 3.
+
+   If `--comment` argument was NOT provided, stop here. Do not post any GitHub comments.
+
+   If `--comment` IS provided and step 3 found PR-description problems, post **one** top-level comment with `gh pr comment` (prefixed `🤖`, not inline) naming the specific problems and the concrete fix (e.g. "move `fixes #131` from the title into the body"). This is independent of the code review — post it whether or not code issues were found, but skip it when the description is fine.
+
+   If `--comment` IS provided and NO code issues were found, post the no-issues summary comment (format below) using `gh pr comment` and stop.
+
+   If `--comment` IS provided and code issues were found, continue to step 8.
+
+8. Draft the list of comments you plan to leave. For your own review only — do not post it anywhere.
+
+9. Post inline comments for each issue using `mcp__github_inline_comment__create_inline_comment` with `confirmed: true`. For each comment:
+   - Begin the body with `🤖` (CLAUDE.md: agent comments on PRs and issues must begin with it)
+   - Provide a brief description of the issue
+   - For small, self-contained fixes, include a committable suggestion block
+   - For larger fixes (6+ lines, structural changes, or changes spanning multiple locations), describe the issue and suggested fix without a suggestion block
+   - Never post a committable suggestion UNLESS committing the suggestion fixes the issue entirely. If follow-up steps are required, do not leave a committable suggestion.
+
+   **IMPORTANT: Only post ONE comment per unique issue. Do not post duplicate comments.**
+
+Use this list when evaluating issues in steps 4 and 5 (these are false positives, do NOT flag):
+
+- Pre-existing issues
+- Something that appears to be a bug but is actually correct
+- Pedantic nitpicks that a senior engineer would not flag
+- Issues that a linter will catch — ruff, mypy, snakefmt run in the Quality workflow (do not run them to verify)
+- General code quality concerns (e.g. general security issues) unless explicitly required in CLAUDE.md
+- Issues mentioned in CLAUDE.md but explicitly silenced in the code (e.g. via a lint ignore comment)
+
+Notes:
+
+- Use the gh CLI to interact with GitHub (fetch pull requests, create comments). Do not use web fetch.
+- Create a todo list before starting.
+- You must cite and link each issue in inline comments (e.g. when referring to CLAUDE.md, include a permalink to it, ideally with line numbers).
+- If no issues are found and `--comment` is provided, post a comment with exactly this format:
+
+---
+
+## 🤖 Code review
+
+No issues found. Checked for bugs and CLAUDE.md compliance.
+
+---
+
+- When linking to code in inline comments, follow this format precisely, otherwise the Markdown preview won't render: https://github.com/Open-Athena/marin-dna/blob/<full-40-char-sha>/CLAUDE.md#L10-L15
+  - Requires the full git sha. Commands like `https://github.com/owner/repo/blob/$(git rev-parse HEAD)/foo/bar` will not work, since your comment is rendered directly as Markdown.
+  - Repo name must be `Open-Athena/marin-dna`.
+  - `#` after the file name; line range format is `L[start]-L[end]`.
+  - Provide at least 1 line of context before and after, centred on the line you are commenting about (commenting on lines 5-6 → link `L4-L7`).

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -11,7 +11,8 @@ The review pipeline and the high-signal policy are unchanged; the repo-specific 
 When `AGENTS.md` or those skills change, re-sync this file (see `maintain-vendored-skills` for the vendor comparison workflow).
 
 **Agent assumptions (applies to all agents and subagents):**
-- All tools are functional. Do not test tools or make exploratory calls.
+- All tools are functional.
+  Do not test tools or make exploratory calls.
 - Only call a tool if it is required to complete the task.
 
 Follow these steps precisely:
@@ -20,7 +21,8 @@ Follow these steps precisely:
    - The PR is closed
    - The PR is a draft
    - The PR does not need code review (e.g. a dependabot bump, a trivial obviously-correct change)
-   - Claude has already commented on this PR (check `gh pr view <PR> --comments`) AND a re-review was not explicitly requested. When a maintainer explicitly requests a re-review, always proceed even if a prior review exists.
+   - Claude has already commented on this PR (check `gh pr view <PR> --comments`) AND a re-review was not explicitly requested.
+     When a maintainer explicitly requests a re-review, always proceed even if a prior review exists.
 
    If any condition is true, stop.
    Note: still review agent-authored PRs (`codex/*` and `claude/*` branches, the `agent-generated` label).
@@ -117,9 +119,11 @@ Follow these steps precisely:
    - Provide a brief description of the issue
    - For small, self-contained fixes, include a committable suggestion block
    - For larger fixes (6+ lines, structural changes, or changes spanning multiple locations), describe the issue and suggested fix without a suggestion block
-   - Never post a committable suggestion UNLESS committing the suggestion fixes the issue entirely. If follow-up steps are required, do not leave a committable suggestion.
+   - Never post a committable suggestion UNLESS committing the suggestion fixes the issue entirely.
+     If follow-up steps are required, do not leave a committable suggestion.
 
-   **IMPORTANT: Only post ONE comment per unique issue. Do not post duplicate comments.**
+   **IMPORTANT: Only post ONE comment per unique issue.
+   Do not post duplicate comments.**
 
 Use this list when evaluating issues in steps 4 and 5 (these are false positives, do NOT flag):
 
@@ -142,12 +146,14 @@ Notes:
 
 ## 🤖 Code review
 
-No issues found. Checked for bugs and AGENTS.md compliance.
+No issues found.
+Checked for bugs and AGENTS.md compliance.
 
 ---
 
 - When linking to code in inline comments, follow this format precisely, otherwise the Markdown preview won't render: https://github.com/Open-Athena/marin-dna/blob/<full-40-char-sha>/AGENTS.md#L10-L15
-  - Requires the full git sha. Commands like `https://github.com/owner/repo/blob/$(git rev-parse HEAD)/foo/bar` will not work, since your comment is rendered directly as Markdown.
+  - Requires the full git sha.
+    Commands like `https://github.com/owner/repo/blob/$(git rev-parse HEAD)/foo/bar` will not work, since your comment is rendered directly as Markdown.
   - Repo name must be `Open-Athena/marin-dna`.
   - `#` after the file name; line range format is `L[start]-L[end]`.
   - Provide at least 1 line of context before and after, centred on the line you are commenting about (commenting on lines 5-6 → link `L4-L7`).

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,60 @@
+name: Claude Code Review
+
+# Automatic correctness + CLAUDE.md-compliance review of pull requests, after
+# marin-community/marin's ops-claude-review.yaml.
+#
+# One review per PR lifecycle event (opened / ready_for_review / reopened),
+# never per push. Ask for a re-review with an `@claude` comment (claude.yml).
+#
+# The author gate is load-bearing: this repo is public and the review spends
+# CLAUDE_CODE_OAUTH_TOKEN quota, so only PRs opened by repo writers run. That
+# also excludes dependabot (CONTRIBUTOR) and fork PRs, which never receive the
+# secret. `pull_request` (not `pull_request_target`) checks out the merge ref
+# — what would actually land — without exposing credentials to PR code.
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: >-
+      github.event.pull_request.draft == false &&
+      (
+        github.event.pull_request.author_association == 'OWNER' ||
+        github.event.pull_request.author_association == 'MEMBER' ||
+        github.event.pull_request.author_association == 'COLLABORATOR'
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write   # the skill posts with `gh pr comment`
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      # consult-agent wraps anthropics/claude-code-action and classifies a 429 /
+      # weekly-limit exit as a skipped consultation (a warning), not a red check.
+      # Pinned by commit like every other action in this repo.
+      - name: Run Claude review
+        id: claude
+        uses: marin-community/marin-style/actions/consult-agent@4b2fc2b0ec0bb9ad1304ef76936eb68e97f893cb # 2026-08-24
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'claude[bot]'
+          track_progress: true
+          prompt: |
+            /review-pr --comment ${{ github.event.pull_request.number }}
+          claude_args: |
+            --model claude-opus-5
+            --max-turns 200
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr review:*)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,6 +11,12 @@ name: Claude Code Review
 # also excludes dependabot (CONTRIBUTOR) and fork PRs, which never receive the
 # secret. `pull_request` (not `pull_request_target`) checks out the merge ref
 # — what would actually land — without exposing credentials to PR code.
+#
+# claude-code-action additionally refuses to run unless this file is identical
+# to the copy on the default branch (anti-tampering check on its app-token
+# exchange). A PR that adds or edits this workflow therefore gets a ~15 s
+# "success" with no review and a "Skipping action due to workflow validation"
+# warning in the log; the review starts working for the next PR after merge.
 
 on:
   pull_request:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,8 +9,11 @@ name: Claude Code Review
 # The author gate is load-bearing: this repo is public and the review spends
 # CLAUDE_CODE_OAUTH_TOKEN quota, so only PRs opened by repo writers run. That
 # also excludes dependabot (CONTRIBUTOR) and fork PRs, which never receive the
-# secret. `pull_request` (not `pull_request_target`) checks out the merge ref
-# — what would actually land — without exposing credentials to PR code.
+# secret. Fork heads are excluded outright: even a member's fork PR passes the
+# association gate, but fork heads receive no secrets, so the review would run
+# token-less and fail confusingly. `pull_request` (not `pull_request_target`)
+# checks out the merge ref — what would actually land — without exposing
+# credentials to PR code.
 #
 # claude-code-action additionally refuses to run unless this file is identical
 # to the copy on the default branch (anti-tampering check on its app-token
@@ -29,6 +32,7 @@ concurrency:
 jobs:
   review:
     if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.draft == false &&
       (
         github.event.pull_request.author_association == 'OWNER' ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,29 @@ on:
 
 jobs:
   claude:
+    # Only repo writers (OWNER / MEMBER / COLLABORATOR) can summon Claude. The
+    # repo is public; without this gate any commenter can spend the OAuth quota.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR') &&
+       contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR') &&
+       contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' &&
+       (github.event.review.author_association == 'OWNER' ||
+        github.event.review.author_association == 'MEMBER' ||
+        github.event.review.author_association == 'COLLABORATOR') &&
+       contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' &&
+       (github.event.issue.author_association == 'OWNER' ||
+        github.event.issue.author_association == 'MEMBER' ||
+        github.event.issue.author_association == 'COLLABORATOR') &&
+       (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,6 +14,10 @@ jobs:
   claude:
     # Only repo writers (OWNER / MEMBER / COLLABORATOR) can summon Claude. The
     # repo is public; without this gate any commenter can spend the OAuth quota.
+    # Issue assignment is exempt from the author check: only users with triage
+    # permission can assign, so the assigning actor is trusted even when the
+    # issue author is external (the event payload does not expose the
+    # assigner's association).
     if: |
       (github.event_name == 'issue_comment' &&
        (github.event.comment.author_association == 'OWNER' ||
@@ -30,10 +34,12 @@ jobs:
         github.event.review.author_association == 'MEMBER' ||
         github.event.review.author_association == 'COLLABORATOR') &&
        contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' &&
+      (github.event_name == 'issues' && github.event.action == 'opened' &&
        (github.event.issue.author_association == 'OWNER' ||
         github.event.issue.author_association == 'MEMBER' ||
         github.event.issue.author_association == 'COLLABORATOR') &&
+       (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
+      (github.event_name == 'issues' && github.event.action == 'assigned' &&
        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Adds automatic Claude review of pull requests, built the way [marin's `ops-claude-review.yaml`](https://github.com/marin-community/marin/blob/e9e77ee6d9603aa2fe665a3f0e0a2db7ed950fda/.github/workflows/ops-claude-review.yaml) does it. The review cannot run on this PR itself (see *First run* below); it starts with the next PR after merge.

## What changes

- **`.github/workflows/claude-code-review.yml`** (new). Fires on `opened` / `ready_for_review` / `reopened` — never `synchronize`; ask for a re-review with an `@claude` comment. Gated on a same-repository head, `draft == false`, **and** `author_association ∈ OWNER/MEMBER/COLLABORATOR`: the repo is public and the review spends the shared `CLAUDE_CODE_OAUTH_TOKEN` quota, so dependabot (`CONTRIBUTOR`) and fork PRs never trigger a run or receive the secret. Runs `/review-pr --comment <N>` through [`marin-style/actions/consult-agent`](https://github.com/marin-community/marin-style/blob/4b2fc2b0ec0bb9ad1304ef76936eb68e97f893cb/actions/consult-agent/action.yaml), which wraps `anthropics/claude-code-action` and classifies a 429 / weekly-limit exit as a warning instead of a red check.
- **`.agents/skills/review-pr/SKILL.md`** (new). [Marin's `review-pr` skill](https://github.com/marin-community/marin/blob/e9e77ee6d9603aa2fe665a3f0e0a2db7ed950fda/.agents/skills/review-pr/SKILL.md) with the pipeline and high-signal policy unchanged (haiku pre-check → opus summary + description check → 2 compliance + 2 bug agents → one validator per finding → filter → inline comments), with findings from all four agents validated. Repo-specific parts are derived from the current `AGENTS.md` (which replaced `CLAUDE.md` while this PR was open): the quotable compliance rules are enumerated with tests and type annotations scoped to every changed project's owning `src/` package; the PR-description check points at the vendored `writing-style` skill plus `communicate-on-github`; figure checks route to `plot-research-results`; bioinformatics failure modes are added to the bug agents; every posted comment starts with 🤖; Marin's stats-logging step is dropped. Registered in the `maintain-vendored-skills` manifest as an adapted Marin skill. Also usable locally as `/review-pr <N>`.
- **`.github/workflows/claude.yml`** — the existing `@claude` responder gains the same author gate on all four triggers, except issue *assignment*, which only triage-permission users can perform and therefore needs no author check. Nothing else in it changes.

## Dry run

`/review-pr 496` run locally without `--comment` (7 agents, ~4 min wall-clock, ~380k subagent tokens): no findings and no description problems, consistent with #496's reviewed-and-merged state. Both compliance agents correctly reasoned that `evals_v2`'s own `src/marin_dna_evals/` package is where AGENTS.md says maintained Python belongs; the skill now states that outright instead of leaving it to inference.

## Choices to confirm

| Decision | This PR | Alternative |
|---|---|---|
| Model | `--model claude-opus-5`, pinned like Marin pins `claude-opus-4-8` | Omit the flag and take the action default; if the first run rejects the ID, drop the flag |
| `marin-style` ref | Pinned to `4b2fc2b` (bump by hand; the repo has no tags, so dependabot won't) | `@main` as Marin does |
| `claude.yml` | Gate only | Also move it onto `consult-agent` |
| Re-review on push | No; `@claude` comment | Add `synchronize` |

**Deliberately not included** from Marin's setup: the lint-review lane (no lint catalog here; ruff/mypy/snakefmt already gate in `quality.yml`), triage/autofix jobs, stats telemetry, prose cleanup (disabled in Marin itself), and adopting `marin-style` as a dependency.

## First run

The run on this PR ([32989278296](https://github.com/Open-Athena/marin-dna/actions/runs/32989278296)) exited in 15 s with `success` and no review: `claude-code-action` refuses to run unless the workflow file is identical to the copy on the default branch (an anti-tampering check on its app-token exchange — "Skipping action due to workflow validation … this is normal … your workflow will begin working once you merge your PR"). That is now documented at the top of the workflow. Consequently the first real run is the first non-draft member PR opened after merge; things to check on it:

- [ ] `Claude Code Review` job ran for longer than a few seconds and was not `skipped`
- [ ] progress comment appeared; inline or summary comment starts with 🤖
- [ ] wall time under the 15-minute cap
- [ ] if rate-limited: green check with a warning, not red

`--model claude-opus-5` was checked locally against the Claude Code CLI and is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


