### PR TITLE
Add OpenMDW 1.1 license tag

### DIFF
--- a/.agents/skills/publish-to-hugging-face/SKILL.md
+++ b/.agents/skills/publish-to-hugging-face/SKILL.md
@@ -28,7 +28,8 @@ Use `manage-research-storage` first when the producing artifact does not already
 3. Prepare the README, model card, or dataset card before the first upload or a material metadata change.
 4. Set the card's `license` metadata to the verified license identified in step 2.
    Use `license: openmdw-1.1` for MarinDNA-trained models and processed datasets released under OpenMDW 1.1, and state the source-data terms and scope of the license in the card.
-   Use the source license tag or `license: other` for a repository whose primary contents retain source terms.
+   Use the source license tag for a repository whose primary contents retain source terms.
+   If Hugging Face has no matching tag, use `license: other`, set `license_name`, and add `license_link` or a repository `LICENSE` file for those terms.
    Include a commit-pinned producing pipeline or training-script link, a concise provenance description, and the `biology`, `genomics`, and `dna` tags.
 5. Describe the file layout, formats, schemas, assemblies, sequence naming, coordinate conventions, and checksums that consumers need.
 

--- a/.agents/skills/publish-to-hugging-face/SKILL.md
+++ b/.agents/skills/publish-to-hugging-face/SKILL.md
@@ -26,7 +26,7 @@ Use `manage-research-storage` first when the producing artifact does not already
    Retain the exact publishable files under that owner, or retain a deterministic transformation from the authoritative artifact.
    In either case, create and validate a release manifest listing every published path, file size, and SHA-256 checksum before upload.
 3. Prepare the README, model card, or dataset card before the first upload or a material metadata change.
-4. Include a commit-pinned producing pipeline or training-script link, a concise provenance description, the artifact's intended use and important limitations, and the `biology`, `genomics`, and `dna` tags.
+4. Set `license: openmdw-1.1` in the card metadata, and include a commit-pinned producing pipeline or training-script link, a concise provenance description, the artifact's intended use and important limitations, and the `biology`, `genomics`, and `dna` tags.
 5. Describe the file layout, formats, schemas, assemblies, sequence naming, coordinate conventions, and checksums that consumers need.
 
 ## Publish Reproducibly

--- a/.agents/skills/publish-to-hugging-face/SKILL.md
+++ b/.agents/skills/publish-to-hugging-face/SKILL.md
@@ -26,7 +26,10 @@ Use `manage-research-storage` first when the producing artifact does not already
    Retain the exact publishable files under that owner, or retain a deterministic transformation from the authoritative artifact.
    In either case, create and validate a release manifest listing every published path, file size, and SHA-256 checksum before upload.
 3. Prepare the README, model card, or dataset card before the first upload or a material metadata change.
-4. Set `license: openmdw-1.1` in the card metadata, and include a commit-pinned producing pipeline or training-script link, a concise provenance description, and the `biology`, `genomics`, and `dna` tags.
+4. Set the card's `license` metadata to the verified license identified in step 2.
+   Use `license: openmdw-1.1` for MarinDNA-trained models and processed datasets released under OpenMDW 1.1, and state the source-data terms and scope of the license in the card.
+   Use the source license tag or `license: other` for a repository whose primary contents retain source terms.
+   Include a commit-pinned producing pipeline or training-script link, a concise provenance description, and the `biology`, `genomics`, and `dna` tags.
 5. Describe the file layout, formats, schemas, assemblies, sequence naming, coordinate conventions, and checksums that consumers need.
 
 ## Publish Reproducibly

--- a/.agents/skills/publish-to-hugging-face/SKILL.md
+++ b/.agents/skills/publish-to-hugging-face/SKILL.md
@@ -26,7 +26,7 @@ Use `manage-research-storage` first when the producing artifact does not already
    Retain the exact publishable files under that owner, or retain a deterministic transformation from the authoritative artifact.
    In either case, create and validate a release manifest listing every published path, file size, and SHA-256 checksum before upload.
 3. Prepare the README, model card, or dataset card before the first upload or a material metadata change.
-4. Set `license: openmdw-1.1` in the card metadata, and include a commit-pinned producing pipeline or training-script link, a concise provenance description, the artifact's intended use and important limitations, and the `biology`, `genomics`, and `dna` tags.
+4. Set `license: openmdw-1.1` in the card metadata, and include a commit-pinned producing pipeline or training-script link, a concise provenance description, and the `biology`, `genomics`, and `dna` tags.
 5. Describe the file layout, formats, schemas, assemblies, sequence naming, coordinate conventions, and checksums that consumers need.
 
 ## Publish Reproducibly


### PR DESCRIPTION
Set `license: openmdw-1.1` in Hugging Face card metadata for MarinDNA-trained models and processed datasets released under OpenMDW 1.1.
Preserve verified source terms for redistributed artifacts and scope OpenMDW coverage in mixed publications.
Use `license_name` plus `license_link` or a repository `LICENSE` file when Hugging Face requires `license: other`.
Stop requiring agent-authored intended-use and limitation prose in repository cards because agents do not produce it reliably.
Hugging Face lists [`openmdw-1.1`](https://huggingface.co/docs/hub/repositories-licenses) as the repository-card identifier for the Open Model, Data & Weights License Agreement v1.1.
