### PR TITLE
Add deterministic weekly research draft skill

### DIFF
--- a/.agents/skills/draft-weekly-research-update/SKILL.md
+++ b/.agents/skills/draft-weekly-research-update/SKILL.md
@@ -19,7 +19,7 @@ Do not summarize or reinterpret the research.
 ## Draft Contract
 
 - Sort pages by the leading experiment number in the filename.
-- Add a visible `Blurb` placeholder after each experiment's copied TL;DR for a human to replace before publishing; do not generate the blurb.
+- Add a visible `Blurb` placeholder after each experiment title and before its copied TL;DR for a human to replace before publishing; do not generate the blurb.
 - Append the originating issue number from the filename to each title, as `Title (#123)`, inside the same link to the canonical page on `main`.
 - Copy the text from the page's `> **TL;DR:**` callout without rewriting it.
 - Do not add an overview, synthesis, author credit, interpretation, supporting-artifact link, or future-work section.

--- a/.agents/skills/draft-weekly-research-update/SKILL.md
+++ b/.agents/skills/draft-weekly-research-update/SKILL.md
@@ -10,7 +10,7 @@ Do not summarize or reinterpret the research.
 
 ## Selection Contract
 
-- Run on Monday at 08:00 in `America/New_York` for the preceding Monday-through-Sunday local-time window.
+- Run on Monday at 08:00 in `America/New_York` for the preceding Monday-through-Sunday UTC window.
 - Fetch `origin/main` before selecting files.
 - Include every Markdown file first added under `docs/research/experiments/` between the two weekly boundary snapshots on `origin/main`.
 - Do not include modified existing experiment pages, issues, pull requests, infrastructure work, bugs, or research-question pages.

--- a/.agents/skills/draft-weekly-research-update/SKILL.md
+++ b/.agents/skills/draft-weekly-research-update/SKILL.md
@@ -32,7 +32,7 @@ From the repository root, fetch `main` and run the deterministic extractor with 
 
 ```bash
 git fetch origin main
-uv run --locked python .agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py \
+python3 .agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py \
   --week-start YYYY-MM-DD
 ```
 

--- a/.agents/skills/draft-weekly-research-update/SKILL.md
+++ b/.agents/skills/draft-weekly-research-update/SKILL.md
@@ -19,7 +19,7 @@ Do not summarize or reinterpret the research.
 ## Draft Contract
 
 - Sort pages by the leading experiment number in the filename.
-- Add a visible `Blurb` placeholder after each experiment title and before its copied TL;DR for a human to replace before publishing; do not generate the blurb.
+- Add a visible `Blurb (replace with contributor name)` placeholder after each experiment title and before its copied TL;DR; the human contributor replaces the bold label with their name and writes the blurb before publishing.
 - Append the originating issue number from the filename to each title, as `Title (#123)`, inside the same link to the canonical page on `main`.
 - Copy the text from the page's `> **TL;DR:**` callout without rewriting it.
 - Do not add an overview, synthesis, author credit, interpretation, supporting-artifact link, or future-work section.

--- a/.agents/skills/draft-weekly-research-update/SKILL.md
+++ b/.agents/skills/draft-weekly-research-update/SKILL.md
@@ -10,7 +10,7 @@ Do not summarize or reinterpret the research.
 
 ## Selection Contract
 
-- Run on Monday at 08:00 in `America/New_York` for the preceding Monday-through-Sunday UTC window.
+- Select the preceding Monday-through-Sunday UTC window.
 - Fetch `origin/main` before selecting files.
 - Include every Markdown file first added under `docs/research/experiments/` between the two weekly boundary snapshots on `origin/main`.
 - Do not include modified existing experiment pages, issues, pull requests, infrastructure work, bugs, or research-question pages.
@@ -24,11 +24,10 @@ Do not summarize or reinterpret the research.
 - Do not add an overview, synthesis, author credit, interpretation, supporting-artifact link, or future-work section.
 - Keep the voice neutral by preserving the canonical TL;DR text.
 - Produce a reviewable draft only.
-- Do not publish to Discord, X, GitHub, or another external destination.
 
 ## Generate The Draft
 
-From the repository root, fetch `main` and run the deterministic extractor with the previous Monday's date:
+From the repository root, fetch `main` and run the deterministic extractor with the reporting week's Monday date:
 
 ```bash
 git fetch origin main

--- a/.agents/skills/draft-weekly-research-update/SKILL.md
+++ b/.agents/skills/draft-weekly-research-update/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: draft-weekly-research-update
+description: Create a reviewable weekly MarinDNA public-research draft from experiment interpretation pages first added to main. Use for the scheduled Monday research update or an explicit request for that draft; do not use for issue activity, infrastructure, bugs, or edits to existing experiment pages.
+---
+
+# Draft Weekly Research Update
+
+Create a deterministic public draft from newly deposited experiment pages.
+Do not summarize or reinterpret the research.
+
+## Selection Contract
+
+- Run on Monday at 08:00 in `America/New_York` for the preceding Monday-through-Sunday local-time window.
+- Fetch `origin/main` before selecting files.
+- Include every Markdown file first added under `docs/research/experiments/` between the two weekly boundary snapshots on `origin/main`.
+- Do not include modified existing experiment pages, issues, pull requests, infrastructure work, bugs, or research-question pages.
+- Attribute a page to the week when it first appears on `main`, regardless of when the experiment ran or its issue closed.
+
+## Draft Contract
+
+- Sort pages by the leading experiment number in the filename.
+- Link each experiment title to its canonical page on `main`.
+- Copy the text from the page's `> **TL;DR:**` callout without rewriting it.
+- Do not add an overview, synthesis, author credit, interpretation, supporting-artifact link, or future-work section.
+- Keep the voice neutral by preserving the canonical TL;DR text.
+- Produce a reviewable draft only.
+- Do not publish to Discord, X, GitHub, or another external destination.
+
+## Generate The Draft
+
+From the repository root, fetch `main` and run the deterministic extractor with the previous Monday's date:
+
+```bash
+git fetch origin main
+uv run --locked python .agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py \
+  --week-start YYYY-MM-DD
+```
+
+Return the script's standard output unchanged as the publishable draft.
+If standard output is empty, report internally that no publishable draft was produced.
+Relay any standard-error warnings as an internal note after the draft.
+A missing title or TL;DR omits that page and emits a warning; do not synthesize replacement text.

--- a/.agents/skills/draft-weekly-research-update/SKILL.md
+++ b/.agents/skills/draft-weekly-research-update/SKILL.md
@@ -19,7 +19,7 @@ Do not summarize or reinterpret the research.
 ## Draft Contract
 
 - Sort pages by the leading experiment number in the filename.
-- Add a visible `Weekly blurb` placeholder after the heading for a human to replace before publishing; do not generate the blurb.
+- Add a visible `Blurb` placeholder after each experiment's copied TL;DR for a human to replace before publishing; do not generate the blurb.
 - Append the originating issue number from the filename to each title, as `Title (#123)`, inside the same link to the canonical page on `main`.
 - Copy the text from the page's `> **TL;DR:**` callout without rewriting it.
 - Do not add an overview, synthesis, author credit, interpretation, supporting-artifact link, or future-work section.

--- a/.agents/skills/draft-weekly-research-update/SKILL.md
+++ b/.agents/skills/draft-weekly-research-update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: draft-weekly-research-update
-description: Create a reviewable weekly MarinDNA public-research draft from experiment interpretation pages first added to main. Use for the scheduled Monday research update or an explicit request for that draft; do not use for issue activity, infrastructure, bugs, or edits to existing experiment pages.
+description: Create a reviewable weekly MarinDNA public-research draft as a temporary Markdown file from experiment interpretation pages first added to main. Use for the scheduled Monday research update or an explicit request for that draft; do not use for issue activity, infrastructure, bugs, or edits to existing experiment pages.
 ---
 
 # Draft Weekly Research Update
@@ -19,11 +19,12 @@ Do not summarize or reinterpret the research.
 ## Draft Contract
 
 - Sort pages by the leading experiment number in the filename.
-- Link each experiment title to its canonical page on `main`.
+- Add a visible `Weekly blurb` placeholder after the heading for a human to replace before publishing; do not generate the blurb.
+- Append the originating issue number from the filename to each title, as `Title (#123)`, inside the same link to the canonical page on `main`.
 - Copy the text from the page's `> **TL;DR:**` callout without rewriting it.
 - Do not add an overview, synthesis, author credit, interpretation, supporting-artifact link, or future-work section.
 - Keep the voice neutral by preserving the canonical TL;DR text.
-- Produce a reviewable draft only.
+- Produce a reviewable draft as a temporary Markdown file.
 
 ## Generate The Draft
 
@@ -35,7 +36,8 @@ python3 .agents/skills/draft-weekly-research-update/scripts/draft_weekly_researc
   --week-start YYYY-MM-DD
 ```
 
-Return the script's standard output unchanged as the publishable draft.
-If standard output is empty, report internally that no publishable draft was produced.
-Relay any standard-error warnings as an internal note after the draft.
-A missing title or TL;DR omits that page and emits a warning; do not synthesize replacement text.
+The script writes the draft to a private temporary Markdown file and prints its absolute path.
+Return a clickable link to that file without pasting its contents into the task.
+If standard output is empty, report internally that no draft file was produced.
+Relay any standard-error warnings as an internal note alongside the file link.
+A missing issue-number filename, title, or TL;DR omits that page and emits a warning; do not synthesize replacement text.

--- a/.agents/skills/draft-weekly-research-update/SKILL.md
+++ b/.agents/skills/draft-weekly-research-update/SKILL.md
@@ -22,7 +22,7 @@ Do not summarize or reinterpret the research.
 - Add a visible `Blurb (replace with contributor name)` placeholder after each experiment title and before its copied TL;DR; the human contributor replaces the bold label with their name and writes the blurb before publishing.
 - Append the originating issue number from the filename to each title, as `Title (#123)`, inside the same link to the canonical page on `main`.
 - Copy the text from the page's `> **TL;DR:**` callout without rewriting it.
-- Do not add an overview, synthesis, author credit, interpretation, supporting-artifact link, or future-work section.
+- Do not add an overview, synthesis, interpretation, supporting-artifact link, or future-work section.
 - Keep the voice neutral by preserving the canonical TL;DR text.
 - Produce a reviewable draft as a temporary Markdown file.
 

--- a/.agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py
+++ b/.agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py
@@ -19,7 +19,8 @@ TLDR_RE = re.compile(r"^>\s*\*\*TL;DR:\*\*\s*(.*)$")
 EXPERIMENT_NUMBER_RE = re.compile(r"^(\d+)-")
 REPORT_TIMEZONE = ZoneInfo("UTC")
 BLURB_PLACEHOLDER = (
-    "> **Weekly blurb:** _Add a short human-written introduction before publishing._"
+    "> **Blurb:** _Add a short human-written note about this experiment before "
+    "publishing._"
 )
 
 
@@ -205,14 +206,12 @@ def format_draft(
         return ""
 
     date_label = f"{week_start.strftime('%B')} {week_start.day}, {week_start.year}"
-    blocks = [
-        f"# MarinDNA research updates — week of {date_label}",
-        BLURB_PLACEHOLDER,
-    ]
+    blocks = [f"# MarinDNA research updates — week of {date_label}"]
     for page in pages:
         url = canonical_page_url(repository_url, branch, page.path)
         blocks.append(
-            f"**[{page.title} (#{page.issue_number})]({url})**\n\n{page.tldr}"
+            f"**[{page.title} (#{page.issue_number})]({url})**\n\n"
+            f"{page.tldr}\n\n{BLURB_PLACEHOLDER}"
         )
     return "\n\n".join(blocks) + "\n"
 

--- a/.agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py
+++ b/.agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py
@@ -211,7 +211,7 @@ def format_draft(
         url = canonical_page_url(repository_url, branch, page.path)
         blocks.append(
             f"**[{page.title} (#{page.issue_number})]({url})**\n\n"
-            f"{page.tldr}\n\n{BLURB_PLACEHOLDER}"
+            f"{BLURB_PLACEHOLDER}\n\n{page.tldr}"
         )
     return "\n\n".join(blocks) + "\n"
 

--- a/.agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py
+++ b/.agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py
@@ -19,8 +19,8 @@ TLDR_RE = re.compile(r"^>\s*\*\*TL;DR:\*\*\s*(.*)$")
 EXPERIMENT_NUMBER_RE = re.compile(r"^(\d+)-")
 REPORT_TIMEZONE = ZoneInfo("UTC")
 BLURB_PLACEHOLDER = (
-    "> **Blurb:** _Add a short human-written note about this experiment before "
-    "publishing._"
+    "> **Blurb (replace with contributor name):** _Add a short human-written note "
+    "about this experiment before publishing._"
 )
 
 

--- a/.agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py
+++ b/.agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py
@@ -96,10 +96,30 @@ def new_experiment_paths(
         if status != "A" or not separator:
             continue
         path = PurePosixPath(raw_path)
-        if path.parent == EXPERIMENTS_DIR and path.suffix == ".md":
+        if (
+            path.parent == EXPERIMENTS_DIR
+            and path.suffix == ".md"
+            and not path_was_previously_added(repo_root, start_commit, raw_path)
+        ):
             paths.append(raw_path)
 
     return end_commit, sorted(paths, key=experiment_sort_key)
+
+
+def path_was_previously_added(repo_root: Path, commit: str, path: str) -> bool:
+    """Return whether a path was added anywhere in the snapshot's ancestry."""
+
+    additions = run_git(
+        repo_root,
+        "log",
+        "--first-parent",
+        "--diff-filter=A",
+        "--format=%H",
+        commit,
+        "--",
+        path,
+    )
+    return bool(additions.strip())
 
 
 def experiment_sort_key(path: str) -> tuple[int, int | str]:

--- a/.agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py
+++ b/.agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py
@@ -52,12 +52,13 @@ def weekly_boundaries(week_start: date) -> tuple[datetime, datetime]:
 def commit_before(repo_root: Path, ref: str, boundary: datetime) -> str:
     """Resolve the last first-parent commit before a time boundary."""
 
+    latest_included = boundary - timedelta(seconds=1)
     commit = run_git(
         repo_root,
         "rev-list",
         "-1",
         "--first-parent",
-        f"--before={boundary.isoformat()}",
+        f"--before={latest_included.isoformat()}",
         ref,
     ).strip()
     if not commit:

--- a/.agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py
+++ b/.agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py
@@ -6,6 +6,7 @@ import argparse
 import re
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
 from pathlib import Path, PurePosixPath
@@ -17,6 +18,9 @@ TITLE_RE = re.compile(r"^#\s+(.+?)\s*$")
 TLDR_RE = re.compile(r"^>\s*\*\*TL;DR:\*\*\s*(.*)$")
 EXPERIMENT_NUMBER_RE = re.compile(r"^(\d+)-")
 REPORT_TIMEZONE = ZoneInfo("UTC")
+BLURB_PLACEHOLDER = (
+    "> **Weekly blurb:** _Add a short human-written introduction before publishing._"
+)
 
 
 @dataclass(frozen=True)
@@ -24,6 +28,7 @@ class ExperimentPage:
     """The public fields extracted from one canonical experiment page."""
 
     path: str
+    issue_number: int
     title: str
     tldr: str
 
@@ -136,6 +141,10 @@ def experiment_sort_key(path: str) -> tuple[int, int | str]:
 def extract_page(path: str, markdown: str) -> ExperimentPage | None:
     """Extract the H1 title and canonical TL;DR callout text."""
 
+    issue_match = EXPERIMENT_NUMBER_RE.match(PurePosixPath(path).name)
+    if issue_match is None:
+        return None
+
     lines = markdown.splitlines()
     title = next(
         (match.group(1) for line in lines if (match := TITLE_RE.match(line))), None
@@ -160,7 +169,12 @@ def extract_page(path: str, markdown: str) -> ExperimentPage | None:
             tldr_lines.pop()
         tldr = "\n".join(tldr_lines).strip()
         if tldr:
-            return ExperimentPage(path=path, title=title, tldr=tldr)
+            return ExperimentPage(
+                path=path,
+                issue_number=int(issue_match.group(1)),
+                title=title,
+                tldr=tldr,
+            )
         return None
 
     return None
@@ -191,11 +205,35 @@ def format_draft(
         return ""
 
     date_label = f"{week_start.strftime('%B')} {week_start.day}, {week_start.year}"
-    blocks = [f"# MarinDNA research updates — week of {date_label}"]
+    blocks = [
+        f"# MarinDNA research updates — week of {date_label}",
+        BLURB_PLACEHOLDER,
+    ]
     for page in pages:
         url = canonical_page_url(repository_url, branch, page.path)
-        blocks.append(f"**[{page.title}]({url})**\n\n{page.tldr}")
+        blocks.append(
+            f"**[{page.title} (#{page.issue_number})]({url})**\n\n{page.tldr}"
+        )
     return "\n\n".join(blocks) + "\n"
+
+
+def write_temporary_draft(
+    week_start: date,
+    draft: str,
+    directory: Path | None = None,
+) -> Path:
+    """Write a draft to a private temporary Markdown file."""
+
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        prefix=f"marindna-research-updates-{week_start.isoformat()}-",
+        suffix=".md",
+        dir=directory,
+        delete=False,
+    ) as output:
+        output.write(draft)
+        return Path(output.name)
 
 
 def parse_args() -> argparse.Namespace:
@@ -218,7 +256,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
-    """Generate the draft and print omissions to standard error."""
+    """Write the draft to a temporary file and print its path."""
 
     args = parse_args()
     start, end = weekly_boundaries(args.week_start)
@@ -229,20 +267,21 @@ def main() -> int:
         page = extract_page(path, read_page_at_commit(args.repo_root, end_commit, path))
         if page is None:
             print(
-                f"WARNING: omitted {path}: missing H1 title or TL;DR callout",
+                f"WARNING: omitted {path}: missing issue-number filename, H1 title, "
+                "or TL;DR callout",
                 file=sys.stderr,
             )
             continue
         pages.append(page)
 
-    sys.stdout.write(
-        format_draft(
-            week_start=args.week_start,
-            pages=pages,
-            repository_url=args.repository_url,
-            branch=args.branch,
-        )
+    draft = format_draft(
+        week_start=args.week_start,
+        pages=pages,
+        repository_url=args.repository_url,
+        branch=args.branch,
     )
+    if draft:
+        print(write_temporary_draft(args.week_start, draft))
     return 0
 
 

--- a/.agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py
+++ b/.agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py
@@ -16,7 +16,7 @@ EXPERIMENTS_DIR = PurePosixPath("docs/research/experiments")
 TITLE_RE = re.compile(r"^#\s+(.+?)\s*$")
 TLDR_RE = re.compile(r"^>\s*\*\*TL;DR:\*\*\s*(.*)$")
 EXPERIMENT_NUMBER_RE = re.compile(r"^(\d+)-")
-REPORT_TIMEZONE = ZoneInfo("America/New_York")
+REPORT_TIMEZONE = ZoneInfo("UTC")
 
 
 @dataclass(frozen=True)
@@ -41,7 +41,7 @@ def run_git(repo_root: Path, *args: str) -> str:
 
 
 def weekly_boundaries(week_start: date) -> tuple[datetime, datetime]:
-    """Return the inclusive start and exclusive end of a New York week."""
+    """Return the inclusive start and exclusive end of a UTC week."""
 
     if week_start.weekday() != 0:
         raise ValueError(f"Week start must be a Monday: {week_start.isoformat()}")

--- a/.agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py
+++ b/.agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py
@@ -1,0 +1,228 @@
+"""Build a weekly draft from newly added research experiment pages."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta
+from pathlib import Path, PurePosixPath
+from urllib.parse import quote
+from zoneinfo import ZoneInfo
+
+EXPERIMENTS_DIR = PurePosixPath("docs/research/experiments")
+TITLE_RE = re.compile(r"^#\s+(.+?)\s*$")
+TLDR_RE = re.compile(r"^>\s*\*\*TL;DR:\*\*\s*(.*)$")
+EXPERIMENT_NUMBER_RE = re.compile(r"^(\d+)-")
+REPORT_TIMEZONE = ZoneInfo("America/New_York")
+
+
+@dataclass(frozen=True)
+class ExperimentPage:
+    """The public fields extracted from one canonical experiment page."""
+
+    path: str
+    title: str
+    tldr: str
+
+
+def run_git(repo_root: Path, *args: str) -> str:
+    """Run Git and return decoded standard output."""
+
+    completed = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout
+
+
+def weekly_boundaries(week_start: date) -> tuple[datetime, datetime]:
+    """Return the inclusive start and exclusive end of a New York week."""
+
+    if week_start.weekday() != 0:
+        raise ValueError(f"Week start must be a Monday: {week_start.isoformat()}")
+    start = datetime.combine(week_start, time.min, tzinfo=REPORT_TIMEZONE)
+    return start, start + timedelta(days=7)
+
+
+def commit_before(repo_root: Path, ref: str, boundary: datetime) -> str:
+    """Resolve the last first-parent commit before a time boundary."""
+
+    commit = run_git(
+        repo_root,
+        "rev-list",
+        "-1",
+        "--first-parent",
+        f"--before={boundary.isoformat()}",
+        ref,
+    ).strip()
+    if not commit:
+        raise RuntimeError(f"No commit on {ref} exists before {boundary.isoformat()}")
+    return commit
+
+
+def new_experiment_paths(
+    repo_root: Path,
+    ref: str,
+    start: datetime,
+    end: datetime,
+) -> tuple[str, list[str]]:
+    """Return the end snapshot and experiment pages added during the window."""
+
+    start_commit = commit_before(repo_root, ref, start)
+    end_commit = commit_before(repo_root, ref, end)
+    if start_commit == end_commit:
+        return end_commit, []
+
+    changed = run_git(
+        repo_root,
+        "diff",
+        "--name-status",
+        "--diff-filter=A",
+        start_commit,
+        end_commit,
+        "--",
+        str(EXPERIMENTS_DIR),
+    )
+
+    paths: list[str] = []
+    for line in changed.splitlines():
+        status, separator, raw_path = line.partition("\t")
+        if status != "A" or not separator:
+            continue
+        path = PurePosixPath(raw_path)
+        if path.parent == EXPERIMENTS_DIR and path.suffix == ".md":
+            paths.append(raw_path)
+
+    return end_commit, sorted(paths, key=experiment_sort_key)
+
+
+def experiment_sort_key(path: str) -> tuple[int, int | str]:
+    """Sort numbered experiment pages numerically, then any fallback paths."""
+
+    filename = PurePosixPath(path).name
+    match = EXPERIMENT_NUMBER_RE.match(filename)
+    if match:
+        return 0, int(match.group(1))
+    return 1, path
+
+
+def extract_page(path: str, markdown: str) -> ExperimentPage | None:
+    """Extract the H1 title and canonical TL;DR callout text."""
+
+    lines = markdown.splitlines()
+    title = next(
+        (match.group(1) for line in lines if (match := TITLE_RE.match(line))), None
+    )
+    if title is None:
+        return None
+
+    for index, line in enumerate(lines):
+        match = TLDR_RE.match(line)
+        if match is None:
+            continue
+
+        tldr_lines = [match.group(1)]
+        for continuation in lines[index + 1 :]:
+            if not continuation.startswith(">"):
+                break
+            text = continuation[1:]
+            text = text.removeprefix(" ")
+            tldr_lines.append(text)
+
+        while tldr_lines and not tldr_lines[-1]:
+            tldr_lines.pop()
+        tldr = "\n".join(tldr_lines).strip()
+        if tldr:
+            return ExperimentPage(path=path, title=title, tldr=tldr)
+        return None
+
+    return None
+
+
+def read_page_at_commit(repo_root: Path, commit: str, path: str) -> str:
+    """Read one page from a Git snapshot."""
+
+    return run_git(repo_root, "show", f"{commit}:{path}")
+
+
+def canonical_page_url(repository_url: str, branch: str, path: str) -> str:
+    """Build the moving canonical GitHub URL for an experiment page."""
+
+    base = repository_url.rstrip("/")
+    return f"{base}/blob/{quote(branch, safe='')}/{quote(path, safe='/')}"
+
+
+def format_draft(
+    week_start: date,
+    pages: list[ExperimentPage],
+    repository_url: str,
+    branch: str,
+) -> str:
+    """Format the Discord-ready Markdown draft."""
+
+    if not pages:
+        return ""
+
+    date_label = f"{week_start.strftime('%B')} {week_start.day}, {week_start.year}"
+    blocks = [f"# MarinDNA research updates — week of {date_label}"]
+    for page in pages:
+        url = canonical_page_url(repository_url, branch, page.path)
+        blocks.append(f"**[{page.title}]({url})**\n\n{page.tldr}")
+    return "\n\n".join(blocks) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--week-start",
+        required=True,
+        type=date.fromisoformat,
+        help="Monday starting the report window, in YYYY-MM-DD form.",
+    )
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--ref", default="origin/main")
+    parser.add_argument("--branch", default="main")
+    parser.add_argument(
+        "--repository-url", default="https://github.com/Open-Athena/marin-dna"
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Generate the draft and print omissions to standard error."""
+
+    args = parse_args()
+    start, end = weekly_boundaries(args.week_start)
+    end_commit, paths = new_experiment_paths(args.repo_root, args.ref, start, end)
+
+    pages: list[ExperimentPage] = []
+    for path in paths:
+        page = extract_page(path, read_page_at_commit(args.repo_root, end_commit, path))
+        if page is None:
+            print(
+                f"WARNING: omitted {path}: missing H1 title or TL;DR callout",
+                file=sys.stderr,
+            )
+            continue
+        pages.append(page)
+
+    sys.stdout.write(
+        format_draft(
+            week_start=args.week_start,
+            pages=pages,
+            repository_url=args.repository_url,
+            branch=args.branch,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py
+++ b/.agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py
@@ -83,6 +83,7 @@ def new_experiment_paths(
         repo_root,
         "diff",
         "--name-status",
+        "--find-renames",
         "--diff-filter=A",
         start_commit,
         end_commit,

--- a/tests/test_weekly_research_update.py
+++ b/tests/test_weekly_research_update.py
@@ -146,6 +146,30 @@ def test_new_experiment_paths_uses_weekly_main_snapshots(tmp_path: Path) -> None
     )
 
 
+def test_new_experiment_paths_excludes_restored_page(tmp_path: Path) -> None:
+    run_git(tmp_path, "init", "--initial-branch=main")
+    run_git(tmp_path, "config", "user.name", "Test User")
+    run_git(tmp_path, "config", "user.email", "test@example.com")
+
+    path = "docs/research/experiments/100-restored.md"
+    content = "# Restored\n\n> **TL;DR:** Already announced.\n"
+    commit_file(tmp_path, path, content, "2026-08-10T12:00:00+00:00")
+    run_git(tmp_path, "rm", path)
+    run_git(
+        tmp_path,
+        "commit",
+        "-m",
+        "Remove experiment page",
+        commit_date="2026-08-16T12:00:00+00:00",
+    )
+    commit_file(tmp_path, path, content, "2026-08-18T12:00:00+00:00")
+
+    start, end = weekly.weekly_boundaries(date(2026, 8, 17))
+    _, paths = weekly.new_experiment_paths(tmp_path, "HEAD", start, end)
+
+    assert paths == []
+
+
 def test_format_draft_no_content_and_links_canonical_page() -> None:
     pages = [
         weekly.ExperimentPage(

--- a/tests/test_weekly_research_update.py
+++ b/tests/test_weekly_research_update.py
@@ -226,11 +226,11 @@ def test_format_draft_no_content_and_links_canonical_page() -> None:
         "main",
     ) == (
         "# MarinDNA research updates — week of August 17, 2026\n\n"
-        "> **Weekly blurb:** _Add a short human-written introduction before "
-        "publishing._\n\n"
         "**[Second result (#20)](https://github.com/Open-Athena/marin-dna/blob/main/"
         "docs/research/experiments/20-second.md)**\n\n"
-        "A result.\n"
+        "A result.\n\n"
+        "> **Blurb:** _Add a short human-written note about this experiment before "
+        "publishing._\n"
     )
 
 

--- a/tests/test_weekly_research_update.py
+++ b/tests/test_weekly_research_update.py
@@ -94,43 +94,43 @@ def test_new_experiment_paths_uses_weekly_main_snapshots(tmp_path: Path) -> None
         tmp_path,
         "docs/research/experiments/100-existing.md",
         "# Existing\n\n> **TL;DR:** Old.\n",
-        "2026-08-16T20:00:00-04:00",
+        "2026-08-16T23:00:00+00:00",
     )
     commit_file(
         tmp_path,
         "docs/research/experiments/201-at-start.md",
         "# At start\n\n> **TL;DR:** At start.\n",
-        "2026-08-17T00:00:00-04:00",
+        "2026-08-17T00:00:00+00:00",
     )
     commit_file(
         tmp_path,
         "docs/research/experiments/200-new.md",
         "# New\n\n> **TL;DR:** New.\n",
-        "2026-08-18T12:00:00-04:00",
+        "2026-08-18T12:00:00+00:00",
     )
     commit_file(
         tmp_path,
         "docs/research/experiments/100-existing.md",
         "# Existing\n\n> **TL;DR:** Edited.\n",
-        "2026-08-19T12:00:00-04:00",
+        "2026-08-19T12:00:00+00:00",
     )
     commit_file(
         tmp_path,
         "docs/research/experiments/figures/200/plot.svg",
         "<svg />\n",
-        "2026-08-20T12:00:00-04:00",
+        "2026-08-20T12:00:00+00:00",
     )
     commit_file(
         tmp_path,
         "docs/research/experiments/299-at-end.md",
         "# At end\n\n> **TL;DR:** At end.\n",
-        "2026-08-24T00:00:00-04:00",
+        "2026-08-24T00:00:00+00:00",
     )
     commit_file(
         tmp_path,
         "docs/research/experiments/300-late.md",
         "# Late\n\n> **TL;DR:** Late.\n",
-        "2026-08-24T01:00:00-04:00",
+        "2026-08-24T01:00:00+00:00",
     )
 
     start, end = weekly.weekly_boundaries(date(2026, 8, 17))

--- a/tests/test_weekly_research_update.py
+++ b/tests/test_weekly_research_update.py
@@ -228,8 +228,8 @@ def test_format_draft_no_content_and_links_canonical_page() -> None:
         "# MarinDNA research updates — week of August 17, 2026\n\n"
         "**[Second result (#20)](https://github.com/Open-Athena/marin-dna/blob/main/"
         "docs/research/experiments/20-second.md)**\n\n"
-        "> **Blurb:** _Add a short human-written note about this experiment before "
-        "publishing._\n\n"
+        "> **Blurb (replace with contributor name):** _Add a short human-written "
+        "note about this experiment before publishing._\n\n"
         "A result.\n"
     )
 

--- a/tests/test_weekly_research_update.py
+++ b/tests/test_weekly_research_update.py
@@ -70,6 +70,7 @@ Ignored.
 
     assert page == weekly.ExperimentPage(
         path="docs/research/experiments/123-example.md",
+        issue_number=123,
         title="Example experiment",
         tldr="The first sentence is retained.\nThe second sentence is retained too.",
     )
@@ -78,6 +79,13 @@ Ignored.
 def test_extract_page_requires_title_and_tldr() -> None:
     assert weekly.extract_page("missing-title.md", "> **TL;DR:** Result.\n") is None
     assert weekly.extract_page("missing-tldr.md", "# Result\n") is None
+    assert (
+        weekly.extract_page(
+            "docs/research/experiments/unnumbered.md",
+            "# Result\n\n> **TL;DR:** Result.\n",
+        )
+        is None
+    )
 
 
 def test_weekly_boundaries_requires_monday() -> None:
@@ -205,6 +213,7 @@ def test_format_draft_no_content_and_links_canonical_page() -> None:
     pages = [
         weekly.ExperimentPage(
             path="docs/research/experiments/20-second.md",
+            issue_number=20,
             title="Second result",
             tldr="A result.",
         )
@@ -217,10 +226,23 @@ def test_format_draft_no_content_and_links_canonical_page() -> None:
         "main",
     ) == (
         "# MarinDNA research updates — week of August 17, 2026\n\n"
-        "**[Second result](https://github.com/Open-Athena/marin-dna/blob/main/"
+        "> **Weekly blurb:** _Add a short human-written introduction before "
+        "publishing._\n\n"
+        "**[Second result (#20)](https://github.com/Open-Athena/marin-dna/blob/main/"
         "docs/research/experiments/20-second.md)**\n\n"
         "A result.\n"
     )
+
+
+def test_write_temporary_draft_creates_markdown_file(tmp_path: Path) -> None:
+    draft = "# Weekly draft\n"
+
+    output = weekly.write_temporary_draft(date(2026, 8, 17), draft, directory=tmp_path)
+
+    assert output.parent == tmp_path
+    assert output.name.startswith("marindna-research-updates-2026-08-17-")
+    assert output.suffix == ".md"
+    assert output.read_text() == draft
     assert (
         weekly.format_draft(
             date(2026, 8, 17), [], "https://github.com/Open-Athena/marin-dna", "main"

--- a/tests/test_weekly_research_update.py
+++ b/tests/test_weekly_research_update.py
@@ -228,9 +228,9 @@ def test_format_draft_no_content_and_links_canonical_page() -> None:
         "# MarinDNA research updates — week of August 17, 2026\n\n"
         "**[Second result (#20)](https://github.com/Open-Athena/marin-dna/blob/main/"
         "docs/research/experiments/20-second.md)**\n\n"
-        "A result.\n\n"
         "> **Blurb:** _Add a short human-written note about this experiment before "
-        "publishing._\n"
+        "publishing._\n\n"
+        "A result.\n"
     )
 
 

--- a/tests/test_weekly_research_update.py
+++ b/tests/test_weekly_research_update.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).parents[1]
+    / ".agents/skills/draft-weekly-research-update/scripts/draft_weekly_research_update.py"
+)
+
+
+def load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "draft_weekly_research_update", SCRIPT_PATH
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+weekly = load_script()
+
+
+def run_git(repo: Path, *args: str, commit_date: str | None = None) -> str:
+    env = os.environ.copy()
+    if commit_date is not None:
+        env["GIT_AUTHOR_DATE"] = commit_date
+        env["GIT_COMMITTER_DATE"] = commit_date
+    completed = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return completed.stdout
+
+
+def commit_file(repo: Path, path: str, content: str, commit_date: str) -> None:
+    destination = repo / path
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(content)
+    run_git(repo, "add", path)
+    run_git(repo, "commit", "-m", f"Update {path}", commit_date=commit_date)
+
+
+def test_extract_page_reads_multiline_tldr_callout() -> None:
+    page = weekly.extract_page(
+        "docs/research/experiments/123-example.md",
+        """# Example experiment
+
+> [!NOTE]
+> **TL;DR:** The first sentence is retained.
+> The second sentence is retained too.
+
+## Findings
+Ignored.
+""",
+    )
+
+    assert page == weekly.ExperimentPage(
+        path="docs/research/experiments/123-example.md",
+        title="Example experiment",
+        tldr="The first sentence is retained.\nThe second sentence is retained too.",
+    )
+
+
+def test_extract_page_requires_title_and_tldr() -> None:
+    assert weekly.extract_page("missing-title.md", "> **TL;DR:** Result.\n") is None
+    assert weekly.extract_page("missing-tldr.md", "# Result\n") is None
+
+
+def test_weekly_boundaries_requires_monday() -> None:
+    with pytest.raises(ValueError, match="must be a Monday"):
+        weekly.weekly_boundaries(date(2026, 8, 18))
+
+
+def test_new_experiment_paths_uses_weekly_main_snapshots(tmp_path: Path) -> None:
+    run_git(tmp_path, "init", "--initial-branch=main")
+    run_git(tmp_path, "config", "user.name", "Test User")
+    run_git(tmp_path, "config", "user.email", "test@example.com")
+
+    commit_file(
+        tmp_path,
+        "docs/research/experiments/100-existing.md",
+        "# Existing\n\n> **TL;DR:** Old.\n",
+        "2026-08-16T20:00:00-04:00",
+    )
+    commit_file(
+        tmp_path,
+        "docs/research/experiments/200-new.md",
+        "# New\n\n> **TL;DR:** New.\n",
+        "2026-08-18T12:00:00-04:00",
+    )
+    commit_file(
+        tmp_path,
+        "docs/research/experiments/100-existing.md",
+        "# Existing\n\n> **TL;DR:** Edited.\n",
+        "2026-08-19T12:00:00-04:00",
+    )
+    commit_file(
+        tmp_path,
+        "docs/research/experiments/figures/200/plot.svg",
+        "<svg />\n",
+        "2026-08-20T12:00:00-04:00",
+    )
+    commit_file(
+        tmp_path,
+        "docs/research/experiments/300-late.md",
+        "# Late\n\n> **TL;DR:** Late.\n",
+        "2026-08-24T01:00:00-04:00",
+    )
+
+    start, end = weekly.weekly_boundaries(date(2026, 8, 17))
+    end_commit, paths = weekly.new_experiment_paths(tmp_path, "HEAD", start, end)
+
+    assert paths == ["docs/research/experiments/200-new.md"]
+    assert (
+        weekly.read_page_at_commit(tmp_path, end_commit, paths[0])
+        == "# New\n\n> **TL;DR:** New.\n"
+    )
+
+
+def test_format_draft_no_content_and_links_canonical_page() -> None:
+    pages = [
+        weekly.ExperimentPage(
+            path="docs/research/experiments/20-second.md",
+            title="Second result",
+            tldr="A result.",
+        )
+    ]
+
+    assert weekly.format_draft(
+        date(2026, 8, 17),
+        pages,
+        "https://github.com/Open-Athena/marin-dna",
+        "main",
+    ) == (
+        "# MarinDNA research updates — week of August 17, 2026\n\n"
+        "**[Second result](https://github.com/Open-Athena/marin-dna/blob/main/"
+        "docs/research/experiments/20-second.md)**\n\n"
+        "A result.\n"
+    )
+    assert (
+        weekly.format_draft(
+            date(2026, 8, 17), [], "https://github.com/Open-Athena/marin-dna", "main"
+        )
+        == ""
+    )
+
+
+def test_experiment_sort_key_uses_numeric_prefix() -> None:
+    paths = [
+        "docs/research/experiments/100-later.md",
+        "docs/research/experiments/20-earlier.md",
+        "docs/research/experiments/unnumbered.md",
+    ]
+
+    assert sorted(paths, key=weekly.experiment_sort_key) == [
+        "docs/research/experiments/20-earlier.md",
+        "docs/research/experiments/100-later.md",
+        "docs/research/experiments/unnumbered.md",
+    ]

--- a/tests/test_weekly_research_update.py
+++ b/tests/test_weekly_research_update.py
@@ -170,6 +170,37 @@ def test_new_experiment_paths_excludes_restored_page(tmp_path: Path) -> None:
     assert paths == []
 
 
+def test_new_experiment_paths_excludes_rename_with_detection_disabled(
+    tmp_path: Path,
+) -> None:
+    run_git(tmp_path, "init", "--initial-branch=main")
+    run_git(tmp_path, "config", "user.name", "Test User")
+    run_git(tmp_path, "config", "user.email", "test@example.com")
+    run_git(tmp_path, "config", "diff.renames", "false")
+
+    old_path = "docs/research/experiments/100-old-name.md"
+    new_path = "docs/research/experiments/100-new-name.md"
+    commit_file(
+        tmp_path,
+        old_path,
+        "# Renamed\n\n> **TL;DR:** Already announced.\n",
+        "2026-08-16T12:00:00+00:00",
+    )
+    run_git(tmp_path, "mv", old_path, new_path)
+    run_git(
+        tmp_path,
+        "commit",
+        "-m",
+        "Rename experiment page",
+        commit_date="2026-08-18T12:00:00+00:00",
+    )
+
+    start, end = weekly.weekly_boundaries(date(2026, 8, 17))
+    _, paths = weekly.new_experiment_paths(tmp_path, "HEAD", start, end)
+
+    assert paths == []
+
+
 def test_format_draft_no_content_and_links_canonical_page() -> None:
     pages = [
         weekly.ExperimentPage(

--- a/tests/test_weekly_research_update.py
+++ b/tests/test_weekly_research_update.py
@@ -98,6 +98,12 @@ def test_new_experiment_paths_uses_weekly_main_snapshots(tmp_path: Path) -> None
     )
     commit_file(
         tmp_path,
+        "docs/research/experiments/201-at-start.md",
+        "# At start\n\n> **TL;DR:** At start.\n",
+        "2026-08-17T00:00:00-04:00",
+    )
+    commit_file(
+        tmp_path,
         "docs/research/experiments/200-new.md",
         "# New\n\n> **TL;DR:** New.\n",
         "2026-08-18T12:00:00-04:00",
@@ -116,6 +122,12 @@ def test_new_experiment_paths_uses_weekly_main_snapshots(tmp_path: Path) -> None
     )
     commit_file(
         tmp_path,
+        "docs/research/experiments/299-at-end.md",
+        "# At end\n\n> **TL;DR:** At end.\n",
+        "2026-08-24T00:00:00-04:00",
+    )
+    commit_file(
+        tmp_path,
         "docs/research/experiments/300-late.md",
         "# Late\n\n> **TL;DR:** Late.\n",
         "2026-08-24T01:00:00-04:00",
@@ -124,7 +136,10 @@ def test_new_experiment_paths_uses_weekly_main_snapshots(tmp_path: Path) -> None
     start, end = weekly.weekly_boundaries(date(2026, 8, 17))
     end_commit, paths = weekly.new_experiment_paths(tmp_path, "HEAD", start, end)
 
-    assert paths == ["docs/research/experiments/200-new.md"]
+    assert paths == [
+        "docs/research/experiments/200-new.md",
+        "docs/research/experiments/201-at-start.md",
+    ]
     assert (
         weekly.read_page_at_commit(tmp_path, end_commit, paths[0])
         == "# New\n\n> **TL;DR:** New.\n"


### PR DESCRIPTION
Add a repository skill that writes a temporary Markdown draft from experiment interpretation pages first added to `main` during the preceding Monday–Sunday UTC window. Each title includes its originating issue number inside the canonical experiment-page link, each TL;DR is copied unchanged, and every experiment has a generic placeholder for a human-written blurb.

A skill-local Python extractor fixes the Git boundary, numeric ordering, Markdown extraction, canonical-link, empty-week, missing-field, restored-page, and renamed-page behavior. It produced the expected seven-item draft file for August 17–23, and the root test suite passes with 124 tests passed and 1 skipped.

The recurring Codex task will be configured after this merges so scheduled runs depend only on `main`.