### PR TITLE
Register issue #517 terminal VEP evaluations

### DIFF
--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -234,6 +234,20 @@ uv run --locked --group genome-s3 snakemake
 The default profile (`workflow/profiles/default/config.yaml`) uses S3 storage
 at `s3://oa-bolinas/snakemake/analysis/evals_v2/`.
 
+### Issue #517 GPN uniform terminal specialists
+
+`config/issue517_gpn_uniform.yaml` registers the six GPN-Star-P-filtered uniform-grid specialists at terminal step 4,999.
+It reads only the development `train` splits and removes complete mature-miRNA match groups from Mendelian metrics.
+Each arm runs Mendelian Traits and Complex Traits; CDS also runs the biologically scoped SGE evaluation.
+Launch one model-dataset target per Sky cluster so completed arms can begin evaluation independently:
+
+```bash
+sky launch sky/run.yaml \
+  -c evals-v2-exp517-gpn-cds-mendelian \
+  --env SNAKEMAKE_ARGS="--configfile config/issue517_gpn_uniform.yaml -- results/metrics/exp517-gpn-uniform-cds-step-4999/mendelian_traits.parquet" \
+  --down
+```
+
 ### Issue #417 repair trajectory and #473 validation control
 
 The default `all` target includes nine checkpoints from the repaired issue #417 CDS full-window trajectory at steps 1,000 through 4,999 and the terminal issue #473 CDS full-window random-validation control.

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -1316,6 +1316,33 @@ models:
     window_size: 256
     datasets: [mendelian_traits]
 
+  # Issue #517 GPN-Star-P-filtered uniform-grid specialists.
+  # Register only the terminal checkpoints selected for development VEP evaluation.
+  - name: exp517-gpn-uniform-cds-step-4999
+    gcs_path: gs://marin-us-east5/MarinDNA/exp517_gpn_uniform_specialists/checkpoints/dna-exp517-gpn-uniform-0p25b-cds-v1/2026.08.26/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits, sge]
+  - name: exp517-gpn-uniform-utr3-step-4999
+    gcs_path: gs://marin-us-east5/MarinDNA/exp517_gpn_uniform_specialists/checkpoints/dna-exp517-gpn-uniform-0p25b-utr3-v1/2026.08.26/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits]
+  - name: exp517-gpn-uniform-tss-utr5-step-4999
+    gcs_path: gs://marin-us-east5/MarinDNA/exp517_gpn_uniform_specialists/checkpoints/dna-exp517-gpn-uniform-0p25b-tss_utr5-v1/2026.08.26/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits]
+  - name: exp517-gpn-uniform-ncrna-exon-step-4999
+    gcs_path: gs://marin-us-east5/MarinDNA/exp517_gpn_uniform_specialists/checkpoints/dna-exp517-gpn-uniform-0p25b-ncrna_exon-v1/2026.08.26/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits]
+  - name: exp517-gpn-uniform-enhancer-arm-a-step-4999
+    gcs_path: gs://marin-us-east5/MarinDNA/exp517_gpn_uniform_specialists/checkpoints/dna-exp517-gpn-uniform-0p25b-enhancer_arm_a-v1/2026.08.26/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits]
+  - name: exp517-gpn-uniform-background-step-4999
+    gcs_path: gs://marin-us-east5/MarinDNA/exp517_gpn_uniform_specialists/checkpoints/dna-exp517-gpn-uniform-0p25b-background-v1/2026.08.26/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits]
+
 inference:
   batch_size: 128       # Was 64 with output_hidden_states=True keeping all
                         # 19+2 layers' activations alive (~2.6 GB at L=256,

--- a/snakemake/analysis/evals_v2/config/issue517_gpn_uniform.yaml
+++ b/snakemake/analysis/evals_v2/config/issue517_gpn_uniform.yaml
@@ -1,0 +1,74 @@
+# Issue 517 development-only terminal GPN-Star-P uniform-grid evaluation.
+# This config reads only the pinned VEP development splits.
+# Do not change `split` or add held-out datasets without explicit authorization.
+
+input_hf_prefix: bolinas-dna/evals
+genome_path: s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz
+split: train
+
+datasets:
+  - name: mendelian_traits
+    hf_revision: 4aed58e50c5dea0b878a665007af2ef9e5108e9f
+    score_protocol: minus_llr
+    exclude_complete_match_groups_with_subsets: [mature_miRNA_variant]
+  - name: complex_traits
+    hf_revision: 22f86a89c65cb8f3007ac3cc2739f40efefa4340
+    score_protocol: abs_llr
+  - name: sge
+    hf_revision: 225d3d1ea32a4af547891b13c33b5e92a5aae849
+    score_protocol: minus_llr
+    eval_protocol: sge
+
+models:
+  - name: exp517-gpn-uniform-cds-step-4999
+    gcs_path: gs://marin-us-east5/MarinDNA/exp517_gpn_uniform_specialists/checkpoints/dna-exp517-gpn-uniform-0p25b-cds-v1/2026.08.26/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits, sge]
+
+  - name: exp517-gpn-uniform-utr3-step-4999
+    gcs_path: gs://marin-us-east5/MarinDNA/exp517_gpn_uniform_specialists/checkpoints/dna-exp517-gpn-uniform-0p25b-utr3-v1/2026.08.26/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits]
+
+  - name: exp517-gpn-uniform-tss-utr5-step-4999
+    gcs_path: gs://marin-us-east5/MarinDNA/exp517_gpn_uniform_specialists/checkpoints/dna-exp517-gpn-uniform-0p25b-tss_utr5-v1/2026.08.26/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits]
+
+  - name: exp517-gpn-uniform-ncrna-exon-step-4999
+    gcs_path: gs://marin-us-east5/MarinDNA/exp517_gpn_uniform_specialists/checkpoints/dna-exp517-gpn-uniform-0p25b-ncrna_exon-v1/2026.08.26/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits]
+
+  - name: exp517-gpn-uniform-enhancer-arm-a-step-4999
+    gcs_path: gs://marin-us-east5/MarinDNA/exp517_gpn_uniform_specialists/checkpoints/dna-exp517-gpn-uniform-0p25b-enhancer_arm_a-v1/2026.08.26/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits]
+
+  - name: exp517-gpn-uniform-background-step-4999
+    gcs_path: gs://marin-us-east5/MarinDNA/exp517_gpn_uniform_specialists/checkpoints/dna-exp517-gpn-uniform-0p25b-background-v1/2026.08.26/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits]
+
+inference:
+  batch_size: 128
+  num_workers: 4
+  data_transform_on_the_fly: true
+  torch_compile: true
+  bf16: true
+  rc: true
+  return_embeddings: true
+  eval_accumulation_steps: null
+  n_bootstrap: 1000
+  bootstrap_seed: 0
+
+# The command-line config extends config/config.yaml.
+# Disable unrelated off-rule-all registries whose models are absent here.
+probe:
+  models: []
+nuc_dep:
+  models: []
+umap_embeddings:
+  models: []
+ll_gap:
+  models: []


### PR DESCRIPTION
Supports #517.

Registers the six GPN-Star-P-filtered uniform-grid specialists at terminal step 4,999 for development VEP evaluation. The dedicated config uses only the pinned `train` splits. Every specialist runs Mendelian Traits and Complex Traits; CDS also runs SGE.

Validation:

- `31 passed` in the focused workflow, model-registry, Sky-task, and GPU-runtime tests.
- The exact CDS dry-run resolves one checkpoint download, three score jobs, and three metric jobs.

The full project suite reached 80% before it was stopped after slow failures across unrelated model tests; the focused launch-gate tests pass.