### PR TITLE
Add capacity-aware training sweep skills

### DIFF
--- a/.agents/skills/maintain-vendored-skills/SKILL.md
+++ b/.agents/skills/maintain-vendored-skills/SKILL.md
@@ -1,29 +1,34 @@
 ---
 name: maintain-vendored-skills
-description: Compare, refresh, and audit Marin-derived skills in MarinDNA. Use when checking the pinned Marin commit, showing exact upstream-to-local modifications, performing the monthly upstream review, updating vendored skills, or triaging newly available Marin skills.
+description: Compare, refresh, and audit externally derived skills in MarinDNA. Use when checking a pinned source commit, showing exact upstream-to-local modifications, performing the monthly upstream review, updating vendored skills, or triaging newly available upstream skills.
 ---
 
 # Maintain Vendored Skills
 
-Keep vendor maintenance out of normal task context. Load [references/manifest.json](references/manifest.json) only when comparing or updating Marin-derived skills.
+Keep vendor maintenance out of normal task context.
+Load the source-specific manifest under `references/` only when comparing or updating its vendored skills.
 
 ## Preserve The Vendor Boundary
 
-- Treat every skill listed under `unchanged` or `adapted` in the manifest as vendor-owned. Do not edit those skill directories in ordinary feature, documentation, or repository-guidance work.
+- Treat every skill listed under `unchanged` or `adapted` in a vendor manifest as vendor-owned. Do not edit those skill directories in ordinary feature, documentation, or repository-guidance work.
 - Change vendored content only in a dedicated vendor-maintenance task that explicitly owns the upstream comparison and provenance update.
 - Put MarinDNA-specific behavior in a local skill that composes with the vendored skill. The local skill may route to the vendor, add repository-specific constraints, or coordinate it with other skills.
 - Register composing skills under `local` in the manifest. If composition cannot express a required change, report the limitation and propose a vendor adaptation instead of modifying the vendor implicitly.
 
 ## Show Exact Modifications
 
-1. Obtain a Git checkout of the manifest's pinned Marin commit when possible. For a non-Git archive, retain the commit URL used to fetch it and pass its SHA with `--upstream-commit`; the report marks archive provenance as not independently verified.
+1. Select the vendor manifest and obtain a Git checkout of its pinned commit when possible. For a non-Git archive, retain the commit URL used to fetch it and pass its SHA with `--upstream-commit`; the report marks archive provenance as not independently verified.
 2. Run:
 
    ```bash
    python3 .agents/skills/maintain-vendored-skills/scripts/compare_upstream.py \
-     --upstream-root <marin-checkout> \
+     --manifest .agents/skills/maintain-vendored-skills/references/<source>-manifest.json \
+     --upstream-root <upstream-checkout> \
      --repo-root .
    ```
+
+   Omit `--manifest` only for the default Marin [manifest](references/manifest.json).
+   Run the comparison once per vendor manifest and matching checkout.
 
    For a non-Git archive, add `--upstream-commit <pinned-sha>`. A Git checkout verifies `HEAD` automatically.
 
@@ -33,7 +38,7 @@ Keep vendor maintenance out of normal task context. Load [references/manifest.js
 ## Refresh From Upstream
 
 1. Check for an existing vendor-update PR.
-2. Compare the pinned commit with current Marin `main`.
+2. Compare each selected manifest's pinned commit with its current upstream branch.
 3. Replace unchanged vendors byte-for-byte.
 4. Start each adapted vendor from the new upstream file, then reapply only the deviations in the manifest.
 5. Run the comparison script against the new upstream checkout and inspect every adapted diff.
@@ -45,4 +50,6 @@ Do not add newly discovered skills automatically. Report candidates with their p
 
 ## Monthly Review
 
-Use one external monthly Codex scheduled task. Compare current Marin `main`, run the exact-delta report, and scan the upstream skill catalog. Keep scheduling infrastructure outside the repository.
+Use one external monthly Codex scheduled task.
+Compare each vendored source's current branch, run its exact-delta report, and scan its skill catalog.
+Keep scheduling infrastructure outside the repository.

--- a/.agents/skills/maintain-vendored-skills/references/manifest.json
+++ b/.agents/skills/maintain-vendored-skills/references/manifest.json
@@ -5,7 +5,6 @@
   "unchanged": [
     "writing-style",
     "background-research",
-    "update-docs",
     "wandb-reporting"
   ],
   "adapted": [
@@ -13,21 +12,26 @@
       "name": "file-issue",
       "deviations": [
         "Replace the hard-coded upstream repository target with Open-Athena/marin-dna.",
-        "Replace the unavailable fix-issue style reference with writing-style."
+        "Replace the unavailable fix-issue style reference with writing-style.",
+        "Use MarinDNA's Kind, Topic, and metadata label taxonomy.",
+        "Compose experiment issues with maintain-knowledge-base disposition and run-research closure policy."
       ]
     },
     {
       "name": "run-research",
       "deviations": [
         "Use marin-experiment for MarinDNA long-running training jobs.",
-        "Replace unavailable optional See Also entries with MarinDNA research skills."
+        "Replace unavailable optional See Also entries with MarinDNA research skills.",
+        "Use the branch policy in AGENTS.md.",
+        "Promote accepted interpretations through maintain-knowledge-base and require its disposition before issue closure."
       ]
     },
     {
       "name": "task-logbook",
       "deviations": [
         "Require the robot prefix on every agent-authored GitHub comment.",
-        "Replace the unavailable commit-skill reference with AGENTS.md production commit rules."
+        "Replace the unavailable commit-skill reference with AGENTS.md production commit rules.",
+        "Promote accepted interpretations into MarinDNA's research knowledge base and record the disposition before closure."
       ]
     },
     {
@@ -35,12 +39,19 @@
       "deviations": [
         "Use Open-Athena/marin-dna in the pinned-logbook permalink example."
       ]
+    },
+    {
+      "name": "update-docs",
+      "deviations": [
+        "Route accepted research findings and their provenance through maintain-knowledge-base instead of generic experiment reports."
+      ]
     }
   ],
   "local": [
     "access-reference-genomes",
     "communicate-on-github",
     "develop-snakemake-pipelines",
+    "draft-weekly-research-update",
     "evaluate-models",
     "maintain-knowledge-base",
     "maintain-vendored-skills",

--- a/.agents/skills/maintain-vendored-skills/references/marinfold-manifest.json
+++ b/.agents/skills/maintain-vendored-skills/references/marinfold-manifest.json
@@ -1,0 +1,29 @@
+{
+  "upstream_repo": "Open-Athena/MarinFold",
+  "commit": "ac4a41b70e4b2b3900c4778f3f40b8418fab673f",
+  "vendored_on": "2026-08-27",
+  "unchanged": [],
+  "adapted": [
+    {
+      "name": "run-training-sweep-cw",
+      "deviations": [
+        "Compose sweep operation with MarinDNA's experiment setup, coherent-version, snapshot, and remote-compute approval policy.",
+        "Use MarinDNA W&B routing and dna-exp<N> run identity instead of the MarinFold project.",
+        "Require explicit approval and final lineage reporting before a trial resumes across accelerator families.",
+        "Replace the BUILD_DATE-only Iris freshness workaround with a coherent dependency update under marin-experiment.",
+        "Apply MarinDNA's Python lint and format rules to bundled helpers without changing behavior."
+      ]
+    },
+    {
+      "name": "run-training-sweep-trc",
+      "deviations": [
+        "Compose sweep operation with MarinDNA's experiment setup, coherent-version, snapshot, and remote-compute approval policy.",
+        "Use MarinDNA W&B run identity and the execution environment's supported time-based wakeup mechanism.",
+        "Require explicit approval and final lineage reporting before a trial resumes across accelerator families.",
+        "Replace the BUILD_DATE-only Iris freshness workaround with a coherent dependency update under marin-experiment.",
+        "Apply MarinDNA's Python lint and format rules to bundled helpers without changing behavior."
+      ]
+    }
+  ],
+  "local": []
+}

--- a/.agents/skills/maintain-vendored-skills/scripts/compare_upstream.py
+++ b/.agents/skills/maintain-vendored-skills/scripts/compare_upstream.py
@@ -10,12 +10,19 @@ import json
 import subprocess
 from pathlib import Path
 
+IGNORED_DIRECTORY_NAMES = {".pytest_cache", "__pycache__"}
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--upstream-root", type=Path, required=True)
     parser.add_argument("--upstream-commit")
     parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        help="Vendor manifest; defaults to references/manifest.json",
+    )
     parser.add_argument("--output", type=Path)
     return parser.parse_args()
 
@@ -24,14 +31,25 @@ def file_identity(data: bytes) -> str:
     return f"size={len(data)} sha256={hashlib.sha256(data).hexdigest()}"
 
 
-def directory_diff(upstream: Path, local: Path) -> str:
+def directory_diff(
+    upstream: Path,
+    local: Path,
+    upstream_label: str,
+    local_label: str,
+) -> str:
     upstream_files = {
         path.relative_to(upstream): path
         for path in upstream.rglob("*")
         if path.is_file()
+        and not IGNORED_DIRECTORY_NAMES.intersection(path.parts)
+        and path.suffix != ".pyc"
     }
     local_files = {
-        path.relative_to(local): path for path in local.rglob("*") if path.is_file()
+        path.relative_to(local): path
+        for path in local.rglob("*")
+        if path.is_file()
+        and not IGNORED_DIRECTORY_NAMES.intersection(path.parts)
+        and path.suffix != ".pyc"
     }
     chunks: list[str] = []
     for relative in sorted(upstream_files.keys() | local_files.keys()):
@@ -49,12 +67,12 @@ def directory_diff(upstream: Path, local: Path) -> str:
             continue
 
         upstream_name = (
-            f"marin/.agents/skills/{upstream.name}/{relative}"
+            f"{upstream_label}/.agents/skills/{upstream.name}/{relative}"
             if upstream_path is not None
             else "/dev/null"
         )
         local_name = (
-            f"marin-dna/.agents/skills/{local.name}/{relative}"
+            f"{local_label}/.agents/skills/{local.name}/{relative}"
             if local_path is not None
             else "/dev/null"
         )
@@ -147,7 +165,8 @@ def upstream_provenance(
 def main() -> int:
     args = parse_args()
     skill_root = Path(__file__).resolve().parents[1]
-    manifest = json.loads((skill_root / "references/manifest.json").read_text())
+    manifest_path = args.manifest or skill_root / "references/manifest.json"
+    manifest = json.loads(manifest_path.read_text())
     local_root = args.repo_root.resolve() / ".agents/skills"
     upstream_repo = manifest["upstream_repo"]
     expected_commit = manifest["commit"]
@@ -158,7 +177,7 @@ def main() -> int:
     )
 
     lines = [
-        "# Marin vendored-skill deltas",
+        f"# {upstream_repo} vendored-skill deltas",
         "",
         f"Expected upstream: `{upstream_repo}@{expected_commit}`",
         "",
@@ -178,7 +197,12 @@ def main() -> int:
             lines.append(f"- `{name}`: missing directory")
             errors.extend(f"missing skill directory: {path}" for path in missing)
             continue
-        diff = directory_diff(upstream_skill, local_skill)
+        diff = directory_diff(
+            upstream_skill,
+            local_skill,
+            upstream_repo,
+            "Open-Athena/marin-dna",
+        )
         state = "byte-identical" if not diff else "unexpected local diff"
         lines.append(f"- `{name}`: {state}")
         if diff:
@@ -210,7 +234,12 @@ def main() -> int:
             lines.extend(["Missing skill directory.", ""])
             errors.extend(f"missing skill directory: {path}" for path in missing)
             continue
-        diff = directory_diff(upstream_skill, local_skill)
+        diff = directory_diff(
+            upstream_skill,
+            local_skill,
+            upstream_repo,
+            "Open-Athena/marin-dna",
+        )
         if diff:
             lines.extend(["```diff", diff.rstrip(), "```", ""])
         else:

--- a/.agents/skills/marin-experiment/SKILL.md
+++ b/.agents/skills/marin-experiment/SKILL.md
@@ -1,11 +1,14 @@
 ---
 name: marin-experiment
-description: Set up, launch, monitor, and debug a Marin-launched DNA training or evaluation experiment on the shared iris cluster. Use when creating a new numbered experiment, packaging it as an independent locked project, choosing a current Marin dependency set, launching remote training, or diagnosing coordinator, worker, accelerator, or resume failures. Do not use for Snakemake pipelines or one-off analyses.
+description: Set up, launch, monitor, and debug a Marin-launched DNA training or evaluation experiment on the shared iris cluster. Use when creating a new numbered experiment, packaging it as an independent locked project, choosing a current Marin dependency set, launching remote training, or diagnosing coordinator, worker, accelerator, or resume failures. Use run-training-sweep-cw or run-training-sweep-trc for capacity-aware operation after a multi-trial catalog exists. Do not use for Snakemake pipelines or one-off analyses.
 ---
 
 # Marin Experiment
 
 Keep each experiment reproducible on its permanent branch. Use a self-contained directory with its own `pyproject.toml`, `uv.lock`, and launch module, and cite the resulting commit from the experiment issue.
+
+For a multi-trial sweep, use this skill to build and validate the experiment project.
+Once the trial catalog and one-trial launch command exist, route ongoing placement, recovery, and completion to `run-training-sweep-cw` or `run-training-sweep-trc`.
 
 ## Build A Self-Contained Project
 

--- a/.agents/skills/run-training-sweep-cw/SKILL.md
+++ b/.agents/skills/run-training-sweep-cw/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: run-training-sweep-cw
+description: Maximize sweep throughput and minimize wall-clock time to completion across CoreWeave H100 and GB200 GPUs. Use when a training sweep defines multiple configurations as trials and an agent must validate GPU gang profiles, use live fleet capacity, dispatch and recover Iris jobs, monitor W&B progress, persist execution state, and report until every trial finishes.
+---
+
+# Run CoreWeave GPU Training Sweep
+
+Finish the declared sweep as fast as possible without violating its operations document.
+
+Use approved CoreWeave GPU capacity at batch priority. Iris handles preemptions;
+do not replace a dispatch for a preemption alone—act from W&B progress and the
+recovery policy.
+
+## Contract
+
+- Treat each experiment-defined configuration as an opaque logical trial.
+- Let the training code own configuration and training semantics. Assume standard
+  W&B training fields; inspect code for launch, data, checkpoint, and gang behavior.
+- Keep one W&B and checkpoint identity per trial. Cluster, GPU type, and gang size
+  are placement, so reslicing preserves that identity.
+- Own only validation, placement, dispatch, monitoring, recovery, accounting, and reporting.
+- Never generate configurations or decide experimental convergence.
+- Compose with `marin-experiment` for project setup, coherent Marin and Iris
+  versions, snapshots, and launch authorization. This skill does not authorize
+  remote compute by itself.
+- Follow `wandb-reporting` for MarinDNA run, group, and project naming.
+- Do not move a trial between accelerator families unless the operator explicitly
+  allows it. Persist and report the resulting hardware lineage as a reproducibility
+  caveat.
+
+## State
+
+Keep each durable fact in one authoritative form:
+
+- **Operations (text):** policy, choices, constraints, exceptions, and operating
+  conclusions not reliably recovered from code or data.
+- **Experiment and helper code:** executable behavior.
+- **SQLite (data):** structured observations, identities, attempts, action results,
+  clocks, and history.
+
+Session chat is the interface, not state. Put heartbeat reports and decisions needing
+operator input there. Anything needed by a later heartbeat belongs in text, code, or
+data.
+
+Never restate code or configuration in Operations; prefer a source reference. Create
+no other experiment log, runbook, or recurring status file. Correct the authoritative
+form instead of adding a competing note.
+
+## Process
+
+Read every reference in this table before setup. It assigns ownership; later
+sections define the phase contracts.
+
+| Phase | Purpose | Detailed references |
+| --- | --- | --- |
+| Initialize | Gather choices and establish durable state | [operations.md](references/operations.md), [targets.md](references/targets.md), [persistence.md](references/persistence.md) |
+| Validate | Establish safe targets and launch behavior | [validation.md](references/validation.md) |
+| Operate | Observe, place, recover, report, and schedule | [execution.md](references/execution.md), [throughput.md](references/throughput.md), [persistence.md](references/persistence.md), [utilization.md](references/utilization.md) |
+| Finish | Verify completion, checkpoints, and integrity | [throughput.md](references/throughput.md), [persistence.md](references/persistence.md) |
+
+Use a valid [utilization snapshot](references/utilization.md) before dispatching or
+changing capacity. It informs placement; W&B remains the source of training progress.
+
+## Initialize
+
+### Interview Briefly
+
+Ask only for missing information. Offer the recommended answer first.
+
+1. **Training entry point and trial catalog.** Require both.
+2. **Time limit.** Recommend two weeks. Explain shorter means faster recovery;
+   longer is useful only when healthy trials need it.
+3. **Compute and GPU scope.** Require an explicitly approved remote-compute scope
+   and overall GPU limit before any smoke or production dispatch. Recommend the
+   limit from the training code and prior runs. Confirm whether to use both H100
+   and GB200, both H100 clusters (`cw-us-east-02a` and `cw-rno2a`), and GB200 on
+   `cw-us-east-08a`; recommend all three production clusters by default. Recommend
+   keeping cross-family reslicing disabled unless throughput outweighs the
+   reproducibility cost.
+4. **Sweep timing.** Recommend `heartbeat_every=30m`, `reslice_after=1h`, and
+   `restart_after=3h`. Ask whether to use the defaults.
+
+Create the document from [operations.md](references/operations.md). Default to
+`scratch/<sweep>/expXXX_operations.md`; offer a tracked experiment-side file only
+if requested. Build its candidate grid from [targets.md](references/targets.md), then
+initialize SQLite:
+
+```bash
+uv run .agents/skills/run-training-sweep-cw/scripts/persistence.py \
+  init scratch/<sweep>/expXXX_sweep.sqlite
+```
+
+## Validate
+
+Follow [validation.md](references/validation.md) before the first dispatch. Validate
+the experiment entry point, shared inputs and checkpoints, target compatibility,
+W&B observation, fleet visibility, and Iris submission. Submit only `eligible`
+targets and show the first assembled dispatch command to the operator.
+
+## Operate
+
+Run each heartbeat as a complete agent decision pass. Helpers may calculate or
+render facts; they may not choose or perform actions. Never delegate decisions to a
+monitor, dispatcher, scheduled loop, or recovery script.
+
+At every heartbeat:
+
+1. **Refresh context and inventory:** enter from authoritative state, not memory.
+   Reread Operations and relevant code, then build the inventory snapshot.
+2. **Observe, reconcile, decide, and act:** query W&B first, then exact Iris
+   liveness and fleet utilization. Persist observations, rebuild the decision
+   snapshot, and coordinate one fleet plan with [execution.md](references/execution.md).
+   Persist each result and replan after a material action.
+3. **Finish or continue:** if finished or out of time, stop, verify, and summarize.
+   Otherwise report in chat and schedule exactly one time-based next pass for
+   `heartbeat_every`. Never rely on event-based monitoring.
+
+Build inventory and decision snapshots with:
+
+```bash
+uv run .agents/skills/run-training-sweep-cw/scripts/persistence.py \
+  snapshot scratch/<sweep>/expXXX_sweep.sqlite --reslice-after-hours <hours>
+```
+
+Rebuild after material actions when needed. A snapshot is an ephemeral,
+decision-complete projection, not another status record.
+
+## Finish
+
+A trial finishes when `run_progress >= 1` and the expected checkpoint is reachable.
+W&B `finished` alone is insufficient.
+
+When every trial finishes or the time limit expires, stop remaining dispatches,
+verify completion and checkpoints, check SQLite integrity, and report the outcome as
+defined by [throughput.md](references/throughput.md). Include the accelerator and
+placement lineage for every trial that moved across hardware families. Do not
+schedule another pass.

--- a/.agents/skills/run-training-sweep-cw/agents/openai.yaml
+++ b/.agents/skills/run-training-sweep-cw/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Run CoreWeave GPU Training Sweep"
+  short_description: "Run and recover CoreWeave GPU training sweeps"
+  default_prompt: "Use $run-training-sweep-cw to launch and actively operate this CoreWeave GPU training sweep until it finishes."

--- a/.agents/skills/run-training-sweep-cw/references/execution.md
+++ b/.agents/skills/run-training-sweep-cw/references/execution.md
@@ -1,0 +1,101 @@
+# Execution
+
+## Use Four Identities
+
+- **Logical trial:** one opaque experiment configuration.
+- **Run:** the trial's single W&B and shared checkpoint identity.
+- **Dispatch:** one immutable Iris submission attempt.
+- **Target:** one allowed cluster, GPU variant, and gang size in Operations.
+
+Never parse W&B or Iris names.
+
+## Keep Iris Operations Simple
+
+Submit one exact unique root through `--cluster marin`, with an exact
+`--target-cluster`, `--priority batch`, and `--user`. Stop or inspect only an exact
+root, read [fleet utilization](utilization.md), and recognize exact
+`unschedulable` results.
+
+W&B is the truth for training progress. Iris reports execution and capacity, not
+progress. Inspect logs, parent/child details, retry history, or pending reasons only
+for a concrete failure or placement question.
+
+An Iris timeout or service failure blocks actions. Schedule one later pass that
+checks only Iris, then reconcile affected exact dispatches before resuming.
+
+## Use Visible Capacity
+
+Read one valid fleet snapshot after W&B observation and before building the fleet
+plan. At batch priority, use reported free GPUs; higher-priority holds explain the
+gap but are not available to reclaim. Never combine capacity from separate backends
+to fit one gang.
+
+Respect the operator's GPU cap and whole-node targets. Reserve capacity for every
+planned dispatch so later choices in the same pass cannot spend it again. Refresh
+utilization and replan after material stops or submissions. The scheduler remains
+the final admission authority, so treat submitted work as pending until W&B proves
+progress.
+
+Use credible free capacity to reduce wall-clock time. This may start unplaced trials
+or enlarge a healthy run when the expected benefit exceeds restart overhead. Let
+measured throughput and current progress override rough peak-FLOP equivalence.
+
+## Handle Unschedulable Targets
+
+On an unproven target, verify the requested cluster, GPU, nodes, and total GPUs.
+Record `target_unschedulable`, mark only that exact target `ineligible`, and reslice
+to another eligible target. If the target worked previously, investigate before
+changing eligibility; simultaneous results may indicate a systemic problem.
+
+## Make Every Dispatch Unique
+
+- Assign attempt numbers in SQLite and use a unique Iris root name.
+- Give every root one immutable dispatch row.
+- Stop and verify the current root before replacing it.
+- Allow at most one active dispatch per trial.
+
+Resume comes from the trial checkpoint, not the Iris name.
+
+## Classify Failures Before Retry
+
+Observe the whole W&B fleet before acting on a failed run. Retry an isolated failure
+from the same checkpoint after stopping its exact root. If failures recur or
+correlate across trials or targets, pause blind replacement and investigate a shared
+cause. Resume with a concrete basis, contain affected work, or ask the operator when
+the safe response is unclear.
+
+## Rebalance Every Heartbeat
+
+Use `heartbeat_every=30m`, `reslice_after=1h`, `restart_after=3h`, and
+`pending_target_limit=1` unless evidence warrants a change. Protect a dispatch with
+W&B progress inside `reslice_after`; consider every other dispatch for reslicing.
+Restart when neither moving nor progressing for `restart_after`. A replacement
+starts a new dispatch clock; the trial clock resets only on progress.
+
+A target's pending count is its active dispatches without recent progress. Treat a
+planned dispatch as pending until it proves progress, and keep the count at or below
+`pending_target_limit` when admitting it. This is an admission rule, not a reason to
+evict progressing work later.
+
+For each reslice candidate:
+
+1. Rank different eligible targets with valid free capacity and pending headroom.
+2. Combine `target_rate`, current progress, prior runs, gang fit, and useful exploration.
+3. Reslice when a credible target is better; otherwise restart the current target
+   when due or leave it unchanged with a concrete reason.
+
+- **Restart:** same cluster, GPU, nodes, and checkpoint; new dispatch.
+- **Reslice:** different cluster, GPU, or nodes; same run and checkpoint.
+
+Stop before replacing and replan after every material action. Never change priority
+to solve scarcity, and never replace a dispatch for preemption alone.
+
+## Handle Client Revision Rejections
+
+Apply this only when a submission says the Iris client is older than the required
+revision floor. Record `client_floor_failed`, then stop new submissions and
+recovery-driven stops. Follow `marin-experiment` to resolve a coherent current Marin
+and Iris dependency set, regenerate the lockfile, validate the launch import, and
+prove a canary submission is accepted. Do not change `BUILD_DATE` alone or restart
+the shared Iris cluster. If the dependency update is outside the approved task
+scope, stop and ask the operator with the reported and required dates.

--- a/.agents/skills/run-training-sweep-cw/references/operations.md
+++ b/.agents/skills/run-training-sweep-cw/references/operations.md
@@ -1,0 +1,76 @@
+# Operations
+
+Create one living `expXXX_operations.md` per sweep. Default to
+`scratch/<sweep>/`. The agent must read it completely at the start of every heartbeat.
+
+Use terse English for rules, choices, constraints, exceptions, and operating
+conclusions not reliably recovered from code or data. Never restate code or
+configuration; reference its source. Never write heartbeat observations, job
+status, progress, rankings, action queues, reports, or next-check times here.
+
+## Required Structure
+
+```markdown
+# expXXX CoreWeave Sweep Operations
+
+> This document governs a training sweep managed with the
+> `run-training-sweep-cw` skill. Read it in full at the start of every heartbeat
+> before inspecting code, SQLite, W&B, or Iris.
+
+## Invariants
+
+State the constraints that must hold throughout the sweep, including one writer
+per trial, shared checkpoint identity, whole-node gangs, and batch priority.
+
+## Sweep Definition
+
+Point to the training entry point and configuration catalog. State only input,
+initialization, checkpoint, or placement constraints not clear from code or SQLite.
+
+## Operator Choices
+
+Record the time limit, approved GPU limit, clusters, GPU families, exclusions,
+whether cross-family reslicing is allowed, Iris user, batch priority, and document
+location.
+
+## Operating Policy
+
+State `heartbeat_every`, `reslice_after`, `restart_after`, and
+`pending_target_limit`; isolated/systemic failure handling; reslicing; and
+completion behavior.
+
+Maintain the authoritative target grid here:
+
+| Cluster | GPU | Nodes | GPUs | State | Reason |
+| --- | --- | ---: | ---: | --- | --- |
+| `<exact Iris peer>` | `<variant>` | `<gang replicas>` | `<total>` | `unvalidated` | — |
+
+Create the candidate rows from `targets.md`, then validate them. State is
+`unvalidated` while validation is pending, `eligible` when dispatch is permitted,
+or `ineligible` when a verified restriction prohibits dispatch. `Reason` is
+required only for `ineligible` targets and names that restriction.
+
+Keep every considered cluster and gang shape visible. Only `eligible` targets may
+be dispatched. A trial-specific failure does not make a target globally ineligible.
+A verified invalid-target result makes only its exact target ineligible; investigate
+the same result on a previously working target before changing eligibility.
+
+## Change Record
+
+Only while the autonomous loop is running, record important, unexpected changes
+made in response to unusual conditions. Every entry must correspond to an actual
+change to this document, the SQLite data model, or execution code. Give UTC time,
+cause, exact change, and operational effect. Do not duplicate SQLite event details
+or session reports.
+
+None.
+```
+
+## Keep A Selective Change Record
+
+Use `Change Record` only when an unusual condition changes Operations, the SQLite
+model, or execution code. Update the relevant section in place, then add one terse
+entry. Ask before changing Operator Choices or experiment semantics.
+
+Never record routine dispatches, retries, progress, utilization, rankings, or next
+checks here. Recompute placement evidence from current utilization and SQLite.

--- a/.agents/skills/run-training-sweep-cw/references/persistence.md
+++ b/.agents/skills/run-training-sweep-cw/references/persistence.md
@@ -1,0 +1,70 @@
+# Persistence
+
+One local SQLite database is the durable record of dynamic sweep state. Its model
+covers heartbeat reconciliation, placement ranking, recovery, completion, and reporting.
+
+## Concepts
+
+| Concept | Essential facts |
+| --- | --- |
+| Sweep | Schema version and creation time; the file path identifies the sweep |
+| Trial | Opaque ID and parameters, W&B ID, checkpoint root, status, and `run_progress` high water |
+| Dispatch | Immutable attempt, trial, Iris ID, cluster, GPU, nodes, total GPUs, priority, redacted command, clocks, and end state |
+| Observation | UTC time, trial and dispatch, W&B state, `run_progress`, and binary Iris running state |
+| Event | UTC time, kind, associated identities, and concise evidence |
+
+## Relationships And Invariants
+
+- A trial owns one W&B and checkpoint identity and at most one active dispatch.
+- A trial's dispatches have persisted attempt numbers; never parse names for identity.
+- All persisted times are UTC.
+- Dispatches retain stopped, failed, and superseded placement history.
+- Commands and experiment parameters contain no secrets.
+- A completed trial has `run_progress >= 1`, a verified checkpoint, and no active dispatch.
+
+Operations owns target eligibility and policy. SQLite owns observed facts and action
+history; it does not own transient fleet utilization, rankings, or the Operations
+`Change Record`.
+
+## Supported Decisions
+
+- **Placement:** historical `target_rate`, productive and pending counts per exact
+  `(cluster, GPU, nodes, GPUs)` target.
+- **Recovery:** dispatch clocks begin at submission or latest progress; the trial
+  clock survives restarts and reslices and resets only on progress.
+- **Liveness:** W&B establishes training state and progress; Iris answers only
+  whether the exact dispatch is running.
+- **Accounting:** active placement separates submitted GPUs from GPUs on W&B-running work.
+- **Failures and completion:** attempt history and observations distinguish isolated
+  failures, repeated failures, abandonment, and verified completion.
+
+## Control Snapshot
+
+```bash
+uv run .agents/skills/run-training-sweep-cw/scripts/persistence.py \
+  snapshot scratch/<sweep>/expXXX_sweep.sqlite --reslice-after-hours <hours>
+```
+
+The read-only JSON snapshot includes every unfinished trial, active dispatches,
+progress clocks, latest observations, target rates and pending counts, fleet
+accounting, actionable conditions, event counts, and a bounded event window.
+Snapshot generation fails when identities, intervals, progress high-water marks,
+or completion state are inconsistent.
+
+## Event History
+
+Expected event kinds include:
+
+- `dispatch_submitted`, `dispatch_stopped`, `dispatch_terminal`
+- `target_unschedulable`, `wandb_registered`, `progress`, `stall_started`
+- `failure_retryable`, `systemic_failure`, `restart`, `reslice`
+- `trial_completed`, `checkpoint_verified`, `client_floor_failed`
+
+Action events carry concise evidence. Heartbeat prose and no-change explanations
+remain in session chat.
+
+## Helper
+
+```bash
+uv run .agents/skills/run-training-sweep-cw/scripts/persistence.py --help
+```

--- a/.agents/skills/run-training-sweep-cw/references/targets.md
+++ b/.agents/skills/run-training-sweep-cw/references/targets.md
@@ -1,0 +1,20 @@
+# Targets
+
+Translate the operator's GPU scope into the complete candidate grid before
+validating placement. By default, include H100 on `cw-us-east-02a` and `cw-rno2a`
+and GB200 on `cw-us-east-08a`. Never target the CI cluster `cw-us-west-04a`.
+
+Read current Marin and Iris configuration and inspect the training code's hardware
+profiles. Expand the requested scope into exact `(cluster, GPU, nodes, GPUs)` rows.
+Use whole nodes—currently eight H100 or four GB200 per node—and only gang sizes the
+training code can fit. If profiles are missing, explain the smallest changes needed
+and ask before editing training semantics.
+
+For a cold start, equal H100 and GB200 node counts are a useful rough BF16 compute
+class: a four-GPU GB200 node has about 1.25 times the dense BF16 peak of an
+eight-GPU H100 node. Treat this only as a sizing heuristic. Batch fit, communication,
+and measured `target_rate` determine useful placement once evidence exists.
+
+Add every candidate to Operations as `unvalidated`. Only validation or a verified
+invalid-target result changes eligibility. Fleet utilization and measured throughput
+rank eligible targets; they never define or narrow the candidate grid.

--- a/.agents/skills/run-training-sweep-cw/references/throughput.md
+++ b/.agents/skills/run-training-sweep-cw/references/throughput.md
@@ -1,0 +1,54 @@
+# Throughput
+
+## Placement Rates
+
+A target's `target_rate` measures how quickly it advances training after charging
+all wall-clock time spent there:
+
+```text
+target_rate = total increase in run_progress high-water / total dispatch hours
+```
+
+Each increase counts once, on the dispatch that first establishes it. Dispatch time
+includes queueing, startup, compilation, evaluation, checkpoints, preemption,
+stalls, failures, and zero-progress attempts.
+
+The persistence helper calculates one rate per `(cluster, GPU, nodes, GPUs)`. Use
+the emitted value rather than routine SQL. Prefer higher measured rates when other
+evidence is comparable, but combine them with current progress, pending headroom,
+and fleet capacity. Do not normalize the rate by GPU count; rough compute-equivalent
+gangs are only cold-start evidence.
+
+## Determine Liveness
+
+- `training now`: W&B state is `running`.
+- `recent progress`: the `run_progress` high water increased within `reslice_after`.
+- `pending`: the current dispatch has not made progress within `reslice_after`.
+- Iris running: the dispatch may execute; never proof of training.
+
+Completion requires `run_progress >= 1` and a reachable expected checkpoint.
+
+## Report Every Heartbeat
+
+Report in session chat with enough detail to audit what is running, what changed,
+and what happens next. Include:
+
+- UTC observation time.
+- Submitted and W&B-running dispatches and GPUs, plus current free/total capacity
+  on relevant clusters.
+- Complete, recently progressing, pending, and not-yet-running trials.
+- Each active trial's target, W&B state, progress and change, and time since increase.
+- Every submit, stop, restart, or reslice and its operational reason.
+- Failed, stalled, and unregistered runs; isolated/systemic classification and action due.
+- Relevant target rates, productive/pending counts, fleet headroom, and blockers.
+- A specific scheduled next-check time and the actions expected if nothing improves.
+
+Include checkpoint/resume evidence, unschedulable targets, priority violations,
+client-floor failures, or decisions needing operator approval when relevant. Do not
+hide a problem inside aggregate counts.
+
+## Keep The Heartbeat In Chat
+
+- Never copy observations, status, progress, actions, or the next check into Operations.
+- Never store the heartbeat report in SQLite.
+- Never create another log, runbook, or recurring status file.

--- a/.agents/skills/run-training-sweep-cw/references/utilization.md
+++ b/.agents/skills/run-training-sweep-cw/references/utilization.md
@@ -1,0 +1,32 @@
+# Utilization
+
+Use this snapshot before initial placement and every capacity-changing decision.
+It describes current admission headroom; W&B remains the progress authority.
+
+```bash
+uv run --project <marin-checkout> --package marin-iris \
+  python <skill-path>/scripts/utilization.py --cluster marin
+```
+
+Pass exactly one of `--cluster <name>` or `--config <path>`. Repeat `--peer` to
+narrow the default production set: `cw-rno2a`, `cw-us-east-02a`, and
+`cw-us-east-08a`.
+
+The script calls `iris rpc controller list-peers` and emits:
+
+- UTC observation time and aggregate free/held/total GPUs by variant.
+- One target per selected peer backend with GPU variant, free/total GPUs,
+  priority-band holds, observation age, and pending/running task counts.
+
+It exits nonzero when a selected peer is missing or unreachable, the availability
+metric is unsupported or stale, the expected GPU is absent, or capacity accounting
+is inconsistent. Extra response fields are safe.
+
+At batch priority, immediately usable capacity is the reported free amount. Do not
+count higher-priority holds, add capacity across separate backends to fit one gang,
+or hard-code fleet totals. Reserve planned and newly submitted gangs in the current
+fleet plan, then refresh after material actions.
+
+The metric semantics and Backends-page mapping are documented in Iris
+[federation placement](https://github.com/marin-community/marin/blob/877bbaddbded9fdb0ffcd7f6f5f00b67d1cb9683/lib/iris/docs/federation.md#L43-L73)
+and [observability](https://github.com/marin-community/marin/blob/877bbaddbded9fdb0ffcd7f6f5f00b67d1cb9683/lib/iris/docs/federation.md#L180-L213).

--- a/.agents/skills/run-training-sweep-cw/references/validation.md
+++ b/.agents/skills/run-training-sweep-cw/references/validation.md
@@ -1,0 +1,82 @@
+# Validation
+
+Establish which experiment-defined configurations and CoreWeave targets can be
+launched, observed, and checkpointed safely. Derive the needed facts from the
+training entry point, its helpers, and existing framework behavior before the first
+sweep dispatch.
+
+## Minimum From The Script
+
+The script needs only to launch one selected, experiment-defined configuration on
+one selected cluster and gang size from explicit parameters. Environment variables
+are preferred.
+
+If the agent cannot select one configuration and placement unambiguously, propose
+the smallest script change and ask before making it. Do not add a manifest or fields
+merely to simplify orchestration.
+
+## Inspect Before Launch
+
+Read the script and the helpers it calls. Verify:
+
+- Configuration inputs and the exact one-trial command.
+- Data, token-cache, initialization, W&B, and checkpoint resolution.
+- Production run and checkpoint identity do not depend on cluster, GPU, or nodes.
+- Supported cluster profiles, gang sizes, batch fit, restart, and reslice behavior.
+
+Do not transcribe code or configuration into Operations. Prefer source references;
+record only resulting constraints, exceptions, and operating conclusions.
+
+## Assess Hardware Profiles
+
+For every candidate target, inspect how the code selects GPU variant, GPUs per
+node, node count, CPU/RAM/disk, and data/tensor/context/pipeline parallelism. Confirm
+the effective global batch and optimizer semantics remain intended across profiles.
+Do not guess memory feasibility; use existing evidence or a smoke run.
+
+The completed exp199 sweep provides compact examples:
+
+- [cluster profiles and measured batch fitting](https://github.com/Open-Athena/MarinFold/blob/a3782d1c04b842731aaf692397643fa83354e1e3/experiments/exp199_optimize_contacts_v1_afdb_esm/gpu/exp199_sweep_cw.py#L491-L605)
+- [smoke and production identity separation](https://github.com/Open-Athena/MarinFold/blob/a3782d1c04b842731aaf692397643fa83354e1e3/experiments/exp199_optimize_contacts_v1_afdb_esm/gpu/exp199_sweep_cw.py#L672-L738)
+- [placement applied outside artifact identity](https://github.com/Open-Athena/MarinFold/blob/a3782d1c04b842731aaf692397643fa83354e1e3/experiments/exp199_optimize_contacts_v1_afdb_esm/gpu/exp199_sweep_cw.py#L741-L827)
+- [whole-node gang request and temporary smoke output](https://github.com/Open-Athena/MarinFold/blob/a3782d1c04b842731aaf692397643fa83354e1e3/experiments/exp199_optimize_contacts_v1_afdb_esm/gpu/exp199_sweep_cw.py#L830-L923)
+
+Use these as patterns, not an interface the new script must copy.
+
+## Validate Inputs And Checkpoints
+
+Confirm every selected cluster can use the resolved CoreWeave S3 inputs,
+initialization state, and checkpoint root. Ensure the child gang receives the
+required storage environment explicitly. A restart or reslice must resume the same
+trial identity, and two live jobs must never write it concurrently.
+
+## Validate Placement
+
+Start from the complete candidate grid in [targets.md](targets.md). Determine exact
+target eligibility from known restrictions, code/framework checks, and smoke runs
+where static evidence is insufficient. Mark each target `eligible`, `ineligible`,
+or `unvalidated` in Operations; submit only eligible targets.
+
+## Validate W&B Observation
+
+Assume training runs provide W&B `state` and `run_progress`. Use `state` for current
+liveness and the `run_progress` high-water mark for progress, completion, stall
+timing, and placement throughput.
+
+Use the sweep's normal W&B entity, project, and group. Follow `wandb-reporting` and
+require MarinDNA run names to map back to `dna-exp<N>`. Require cluster, GPU, and
+nodes as structured config or tags. Treat run IDs as opaque; never extract metadata
+from an ID or display name.
+
+## Validate Submission
+
+Before the first launch:
+
+- Confirm the Iris client meets the required revision floor.
+- Confirm the exact command and forwarded secrets; keep secrets out of Operations
+  and SQLite.
+- Use the `marin` controller, exact `--target-cluster`, `--priority batch`, and an
+  explicit `--user`. The target cluster must match the script's placement input.
+- Confirm the root driver remains alive for its child gang and the gang receives
+  the intended batch priority.
+- Obtain a valid fleet-utilization snapshot and show the first command to the operator.

--- a/.agents/skills/run-training-sweep-cw/scripts/persistence.py
+++ b/.agents/skills/run-training-sweep-cw/scripts/persistence.py
@@ -1,0 +1,743 @@
+"""Initialize, inspect, and check CoreWeave training-sweep persistence."""
+
+import argparse
+import json
+import sqlite3
+from collections import Counter, defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+
+SCHEMA = """
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS trials (
+    trial_id TEXT PRIMARY KEY,
+    env_json TEXT NOT NULL,
+    wandb_run_id TEXT NOT NULL UNIQUE,
+    wandb_url TEXT,
+    checkpoint_root TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'planned',
+    high_water_progress REAL NOT NULL DEFAULT 0 CHECK (high_water_progress >= 0),
+    checkpoint_verified_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS dispatches (
+    dispatch_id TEXT PRIMARY KEY,
+    trial_id TEXT NOT NULL REFERENCES trials(trial_id),
+    attempt INTEGER NOT NULL CHECK (attempt > 0),
+    iris_job_id TEXT NOT NULL UNIQUE,
+    cluster TEXT NOT NULL,
+    gpu_variant TEXT NOT NULL,
+    nodes INTEGER NOT NULL CHECK (nodes > 0),
+    gpus INTEGER NOT NULL CHECK (gpus > 0),
+    priority_band TEXT NOT NULL CHECK (priority_band = 'batch'),
+    command_redacted TEXT NOT NULL,
+    submitted_at TEXT NOT NULL,
+    ended_at TEXT,
+    active INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0, 1)),
+    outcome TEXT,
+    stop_reason TEXT,
+    UNIQUE (trial_id, attempt)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS one_active_dispatch_per_trial
+ON dispatches(trial_id) WHERE active = 1;
+
+CREATE INDEX IF NOT EXISTS dispatch_target_history
+ON dispatches(cluster, gpu_variant, nodes, gpus, submitted_at);
+
+CREATE TABLE IF NOT EXISTS observations (
+    observation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    trial_id TEXT NOT NULL REFERENCES trials(trial_id),
+    dispatch_id TEXT NOT NULL REFERENCES dispatches(dispatch_id),
+    observed_at TEXT NOT NULL,
+    wandb_state TEXT,
+    run_progress REAL CHECK (run_progress IS NULL OR run_progress >= 0),
+    iris_running INTEGER CHECK (iris_running IS NULL OR iris_running IN (0, 1)),
+    UNIQUE (trial_id, observed_at)
+);
+
+CREATE INDEX IF NOT EXISTS observations_by_dispatch_time
+ON observations(dispatch_id, observed_at);
+
+CREATE TABLE IF NOT EXISTS events (
+    event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    recorded_at TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    trial_id TEXT REFERENCES trials(trial_id),
+    dispatch_id TEXT REFERENCES dispatches(dispatch_id),
+    detail TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS events_by_time ON events(recorded_at);
+"""
+
+REQUIRED_COLUMNS = {
+    "meta": {"key", "value"},
+    "trials": {
+        "trial_id",
+        "env_json",
+        "wandb_run_id",
+        "checkpoint_root",
+        "status",
+        "high_water_progress",
+        "checkpoint_verified_at",
+    },
+    "dispatches": {
+        "dispatch_id",
+        "trial_id",
+        "attempt",
+        "iris_job_id",
+        "cluster",
+        "gpu_variant",
+        "nodes",
+        "gpus",
+        "priority_band",
+        "command_redacted",
+        "submitted_at",
+        "ended_at",
+        "active",
+        "outcome",
+        "stop_reason",
+    },
+    "observations": {
+        "observation_id",
+        "trial_id",
+        "dispatch_id",
+        "observed_at",
+        "wandb_state",
+        "run_progress",
+        "iris_running",
+    },
+    "events": {
+        "event_id",
+        "recorded_at",
+        "kind",
+        "trial_id",
+        "dispatch_id",
+        "detail",
+    },
+}
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _parse_time(value: str, field: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise RuntimeError(
+            f"{field} is not an ISO-8601 timestamp: {value!r}"
+        ) from error
+    if parsed.tzinfo is None:
+        raise RuntimeError(f"{field} has no timezone: {value!r}")
+    return parsed.astimezone(UTC)
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(path)
+    connection.execute("PRAGMA foreign_keys = ON")
+    return connection
+
+
+def _user_tables(connection: sqlite3.Connection) -> set[str]:
+    return {
+        row[0]
+        for row in connection.execute(
+            """
+            SELECT name FROM sqlite_master
+            WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+            """
+        )
+    }
+
+
+def _schema_errors(connection: sqlite3.Connection) -> list[str]:
+    errors: list[str] = []
+    version = connection.execute("PRAGMA user_version").fetchone()[0]
+    if version != SCHEMA_VERSION:
+        errors.append(f"schema version {version}; expected {SCHEMA_VERSION}")
+    for table, required in REQUIRED_COLUMNS.items():
+        actual = {row[1] for row in connection.execute(f'PRAGMA table_info("{table}")')}
+        missing = required - actual
+        if missing:
+            errors.append(f"{table}: missing columns {sorted(missing)}")
+    return errors
+
+
+def init(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with _connect(path) as connection:
+        version = connection.execute("PRAGMA user_version").fetchone()[0]
+        if _user_tables(connection) and version != SCHEMA_VERSION:
+            raise RuntimeError(
+                f"{path} has schema version {version}; expected {SCHEMA_VERSION}"
+            )
+        connection.executescript(SCHEMA)
+        connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+        connection.execute(
+            "INSERT OR IGNORE INTO meta(key, value) VALUES (?, ?)",
+            ("created_at", _now()),
+        )
+        errors = _schema_errors(connection)
+        if errors:
+            raise RuntimeError("; ".join(errors))
+
+
+def record_event(
+    path: Path,
+    kind: str,
+    detail: str,
+    trial_id: str | None,
+    dispatch_id: str | None,
+) -> None:
+    with _connect(path) as connection:
+        connection.execute(
+            """
+            INSERT INTO events(recorded_at, kind, trial_id, dispatch_id, detail)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (_now(), kind, trial_id, dispatch_id, detail),
+        )
+
+
+def _structural_errors(path: Path) -> list[str]:
+    if not path.is_file():
+        return [f"database does not exist: {path}"]
+    errors: list[str] = []
+    with _connect(path) as connection:
+        integrity = connection.execute("PRAGMA integrity_check").fetchone()
+        if integrity != ("ok",):
+            errors.append(f"integrity_check: {integrity}")
+        errors.extend(
+            f"foreign_key_check: {row}"
+            for row in connection.execute("PRAGMA foreign_key_check")
+        )
+        errors.extend(_schema_errors(connection))
+        if errors:
+            return errors
+        duplicate_active = connection.execute(
+            """
+            SELECT trial_id, COUNT(*) FROM dispatches
+            WHERE active = 1 GROUP BY trial_id HAVING COUNT(*) > 1
+            """
+        ).fetchall()
+        errors.extend(f"multiple active dispatches: {row}" for row in duplicate_active)
+        inconsistent_dispatches = connection.execute(
+            """
+            SELECT dispatch_id, active, ended_at FROM dispatches
+            WHERE (active = 1 AND ended_at IS NOT NULL)
+               OR (active = 0 AND ended_at IS NULL)
+            """
+        ).fetchall()
+        errors.extend(
+            f"inconsistent dispatch end state: {row}" for row in inconsistent_dispatches
+        )
+        mismatches = connection.execute(
+            """
+            SELECT observations.observation_id FROM observations
+            JOIN dispatches USING (dispatch_id)
+            WHERE observations.trial_id != dispatches.trial_id
+            """
+        ).fetchall()
+        errors.extend(
+            f"observation dispatch/trial mismatch: {row[0]}" for row in mismatches
+        )
+    return errors
+
+
+def _build_snapshot(
+    path: Path, recent_event_limit: int, reslice_after_hours: float
+) -> dict[str, object]:
+    if recent_event_limit < 0:
+        raise RuntimeError("recent event limit must be nonnegative")
+    if reslice_after_hours <= 0:
+        raise RuntimeError("reslice-after hours must be positive")
+
+    snapshot_at = datetime.now(UTC)
+    reslice_after_seconds = reslice_after_hours * 3600
+    with _connect(path) as connection:
+        connection.row_factory = sqlite3.Row
+        trials = list(connection.execute("SELECT * FROM trials ORDER BY trial_id"))
+        dispatches = list(
+            connection.execute(
+                "SELECT * FROM dispatches ORDER BY submitted_at, dispatch_id"
+            )
+        )
+        observations = list(
+            connection.execute(
+                "SELECT * FROM observations ORDER BY trial_id, observed_at, observation_id"
+            )
+        )
+        event_counts = {
+            row["kind"]: row["count"]
+            for row in connection.execute(
+                "SELECT kind, COUNT(*) AS count FROM events GROUP BY kind ORDER BY kind"
+            )
+        }
+        event_total = connection.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+        recent_events = list(
+            connection.execute(
+                """
+                SELECT event_id, recorded_at, kind, trial_id, dispatch_id, detail
+                FROM events ORDER BY event_id DESC LIMIT ?
+                """,
+                (recent_event_limit,),
+            )
+        )
+
+    trial_by_id = {row["trial_id"]: row for row in trials}
+    dispatch_by_id = {row["dispatch_id"]: row for row in dispatches}
+    dispatches_by_trial: dict[str, list[sqlite3.Row]] = defaultdict(list)
+    observations_by_trial: dict[str, list[tuple[sqlite3.Row, datetime]]] = defaultdict(
+        list
+    )
+    observations_by_dispatch: dict[str, list[tuple[sqlite3.Row, datetime]]] = (
+        defaultdict(list)
+    )
+
+    for dispatch in dispatches:
+        dispatches_by_trial[dispatch["trial_id"]].append(dispatch)
+    for observation in observations:
+        observed_at = _parse_time(
+            observation["observed_at"],
+            f"observation {observation['observation_id']} observed_at",
+        )
+        if observed_at > snapshot_at:
+            raise RuntimeError(
+                f"observation {observation['observation_id']} is in the future"
+            )
+        dispatch = dispatch_by_id[observation["dispatch_id"]]
+        submitted_at = _parse_time(
+            dispatch["submitted_at"], f"dispatch {dispatch['dispatch_id']} submitted_at"
+        )
+        if observed_at < submitted_at:
+            raise RuntimeError(
+                f"observation {observation['observation_id']} predates its dispatch"
+            )
+        item = (observation, observed_at)
+        observations_by_trial[observation["trial_id"]].append(item)
+        observations_by_dispatch[observation["dispatch_id"]].append(item)
+
+    progress_by_dispatch: dict[str, float] = defaultdict(float)
+    first_progress_at: dict[str, datetime] = {}
+    last_progress_at: dict[str, datetime] = {}
+    last_trial_progress_at: dict[str, datetime] = {}
+    for trial_id, trial_observations in observations_by_trial.items():
+        high_water = 0.0
+        for observation, observed_at in trial_observations:
+            progress = observation["run_progress"]
+            if progress is None or progress <= high_water:
+                continue
+            progress_by_dispatch[observation["dispatch_id"]] += progress - high_water
+            high_water = progress
+            dispatch_id = observation["dispatch_id"]
+            first_progress_at.setdefault(dispatch_id, observed_at)
+            last_progress_at[dispatch_id] = observed_at
+            last_trial_progress_at[trial_id] = observed_at
+
+    completed_ids = {
+        trial["trial_id"]
+        for trial in trials
+        if trial["status"].casefold() == "completed"
+    }
+    for trial_id in completed_ids:
+        trial = trial_by_id[trial_id]
+        if trial["high_water_progress"] < 1:
+            raise RuntimeError(f"completed trial {trial_id!r} has progress below 1")
+        if trial["checkpoint_verified_at"] is None:
+            raise RuntimeError(
+                f"completed trial {trial_id!r} has no verified checkpoint"
+            )
+        if any(dispatch["active"] for dispatch in dispatches_by_trial[trial_id]):
+            raise RuntimeError(f"completed trial {trial_id!r} has an active dispatch")
+
+    trial_snapshots: list[dict[str, object]] = []
+    current_trial_by_id: dict[str, dict[str, object]] = {}
+    conditions: list[dict[str, object]] = []
+    latest_observation_times: list[datetime] = []
+
+    for trial in trials:
+        trial_id = trial["trial_id"]
+        trial_observations = observations_by_trial[trial_id]
+        progress_values = [
+            row["run_progress"]
+            for row, _ in trial_observations
+            if row["run_progress"] is not None
+        ]
+        observed_high_water = max(progress_values, default=0.0)
+        if abs(observed_high_water - trial["high_water_progress"]) > 1e-12:
+            raise RuntimeError(
+                f"trial {trial_id!r} progress high-water does not match observations"
+            )
+
+        latest = trial_observations[-1] if trial_observations else None
+        latest_row = latest[0] if latest else None
+        latest_at = latest[1] if latest else None
+        if latest_at is not None:
+            latest_observation_times.append(latest_at)
+        prior_high_water = max(
+            (
+                row["run_progress"]
+                for row, _ in trial_observations[:-1]
+                if row["run_progress"] is not None
+            ),
+            default=0.0,
+        )
+
+        active = [row for row in dispatches_by_trial[trial_id] if row["active"]]
+        if len(active) > 1:
+            raise RuntimeError(f"trial {trial_id!r} has multiple active dispatches")
+        active_dispatch = active[0] if active else None
+        active_snapshot = None
+        active_latest_row = None
+        active_latest_at = None
+        if active_dispatch is not None:
+            dispatch_id = active_dispatch["dispatch_id"]
+            submitted_at = _parse_time(
+                active_dispatch["submitted_at"], f"dispatch {dispatch_id} submitted_at"
+            )
+            if submitted_at > snapshot_at:
+                raise RuntimeError(f"dispatch {dispatch_id!r} is in the future")
+            active_observations = observations_by_dispatch[dispatch_id]
+            if active_observations:
+                active_latest_row, active_latest_at = active_observations[-1]
+            progress_at = last_progress_at.get(dispatch_id)
+            stall_since = progress_at or submitted_at
+            stall_seconds = (snapshot_at - stall_since).total_seconds()
+            active_snapshot = {
+                "dispatch_id": dispatch_id,
+                "attempt": active_dispatch["attempt"],
+                "iris_job_id": active_dispatch["iris_job_id"],
+                "cluster": active_dispatch["cluster"],
+                "gpu_variant": active_dispatch["gpu_variant"],
+                "nodes": active_dispatch["nodes"],
+                "gpus": active_dispatch["gpus"],
+                "submitted_at": active_dispatch["submitted_at"],
+                "age_seconds": round((snapshot_at - submitted_at).total_seconds(), 3),
+                "last_progress_at": None
+                if progress_at is None
+                else progress_at.isoformat(),
+                "stall_since": stall_since.isoformat(),
+                "stall_seconds": round(stall_seconds, 3),
+                "recent_progress": progress_at is not None
+                and stall_seconds <= reslice_after_seconds,
+                "latest_observation": None
+                if active_latest_row is None or active_latest_at is None
+                else {
+                    "observed_at": active_latest_row["observed_at"],
+                    "age_seconds": round(
+                        (snapshot_at - active_latest_at).total_seconds(), 3
+                    ),
+                    "wandb_state": active_latest_row["wandb_state"],
+                    "run_progress": active_latest_row["run_progress"],
+                    "iris_running": None
+                    if active_latest_row["iris_running"] is None
+                    else bool(active_latest_row["iris_running"]),
+                },
+            }
+
+        latest_snapshot = None
+        if latest_row is not None and latest_at is not None:
+            latest_snapshot = {
+                "dispatch_id": latest_row["dispatch_id"],
+                "observed_at": latest_row["observed_at"],
+                "age_seconds": round((snapshot_at - latest_at).total_seconds(), 3),
+                "wandb_state": latest_row["wandb_state"],
+                "run_progress": latest_row["run_progress"],
+                "iris_running": None
+                if latest_row["iris_running"] is None
+                else bool(latest_row["iris_running"]),
+            }
+
+        trial_progress_at = last_trial_progress_at.get(trial_id)
+        if trial_progress_at is None and dispatches_by_trial[trial_id]:
+            trial_progress_at = min(
+                _parse_time(
+                    row["submitted_at"], f"dispatch {row['dispatch_id']} submitted_at"
+                )
+                for row in dispatches_by_trial[trial_id]
+            )
+        snapshot = {
+            "trial_id": trial_id,
+            "status": trial["status"],
+            "wandb_run_id": trial["wandb_run_id"],
+            "wandb_url": trial["wandb_url"],
+            "checkpoint_root": trial["checkpoint_root"],
+            "high_water_progress": trial["high_water_progress"],
+            "progress_delta_since_latest_prior_observation": max(
+                0.0, trial["high_water_progress"] - prior_high_water
+            ),
+            "last_progress_at": None
+            if trial_progress_at is None
+            else trial_progress_at.isoformat(),
+            "stall_seconds": None
+            if trial_progress_at is None
+            else round((snapshot_at - trial_progress_at).total_seconds(), 3),
+            "checkpoint_verified_at": trial["checkpoint_verified_at"],
+            "dispatch_count": len(dispatches_by_trial[trial_id]),
+            "active_dispatch": active_snapshot,
+            "latest_observation": latest_snapshot,
+        }
+        current_trial_by_id[trial_id] = snapshot
+
+        if trial_id not in completed_ids:
+            kinds: list[str] = []
+            if active_dispatch is None:
+                kinds.append("no_active_dispatch")
+            elif active_latest_row is None:
+                kinds.append("active_dispatch_unobserved")
+            else:
+                if active_latest_row["wandb_state"] == "failed":
+                    kinds.append("wandb_failed")
+                if (
+                    active_latest_row["wandb_state"] == "finished"
+                    and trial["high_water_progress"] < 1
+                ):
+                    kinds.append("wandb_finished_before_completion")
+                if active_latest_row["iris_running"] == 0:
+                    kinds.append("iris_not_running")
+            for kind in kinds:
+                conditions.append({"kind": kind, "trial_id": trial_id})
+            trial_snapshots.append(snapshot)
+
+    placement_groups: dict[tuple[str, str, int, int], dict[str, object]] = {}
+    for dispatch in dispatches:
+        submitted_at = _parse_time(
+            dispatch["submitted_at"], f"dispatch {dispatch['dispatch_id']} submitted_at"
+        )
+        dispatch_observations = observations_by_dispatch[dispatch["dispatch_id"]]
+        if dispatch["active"]:
+            effective_end = snapshot_at
+        else:
+            ended_at = _parse_time(
+                dispatch["ended_at"], f"dispatch {dispatch['dispatch_id']} ended_at"
+            )
+            effective_end = max(
+                [ended_at, *(observed_at for _, observed_at in dispatch_observations)]
+            )
+        if effective_end < submitted_at:
+            raise RuntimeError(
+                f"dispatch {dispatch['dispatch_id']!r} ends before submission"
+            )
+
+        key = (
+            dispatch["cluster"],
+            dispatch["gpu_variant"],
+            dispatch["nodes"],
+            dispatch["gpus"],
+        )
+        group = placement_groups.setdefault(
+            key,
+            {
+                "cluster": dispatch["cluster"],
+                "gpu_variant": dispatch["gpu_variant"],
+                "nodes": dispatch["nodes"],
+                "gpus": dispatch["gpus"],
+                "dispatch_count": 0,
+                "dispatches_with_progress": 0,
+                "zero_progress_dispatches": 0,
+                "active_dispatches": 0,
+                "productive_dispatches": 0,
+                "pending_dispatches": 0,
+                "total_progress": 0.0,
+                "total_wall_time_seconds": 0.0,
+                "time_to_first_progress_seconds": [],
+            },
+        )
+        delta = progress_by_dispatch[dispatch["dispatch_id"]]
+        group["dispatch_count"] += 1
+        group["total_progress"] += delta
+        group["total_wall_time_seconds"] += (
+            effective_end - submitted_at
+        ).total_seconds()
+        if delta > 0:
+            group["dispatches_with_progress"] += 1
+            group["time_to_first_progress_seconds"].append(
+                (
+                    first_progress_at[dispatch["dispatch_id"]] - submitted_at
+                ).total_seconds()
+            )
+        else:
+            group["zero_progress_dispatches"] += 1
+        if dispatch["active"]:
+            group["active_dispatches"] += 1
+            progress_at = last_progress_at.get(dispatch["dispatch_id"])
+            if (
+                progress_at is not None
+                and (snapshot_at - progress_at).total_seconds() <= reslice_after_seconds
+            ):
+                group["productive_dispatches"] += 1
+            else:
+                group["pending_dispatches"] += 1
+
+    placements: list[dict[str, object]] = []
+    for group in placement_groups.values():
+        first_times = group.pop("time_to_first_progress_seconds")
+        wall_hours = group["total_wall_time_seconds"] / 3600
+        group["total_progress"] = round(group["total_progress"], 12)
+        group["total_wall_time_seconds"] = round(group["total_wall_time_seconds"], 3)
+        group["target_rate"] = (
+            None if wall_hours == 0 else round(group["total_progress"] / wall_hours, 12)
+        )
+        group["average_time_to_first_progress_seconds"] = (
+            None if not first_times else round(sum(first_times) / len(first_times), 3)
+        )
+        placements.append(group)
+    placements.sort(
+        key=lambda row: (
+            -1.0 if row["target_rate"] is None else -row["target_rate"],
+            row["cluster"],
+            row["gpu_variant"],
+            row["nodes"],
+        )
+    )
+
+    active_dispatches = [row for row in dispatches if row["active"]]
+    training_dispatches = 0
+    training_gpus = 0
+    for dispatch in active_dispatches:
+        active = current_trial_by_id[dispatch["trial_id"]]["active_dispatch"]
+        latest = None if active is None else active["latest_observation"]
+        if latest is not None and latest["wandb_state"] == "running":
+            training_dispatches += 1
+            training_gpus += dispatch["gpus"]
+
+    recent_event_snapshots = [
+        {
+            "event_id": row["event_id"],
+            "recorded_at": row["recorded_at"],
+            "kind": row["kind"],
+            "trial_id": row["trial_id"],
+            "dispatch_id": row["dispatch_id"],
+            "detail": row["detail"],
+        }
+        for row in reversed(recent_events)
+    ]
+    trial_status_counts = Counter(row["status"] for row in trials)
+
+    return {
+        "snapshot_at_utc": snapshot_at.isoformat(),
+        "reslice_after_seconds": reslice_after_seconds,
+        "coverage": {
+            "trials_total": len(trials),
+            "unfinished_trials_included": len(trial_snapshots),
+            "completed_trials_omitted": len(completed_ids),
+            "dispatches_total": len(dispatches),
+            "observations_total": len(observations),
+            "events_total": event_total,
+            "recent_events_included": len(recent_event_snapshots),
+            "recent_events_omitted": event_total - len(recent_event_snapshots),
+            "latest_observation_at_utc": None
+            if not latest_observation_times
+            else max(latest_observation_times).isoformat(),
+            "unfinished_trials_without_observations": sum(
+                1 for row in trial_snapshots if row["latest_observation"] is None
+            ),
+        },
+        "fleet": {
+            "trial_status_counts": dict(sorted(trial_status_counts.items())),
+            "active_dispatches": len(active_dispatches),
+            "submitted_gpus": sum(row["gpus"] for row in active_dispatches),
+            "wandb_running_dispatches": training_dispatches,
+            "wandb_running_gpus": training_gpus,
+        },
+        "trials": trial_snapshots,
+        "conditions": sorted(
+            conditions, key=lambda row: (row["trial_id"], row["kind"])
+        ),
+        "placements": placements,
+        "event_counts": event_counts,
+        "recent_events": recent_event_snapshots,
+    }
+
+
+def check(path: Path) -> list[str]:
+    errors = _structural_errors(path)
+    if errors:
+        return errors
+    try:
+        _build_snapshot(path, recent_event_limit=0, reslice_after_hours=1)
+    except (RuntimeError, sqlite3.Error) as error:
+        errors.append(f"semantic_check: {error}")
+    return errors
+
+
+def snapshot(
+    path: Path, recent_event_limit: int, reslice_after_hours: float = 1
+) -> dict[str, object]:
+    errors = _structural_errors(path)
+    if errors:
+        raise RuntimeError("; ".join(errors))
+    return _build_snapshot(path, recent_event_limit, reslice_after_hours)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init")
+    init_parser.add_argument("database", type=Path)
+
+    event_parser = subparsers.add_parser("event")
+    event_parser.add_argument("database", type=Path)
+    event_parser.add_argument("--kind", required=True)
+    event_parser.add_argument("--detail", required=True)
+    event_parser.add_argument("--trial-id")
+    event_parser.add_argument("--dispatch-id")
+
+    check_parser = subparsers.add_parser("check")
+    check_parser.add_argument("database", type=Path)
+
+    snapshot_parser = subparsers.add_parser("snapshot")
+    snapshot_parser.add_argument("database", type=Path)
+    snapshot_parser.add_argument("--recent-events", type=int, default=20)
+    snapshot_parser.add_argument("--reslice-after-hours", type=float, default=1)
+
+    args = parser.parse_args()
+    if args.command == "init":
+        init(args.database)
+        print(f"OK: initialized {args.database}")
+        return 0
+    if args.command == "event":
+        record_event(
+            args.database,
+            args.kind,
+            args.detail,
+            args.trial_id,
+            args.dispatch_id,
+        )
+        print("OK: event recorded")
+        return 0
+    if args.command == "check":
+        errors = check(args.database)
+        if errors:
+            for error in errors:
+                print(f"ERROR: {error}")
+            return 1
+        print(f"OK: {args.database}")
+        return 0
+    if args.command == "snapshot":
+        try:
+            result = snapshot(
+                args.database, args.recent_events, args.reslice_after_hours
+            )
+        except (RuntimeError, sqlite3.Error) as error:
+            print(f"ERROR: {error}")
+            return 1
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/run-training-sweep-cw/scripts/utilization.py
+++ b/.agents/skills/run-training-sweep-cw/scripts/utilization.py
@@ -1,0 +1,325 @@
+"""Emit a strict CoreWeave GPU capacity snapshot from Iris federation peers."""
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+JsonObject = dict[str, Any]
+
+PRODUCTION_PEERS = {
+    "cw-rno2a": "h100",
+    "cw-us-east-02a": "h100",
+    "cw-us-east-08a": "gb200",
+}
+AVAILABILITY_VERSION = 2
+
+
+class SnapshotError(RuntimeError):
+    """Raised when Iris output cannot support an accurate capacity snapshot."""
+
+
+def _object(value: object, path: str) -> JsonObject:
+    if not isinstance(value, dict):
+        raise SnapshotError(f"{path} must be an object")
+    return value
+
+
+def _list(value: object, path: str) -> list[object]:
+    if not isinstance(value, list):
+        raise SnapshotError(f"{path} must be a list")
+    return value
+
+
+def _string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise SnapshotError(f"{path} must be a nonempty string")
+    return value
+
+
+def _boolean(value: object, path: str) -> bool:
+    if not isinstance(value, bool):
+        raise SnapshotError(f"{path} must be a boolean")
+    return value
+
+
+def _integer(value: object, path: str) -> int:
+    if isinstance(value, bool):
+        raise SnapshotError(f"{path} must be an integer")
+    if isinstance(value, int):
+        result = value
+    elif isinstance(value, str):
+        try:
+            result = int(value)
+        except ValueError as error:
+            raise SnapshotError(f"{path} must be an integer") from error
+    else:
+        raise SnapshotError(f"{path} must be an integer")
+    if result < 0:
+        raise SnapshotError(f"{path} must be nonnegative")
+    return result
+
+
+def _counts(value: object, path: str) -> dict[str, int]:
+    raw = _object(value, path)
+    result: dict[str, int] = {}
+    for key, amount in raw.items():
+        if not isinstance(key, str) or not key:
+            raise SnapshotError(f"{path} has an invalid resource key")
+        normalized = key.casefold()
+        if normalized in result:
+            raise SnapshotError(f"{path} repeats resource {normalized!r}")
+        result[normalized] = _integer(amount, f"{path}.{key}")
+    return result
+
+
+def _run_iris(command: list[str], timeout_seconds: float) -> JsonObject:
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except FileNotFoundError as error:
+        raise SnapshotError(f"Iris executable not found: {command[0]}") from error
+    except subprocess.TimeoutExpired as error:
+        raise SnapshotError(
+            f"Iris command timed out after {timeout_seconds:g}s"
+        ) from error
+    if result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip() or "no output"
+        raise SnapshotError(f"Iris command failed ({result.returncode}): {detail}")
+    try:
+        response = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise SnapshotError("Iris output is not valid JSON") from error
+    return _object(response, "response")
+
+
+def summarize(
+    response: JsonObject,
+    observed_at: datetime,
+    *,
+    peers: tuple[str, ...] = tuple(PRODUCTION_PEERS),
+    max_age_seconds: float = 90,
+) -> JsonObject:
+    if observed_at.tzinfo is None:
+        raise SnapshotError("observed_at must include a timezone")
+    if not peers:
+        raise SnapshotError("at least one peer is required")
+    if len(set(peers)) != len(peers):
+        raise SnapshotError("selected peers contain duplicates")
+    if max_age_seconds <= 0:
+        raise SnapshotError("max_age_seconds must be positive")
+    unknown = set(peers) - PRODUCTION_PEERS.keys()
+    if unknown:
+        raise SnapshotError(f"unknown production peers: {sorted(unknown)}")
+
+    raw_peers = _list(response.get("peers"), "response.peers")
+    peer_by_id: dict[str, JsonObject] = {}
+    for index, value in enumerate(raw_peers):
+        path = f"response.peers[{index}]"
+        peer = _object(value, path)
+        peer_id = _string(peer.get("peer_id"), f"{path}.peer_id")
+        if peer_id in peer_by_id:
+            raise SnapshotError(f"response repeats peer {peer_id!r}")
+        peer_by_id[peer_id] = peer
+
+    targets: list[JsonObject] = []
+    fleet_by_gpu: defaultdict[str, dict[str, Any]] = defaultdict(
+        lambda: {
+            "free_gpus": 0,
+            "held_gpus": 0,
+            "total_gpus": 0,
+            "held_by_band": defaultdict(int),
+        }
+    )
+    now_ms = int(observed_at.astimezone(UTC).timestamp() * 1000)
+
+    for peer_id in peers:
+        if peer_id not in peer_by_id:
+            raise SnapshotError(f"selected peer {peer_id!r} is missing")
+        peer = peer_by_id[peer_id]
+        if not _boolean(peer.get("reachable"), f"peer {peer_id}.reachable"):
+            raise SnapshotError(f"selected peer {peer_id!r} is unreachable")
+        backends = _list(peer.get("backends"), f"peer {peer_id}.backends")
+        expected_gpu = PRODUCTION_PEERS[peer_id]
+        matched = 0
+
+        for backend_index, value in enumerate(backends):
+            path = f"peer {peer_id}.backends[{backend_index}]"
+            backend = _object(value, path)
+            backend_id = _string(backend.get("backend_id"), f"{path}.backend_id")
+            availability = _object(backend.get("availability"), f"{path}.availability")
+            version = _integer(
+                availability.get("version"), f"{path}.availability.version"
+            )
+            if version != AVAILABILITY_VERSION:
+                raise SnapshotError(
+                    f"{path} reports availability version {version}; "
+                    f"expected {AVAILABILITY_VERSION}"
+                )
+            observation_ms = _integer(
+                availability.get("observation_epoch_ms"),
+                f"{path}.availability.observation_epoch_ms",
+            )
+            age_seconds = (now_ms - observation_ms) / 1000
+            if age_seconds < 0:
+                raise SnapshotError(f"{path} availability observation is in the future")
+            if age_seconds > max_age_seconds:
+                raise SnapshotError(
+                    f"{path} availability is stale ({age_seconds:.1f}s > {max_age_seconds:g}s)"
+                )
+
+            free = _counts(availability.get("amounts"), f"{path}.availability.amounts")
+            total = _counts(
+                availability.get("total_amounts"),
+                f"{path}.availability.total_amounts",
+            )
+            if set(free) != set(total):
+                raise SnapshotError(f"{path} free and total resource keys disagree")
+            if expected_gpu not in free:
+                continue
+            matched += 1
+
+            held_by_band: dict[str, int] = {}
+            for held_index, held_value in enumerate(
+                _list(
+                    availability.get("held_by_band"),
+                    f"{path}.availability.held_by_band",
+                )
+            ):
+                held_path = f"{path}.availability.held_by_band[{held_index}]"
+                held = _object(held_value, held_path)
+                band = _string(held.get("band"), f"{held_path}.band")
+                if band in held_by_band:
+                    raise SnapshotError(f"{path} repeats priority band {band!r}")
+                amounts = _counts(held.get("amounts"), f"{held_path}.amounts")
+                held_by_band[band] = amounts.get(expected_gpu, 0)
+
+            free_gpus = free[expected_gpu]
+            total_gpus = total[expected_gpu]
+            held_gpus = sum(held_by_band.values())
+            if free_gpus > total_gpus:
+                raise SnapshotError(f"{path} free {expected_gpu} exceeds total")
+            if free_gpus + held_gpus != total_gpus:
+                raise SnapshotError(
+                    f"{path} {expected_gpu} accounting disagrees: "
+                    f"free={free_gpus}, held={held_gpus}, total={total_gpus}"
+                )
+
+            pending_tasks = _integer(
+                backend.get("pending_task_count"), f"{path}.pending_task_count"
+            )
+            running_tasks = _integer(
+                backend.get("running_task_count"), f"{path}.running_task_count"
+            )
+            targets.append(
+                {
+                    "cluster": peer_id,
+                    "backend_id": backend_id,
+                    "gpu_variant": expected_gpu.upper(),
+                    "free_gpus": free_gpus,
+                    "held_gpus": held_gpus,
+                    "total_gpus": total_gpus,
+                    "in_use_percent": round(100 * held_gpus / total_gpus, 1)
+                    if total_gpus
+                    else 0.0,
+                    "held_by_band": dict(sorted(held_by_band.items())),
+                    "pending_task_count": pending_tasks,
+                    "running_task_count": running_tasks,
+                    "observation_epoch_ms": observation_ms,
+                    "observation_age_seconds": round(age_seconds, 3),
+                }
+            )
+            aggregate = fleet_by_gpu[expected_gpu.upper()]
+            aggregate["free_gpus"] += free_gpus
+            aggregate["held_gpus"] += held_gpus
+            aggregate["total_gpus"] += total_gpus
+            for band, amount in held_by_band.items():
+                aggregate["held_by_band"][band] += amount
+
+        if matched == 0:
+            raise SnapshotError(
+                f"selected peer {peer_id!r} has no {expected_gpu.upper()} availability backend"
+            )
+
+    fleet: dict[str, JsonObject] = {}
+    for gpu_variant, aggregate in sorted(fleet_by_gpu.items()):
+        fleet[gpu_variant] = {
+            "free_gpus": aggregate["free_gpus"],
+            "held_gpus": aggregate["held_gpus"],
+            "total_gpus": aggregate["total_gpus"],
+            "held_by_band": dict(sorted(aggregate["held_by_band"].items())),
+        }
+
+    targets.sort(
+        key=lambda row: (row["gpu_variant"], row["cluster"], row["backend_id"])
+    )
+    return {
+        "observed_at_utc": observed_at.astimezone(UTC).isoformat(),
+        "fleet_by_gpu": fleet,
+        "targets": targets,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Emit strict JSON describing CoreWeave GPU fleet capacity."
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--cluster", help="Named Iris cluster, normally marin")
+    source.add_argument("--config", type=Path, help="Exact Iris cluster config path")
+    parser.add_argument(
+        "--peer",
+        action="append",
+        choices=tuple(PRODUCTION_PEERS),
+        help="Production peer to include; repeat as needed (default: all)",
+    )
+    parser.add_argument("--iris-bin", default="iris", help="Iris executable path")
+    parser.add_argument("--timeout-seconds", type=float, default=60)
+    parser.add_argument("--max-age-seconds", type=float, default=90)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if args.timeout_seconds <= 0 or args.max_age_seconds <= 0:
+        print("ERROR: timeout and max age must be positive", file=sys.stderr)
+        return 2
+    if args.config is not None and not args.config.is_file():
+        print(f"ERROR: config does not exist: {args.config}", file=sys.stderr)
+        return 2
+
+    command = [args.iris_bin]
+    if args.cluster is not None:
+        command.extend(["--cluster", args.cluster])
+    else:
+        command.extend(["--config", str(args.config)])
+    command.extend(["rpc", "controller", "list-peers"])
+
+    try:
+        response = _run_iris(command, args.timeout_seconds)
+        snapshot = summarize(
+            response,
+            datetime.now(UTC),
+            peers=tuple(args.peer or PRODUCTION_PEERS),
+            max_age_seconds=args.max_age_seconds,
+        )
+    except SnapshotError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+
+    json.dump(snapshot, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/run-training-sweep-cw/tests/test_cw_tools.py
+++ b/.agents/skills/run-training-sweep-cw/tests/test_cw_tools.py
@@ -1,0 +1,443 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+import importlib.util
+import sqlite3
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SKILL_ROOT = Path(__file__).parents[1]
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+persistence = _load_module(
+    "run_training_sweep_cw_persistence",
+    SKILL_ROOT / "scripts" / "persistence.py",
+)
+utilization = _load_module(
+    "run_training_sweep_cw_utilization",
+    SKILL_ROOT / "scripts" / "utilization.py",
+)
+
+
+def _insert_trial(
+    connection: sqlite3.Connection,
+    trial_id: str,
+    progress: float,
+    *,
+    status: str = "active",
+    checkpoint_verified_at: str | None = None,
+) -> None:
+    connection.execute(
+        """
+        INSERT INTO trials(
+            trial_id, env_json, wandb_run_id, checkpoint_root, status,
+            high_water_progress, checkpoint_verified_at
+        ) VALUES (?, '{}', ?, ?, ?, ?, ?)
+        """,
+        (
+            trial_id,
+            f"wandb-{trial_id}",
+            f"s3://checkpoints/{trial_id}",
+            status,
+            progress,
+            checkpoint_verified_at,
+        ),
+    )
+
+
+def _insert_dispatch(
+    connection: sqlite3.Connection,
+    dispatch_id: str,
+    trial_id: str,
+    attempt: int,
+    cluster: str,
+    gpu_variant: str,
+    nodes: int,
+    gpus: int,
+    submitted_at: str,
+    ended_at: str | None,
+) -> None:
+    connection.execute(
+        """
+        INSERT INTO dispatches(
+            dispatch_id, trial_id, attempt, iris_job_id, cluster, gpu_variant,
+            nodes, gpus, priority_band, command_redacted, submitted_at,
+            ended_at, active, outcome
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'batch', 'launch', ?, ?, ?, ?)
+        """,
+        (
+            dispatch_id,
+            trial_id,
+            attempt,
+            f"iris-{dispatch_id}",
+            cluster,
+            gpu_variant,
+            nodes,
+            gpus,
+            submitted_at,
+            ended_at,
+            int(ended_at is None),
+            None if ended_at is None else "stopped",
+        ),
+    )
+
+
+def _insert_observation(
+    connection: sqlite3.Connection,
+    trial_id: str,
+    dispatch_id: str,
+    observed_at: str,
+    progress: float,
+    iris_running: bool,
+    *,
+    wandb_state: str = "running",
+) -> None:
+    connection.execute(
+        """
+        INSERT INTO observations(
+            trial_id, dispatch_id, observed_at, wandb_state,
+            run_progress, iris_running
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (trial_id, dispatch_id, observed_at, wandb_state, progress, int(iris_running)),
+    )
+
+
+def test_target_rate_pools_trials_and_zero_progress_time(tmp_path: Path) -> None:
+    database = tmp_path / "sweep.sqlite"
+    persistence.init(database)
+    with sqlite3.connect(database) as connection:
+        _insert_trial(connection, "trial-1", 0.12)
+        _insert_trial(connection, "trial-2", 0.0)
+        _insert_dispatch(
+            connection,
+            "dispatch-1",
+            "trial-1",
+            1,
+            "cw-rno2a",
+            "H100",
+            2,
+            16,
+            "2026-01-01T00:00:00+00:00",
+            "2026-01-01T01:00:00+00:00",
+        )
+        _insert_dispatch(
+            connection,
+            "dispatch-2",
+            "trial-2",
+            1,
+            "cw-rno2a",
+            "H100",
+            2,
+            16,
+            "2026-01-01T00:00:00+00:00",
+            "2026-01-01T02:00:00+00:00",
+        )
+        _insert_observation(
+            connection,
+            "trial-1",
+            "dispatch-1",
+            "2026-01-01T00:30:00+00:00",
+            0.12,
+            True,
+        )
+
+    assert persistence.snapshot(database, recent_event_limit=0)["placements"] == [
+        {
+            "cluster": "cw-rno2a",
+            "gpu_variant": "H100",
+            "nodes": 2,
+            "gpus": 16,
+            "dispatch_count": 2,
+            "dispatches_with_progress": 1,
+            "zero_progress_dispatches": 1,
+            "active_dispatches": 0,
+            "productive_dispatches": 0,
+            "pending_dispatches": 0,
+            "total_progress": 0.12,
+            "total_wall_time_seconds": 10800.0,
+            "target_rate": 0.04,
+            "average_time_to_first_progress_seconds": 1800.0,
+        }
+    ]
+
+
+def test_reslice_attributes_progress_to_exact_dispatch(tmp_path: Path) -> None:
+    database = tmp_path / "sweep.sqlite"
+    persistence.init(database)
+    with sqlite3.connect(database) as connection:
+        _insert_trial(connection, "trial", 0.2)
+        _insert_dispatch(
+            connection,
+            "old",
+            "trial",
+            1,
+            "cw-rno2a",
+            "H100",
+            2,
+            16,
+            "2026-01-01T00:00:00+00:00",
+            "2026-01-01T00:10:00+00:00",
+        )
+        _insert_dispatch(
+            connection,
+            "new",
+            "trial",
+            2,
+            "cw-us-east-08a",
+            "GB200",
+            2,
+            8,
+            "2026-01-01T00:10:00+00:00",
+            None,
+        )
+        _insert_observation(
+            connection, "trial", "old", "2026-01-01T00:05:00+00:00", 0.1, True
+        )
+        _insert_observation(
+            connection, "trial", "old", "2026-01-01T00:11:00+00:00", 0.2, False
+        )
+
+    before = persistence.snapshot(database, recent_event_limit=0)
+    assert before["fleet"]["wandb_running_gpus"] == 0
+    assert before["trials"][0]["active_dispatch"]["latest_observation"] is None
+    assert before["conditions"][0]["kind"] == "active_dispatch_unobserved"
+
+    with sqlite3.connect(database) as connection:
+        _insert_observation(
+            connection, "trial", "new", "2026-01-01T00:12:00+00:00", 0.3, True
+        )
+        connection.execute(
+            "UPDATE trials SET high_water_progress = 0.3 WHERE trial_id = 'trial'"
+        )
+
+    after = persistence.snapshot(database, recent_event_limit=0)
+    progress_by_gpu = {
+        placement["gpu_variant"]: placement["total_progress"]
+        for placement in after["placements"]
+    }
+    assert progress_by_gpu == {"H100": 0.2, "GB200": 0.1}
+    assert after["fleet"]["wandb_running_gpus"] == 8
+
+
+def test_snapshot_classifies_target_headroom(tmp_path: Path) -> None:
+    database = tmp_path / "sweep.sqlite"
+    persistence.init(database)
+    now = datetime.now(UTC).replace(microsecond=0)
+    old = (now - timedelta(hours=2)).isoformat()
+    recent = (now - timedelta(minutes=30)).isoformat()
+    with sqlite3.connect(database) as connection:
+        _insert_trial(connection, "trial-1", 0.1)
+        _insert_trial(connection, "trial-2", 0.0)
+        _insert_dispatch(
+            connection, "dispatch-1", "trial-1", 1, "cw-rno2a", "H100", 2, 16, old, None
+        )
+        _insert_dispatch(
+            connection, "dispatch-2", "trial-2", 1, "cw-rno2a", "H100", 2, 16, old, None
+        )
+        _insert_observation(connection, "trial-1", "dispatch-1", recent, 0.1, True)
+        _insert_observation(connection, "trial-2", "dispatch-2", recent, 0.0, True)
+
+    result = persistence.snapshot(database, recent_event_limit=0)
+    placement = result["placements"][0]
+    assert placement["active_dispatches"] == 2
+    assert placement["productive_dispatches"] == 1
+    assert placement["pending_dispatches"] == 1
+    assert result["trials"][0]["active_dispatch"]["recent_progress"] is True
+    assert result["trials"][1]["active_dispatch"]["recent_progress"] is False
+
+    shorter = persistence.snapshot(
+        database, recent_event_limit=0, reslice_after_hours=0.25
+    )["placements"][0]
+    assert shorter["productive_dispatches"] == 0
+    assert shorter["pending_dispatches"] == 2
+
+
+def test_completion_and_snapshot_reject_semantic_errors(tmp_path: Path) -> None:
+    database = tmp_path / "sweep.sqlite"
+    persistence.init(database)
+    with sqlite3.connect(database) as connection:
+        _insert_trial(connection, "trial", 0.5)
+
+    assert persistence.check(database) == [
+        "semantic_check: trial 'trial' progress high-water does not match observations"
+    ]
+    with pytest.raises(RuntimeError, match="progress high-water"):
+        persistence.snapshot(database, recent_event_limit=0)
+
+
+def test_schema_rejects_non_batch_dispatch(tmp_path: Path) -> None:
+    database = tmp_path / "sweep.sqlite"
+    persistence.init(database)
+    with sqlite3.connect(database) as connection:
+        _insert_trial(connection, "trial", 0.0)
+        with pytest.raises(sqlite3.IntegrityError, match="priority_band"):
+            connection.execute(
+                """
+                INSERT INTO dispatches(
+                    dispatch_id, trial_id, attempt, iris_job_id, cluster,
+                    gpu_variant, nodes, gpus, priority_band, command_redacted,
+                    submitted_at, active
+                ) VALUES (
+                    'dispatch', 'trial', 1, 'iris-dispatch', 'cw-rno2a',
+                    'H100', 1, 8, 'interactive', 'launch',
+                    '2026-01-01T00:00:00+00:00', 1
+                )
+                """
+            )
+
+
+def _availability(
+    gpu: str,
+    free: int,
+    total: int,
+    observed_ms: int,
+    held: list[tuple[str, int]],
+) -> dict[str, object]:
+    return {
+        "version": "2",
+        "observation_epoch_ms": str(observed_ms),
+        "amounts": {gpu: str(free)},
+        "total_amounts": {gpu: str(total)},
+        "held_by_band": [
+            {"band": band, "amounts": {gpu: str(amount)}} for band, amount in held
+        ],
+    }
+
+
+def _utilization_response(observed_at: datetime) -> dict[str, object]:
+    observed_ms = int((observed_at - timedelta(seconds=20)).timestamp() * 1000)
+
+    def peer(
+        peer_id: str,
+        gpu: str,
+        free: int,
+        total: int,
+        held: list[tuple[str, int]],
+    ) -> dict[str, object]:
+        return {
+            "peer_id": peer_id,
+            "reachable": True,
+            "backends": [
+                {
+                    "backend_id": "default",
+                    "pending_task_count": 0,
+                    "running_task_count": 4,
+                    "availability": _availability(gpu, free, total, observed_ms, held),
+                }
+            ],
+        }
+
+    return {
+        "peers": [
+            peer(
+                "cw-rno2a",
+                "h100",
+                0,
+                512,
+                [
+                    ("PRIORITY_BAND_INTERACTIVE", 112),
+                    ("PRIORITY_BAND_BATCH", 400),
+                ],
+            ),
+            peer(
+                "cw-us-east-02a",
+                "h100",
+                112,
+                256,
+                [
+                    ("PRIORITY_BAND_PRODUCTION", 16),
+                    ("PRIORITY_BAND_BATCH", 128),
+                ],
+            ),
+            peer(
+                "cw-us-east-08a",
+                "gb200",
+                476,
+                804,
+                [
+                    ("PRIORITY_BAND_PRODUCTION", 320),
+                    ("PRIORITY_BAND_INTERACTIVE", 4),
+                    ("PRIORITY_BAND_BATCH", 4),
+                ],
+            ),
+        ]
+    }
+
+
+def test_utilization_summarizes_all_production_peers() -> None:
+    observed_at = datetime(2026, 8, 16, 13, tzinfo=UTC)
+    result = utilization.summarize(_utilization_response(observed_at), observed_at)
+
+    assert result["fleet_by_gpu"] == {
+        "GB200": {
+            "free_gpus": 476,
+            "held_gpus": 328,
+            "total_gpus": 804,
+            "held_by_band": {
+                "PRIORITY_BAND_BATCH": 4,
+                "PRIORITY_BAND_INTERACTIVE": 4,
+                "PRIORITY_BAND_PRODUCTION": 320,
+            },
+        },
+        "H100": {
+            "free_gpus": 112,
+            "held_gpus": 656,
+            "total_gpus": 768,
+            "held_by_band": {
+                "PRIORITY_BAND_BATCH": 528,
+                "PRIORITY_BAND_INTERACTIVE": 112,
+                "PRIORITY_BAND_PRODUCTION": 16,
+            },
+        },
+    }
+    assert [target["cluster"] for target in result["targets"]] == [
+        "cw-us-east-08a",
+        "cw-rno2a",
+        "cw-us-east-02a",
+    ]
+    assert all(target["observation_age_seconds"] == 20 for target in result["targets"])
+
+
+def test_utilization_rejects_stale_and_inconsistent_capacity() -> None:
+    observed_at = datetime(2026, 8, 16, 13, tzinfo=UTC)
+    stale = _utilization_response(observed_at)
+    stale["peers"][0]["backends"][0]["availability"]["observation_epoch_ms"] = str(
+        int((observed_at - timedelta(minutes=2)).timestamp() * 1000)
+    )
+    with pytest.raises(utilization.SnapshotError, match="stale"):
+        utilization.summarize(stale, observed_at)
+
+    inconsistent = _utilization_response(observed_at)
+    inconsistent["peers"][1]["backends"][0]["availability"]["amounts"]["h100"] = "111"
+    with pytest.raises(utilization.SnapshotError, match="accounting disagrees"):
+        utilization.summarize(inconsistent, observed_at)
+
+
+def test_utilization_requires_reachable_selected_peers() -> None:
+    observed_at = datetime(2026, 8, 16, 13, tzinfo=UTC)
+    response = copy.deepcopy(_utilization_response(observed_at))
+    response["peers"][2]["reachable"] = False
+    with pytest.raises(utilization.SnapshotError, match="unreachable"):
+        utilization.summarize(response, observed_at)
+
+    result = utilization.summarize(
+        response,
+        observed_at,
+        peers=("cw-rno2a", "cw-us-east-02a"),
+    )
+    assert set(result["fleet_by_gpu"]) == {"H100"}

--- a/.agents/skills/run-training-sweep-trc/SKILL.md
+++ b/.agents/skills/run-training-sweep-trc/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: run-training-sweep-trc
+description: Maximize sweep throughput and minimize wall-clock time to completion across global preemptible Google TRC TPUs. Use when a training sweep defines multiple configurations as trials and an agent must autonomously validate regional inputs, adapt placement to changing TPU availability, dispatch and recover Iris jobs, monitor W&B progress, persist execution state, and report until every trial finishes.
+---
+
+# Run Google TPU Training Sweep
+
+Finish the declared sweep as fast as possible without violating its operations document.
+
+Optimize global preemptible TPU capacity. Iris handles preemptions; do not replace a
+dispatch for a preemption alone—act from W&B progress and the recovery policy.
+
+## Contract
+
+- Treat each experiment-defined configuration as an opaque logical trial.
+- Let the training code own configuration and training semantics. Assume standard
+  W&B training fields; inspect code for launch, data, and checkpoint behavior.
+- Own only validation, placement, dispatch, monitoring, recovery, regional racing, accounting, and reporting.
+- Never generate configurations or decide experimental convergence.
+- Compose with `marin-experiment` for project setup, coherent Marin and Iris
+  versions, snapshots, and launch authorization. This skill does not authorize
+  remote compute by itself.
+- Follow `wandb-reporting` for MarinDNA run, group, and project naming.
+- Do not move a trial between accelerator families unless the operator explicitly
+  allows it. Persist and report the resulting hardware lineage as a reproducibility
+  caveat.
+
+## State
+
+Keep each durable fact in one authoritative form:
+
+- **Operations (text):** policy, choices, constraints, exceptions, and operating
+  conclusions not reliably recovered from code or data.
+- **Experiment and helper code:** executable behavior.
+- **SQLite (data):** structured observations, identities, attempts, action results,
+  clocks, and history.
+
+Session chat is the interface, not state. Put heartbeat reports and decisions needing
+operator input there. Anything needed by a later heartbeat belongs in text, code, or
+data.
+
+Never restate code or configuration in Operations; prefer a source reference. Create
+no other experiment log, runbook, or recurring status file. Correct the authoritative
+form instead of adding a competing note.
+
+## Process
+
+Read every reference in this table before setup. It assigns ownership; later
+sections define the phase contracts.
+
+| Phase | Purpose | Detailed references |
+| --- | --- | --- |
+| Initialize | Gather choices and establish durable state | [operations.md](references/operations.md), [targets.md](references/targets.md), [persistence.md](references/persistence.md) |
+| Validate | Establish safe regional targets and launch behavior | [validation.md](references/validation.md) |
+| Operate | Observe, place, recover, report, and schedule | [execution.md](references/execution.md), [throughput.md](references/throughput.md), [persistence.md](references/persistence.md) |
+| Finish | Verify completion, checkpoints, and integrity | [throughput.md](references/throughput.md), [persistence.md](references/persistence.md) |
+
+Use [utilization.md](references/utilization.md) only for optional placement hints.
+Investigate utilization failures when useful, but continue without that hint.
+
+```mermaid
+flowchart TD
+    A["Initialize, validate, and dispatch"] --> B["Refresh context and inventory"]
+    B --> C["Observe, reconcile, decide, and act"]
+    C --> D{"Finished or time limit reached?"}
+    D -- "No" --> E["Report and schedule the next pass"]
+    E --> B
+    D -- "Yes" --> F["Stop, verify, and summarize"]
+```
+
+## Initialize
+
+### Interview Briefly
+
+Ask only for missing information. Offer the recommended answer first.
+
+1. **Training entry point and trial catalog.** Require both.
+2. **Time limit.** Recommend two weeks. Explain shorter means faster recovery; longer is useful only when healthy trials need it.
+3. **Regional replicas per trial.** Recommend `1`; explain `2` often reduces completion time but duplicates work. Discourage more than `2`.
+4. **Compute and TPU scope.** Require an explicitly approved remote-compute scope
+   and overall chip limit before any smoke or production dispatch. Recommend the
+   limit from the training code and prior runs. Default the target scope to every
+   4–16-chip TPU in all otherwise allowed regions. Accept plain-English scopes or
+   exclusions such as “training chips only,” “4–16-chip inference TPUs in `euw4`,”
+   or “32+-chip TPUs in any region.” Recommend keeping cross-family reslicing
+   disabled unless throughput outweighs the reproducibility cost.
+5. **Sweep timing.** Recommend `heartbeat_every=30m`, `reslice_after=1h`,
+   `restart_after=3h`, and `relocate_after=3d`. Explain that they define the major
+   scheduled behavior to expect and should remain unchanged without a concrete
+   reason. Ask whether to use the defaults.
+
+Create the document from [operations.md](references/operations.md). Default to
+`scratch/<sweep>/expXXX_operations.md`; offer a tracked experiment-side file only
+if requested. Build its candidate grid from [targets.md](references/targets.md), then
+initialize SQLite:
+
+```bash
+uv run .agents/skills/run-training-sweep-trc/scripts/persistence.py \
+  init scratch/<sweep>/expXXX_sweep.sqlite
+```
+
+## Validate
+
+Follow [validation.md](references/validation.md) before the first dispatch. Validate
+the experiment entry point, regional inputs and checkpoints, target compatibility,
+W&B observation, and Iris submission. Submit only `eligible` targets and show the
+first assembled dispatch command to the operator.
+
+## Operate
+
+Run each heartbeat as a complete agent decision pass. Helpers may calculate or
+render facts; they may not choose or perform actions. Never delegate decisions to a
+monitor, dispatcher, scheduled loop, or recovery script.
+
+At every heartbeat:
+
+1. **Refresh context and inventory:** enter from authoritative state, not memory.
+   Reread Operations and relevant code, then build the inventory snapshot.
+2. **Observe, reconcile, decide, and act:** establish what is progressing before
+   changing anything. Query W&B first, use Iris only as allowed, persist observations,
+   and rebuild the decision snapshot. Protect recent progress, resolve exceptions,
+   reconsider every dispatch, and coordinate one fleet plan with
+   [execution.md](references/execution.md). Persist each result and revise the plan
+   when an action changes material facts.
+3. **Finish or continue:** if finished or out of time, stop, verify, and summarize.
+   Otherwise report in chat and schedule exactly one next pass for
+   `heartbeat_every`, using the environment's supported time-based task or thread
+   wakeup mechanism. Never rely on event-based monitoring.
+
+Build the inventory and decision snapshots with:
+
+```bash
+uv run .agents/skills/run-training-sweep-trc/scripts/persistence.py \
+  snapshot scratch/<sweep>/expXXX_sweep.sqlite --reslice-after-hours <hours>
+```
+
+Rebuild after material actions when needed. A snapshot is an ephemeral,
+decision-complete projection, not another status record. It covers every unfinished
+trial and actionable condition while summarizing stable history. Query raw history
+only for a specific decision.
+
+## Finish
+
+A trial finishes when `run_progress >= 1` and the expected checkpoint is reachable.
+W&B `finished` alone is insufficient.
+
+When every trial finishes or the time limit expires, stop remaining dispatches,
+verify completion and checkpoints, check SQLite integrity, and report the outcome as
+defined by [throughput.md](references/throughput.md). Include the accelerator and
+placement lineage for every trial that moved across hardware families. Do not
+schedule another pass.

--- a/.agents/skills/run-training-sweep-trc/agents/openai.yaml
+++ b/.agents/skills/run-training-sweep-trc/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Run Google TPU Training Sweep"
+  short_description: "Run and recover TPU training sweeps"
+  default_prompt: "Use $run-training-sweep-trc to launch and actively operate this TPU training sweep until it finishes."

--- a/.agents/skills/run-training-sweep-trc/references/execution.md
+++ b/.agents/skills/run-training-sweep-trc/references/execution.md
@@ -1,0 +1,166 @@
+# Execution
+
+## Use Four Identities
+
+- **Logical trial:** one opaque experiment configuration.
+- **Regional run:** one logical trial in one region; owns W&B and checkpoint identity.
+- **Dispatch:** one immutable Iris submission attempt.
+- **Target:** one allowed region, TPU slice, and chip count; lives in the operations document.
+
+Never parse W&B or Iris names.
+
+## Keep Iris Operations Simple
+
+Allowed routine job actions:
+
+- Submit an exact unique job.
+- Stop an exact job.
+- Ask whether an exact dispatch is running.
+- Recognize exact `unschedulable` results.
+- Treat every other successfully returned job state as not-running for liveness purposes.
+
+Iris never proves training progress. Do not routinely inspect logs, summaries, task counts,
+parent-child structure, retry history, pending reasons, or cluster capacity. W&B is the truth.
+
+An Iris timeout or service failure blocks all sweep work. Do not infer whether the request
+succeeded, inspect W&B, or take another action. Schedule one later pass that checks only Iris;
+keep waiting until it responds, then reconcile the affected exact dispatches before resuming.
+
+Inspect deeper only for a recorded reason, such as the same first-attempt failure reproducing
+across regions or a dispatch command failing before W&B registration. Do not derive placement
+policy from unfamiliar Iris internals.
+
+## Handle Unschedulable Targets
+
+On an unproven target, `unschedulable` normally exposes an invalid region and slice
+combination admitted to the grid; it does not mean temporary scarcity.
+
+1. Verify the dispatch requested the intended region, slice, and chip count.
+2. Record `target_unschedulable`; do not retry the exact target.
+3. Mark only that target `ineligible` in Operations and add a terse `Change Record`
+   entry naming the grid change and its cause.
+4. Reslice or relocate immediately to another eligible target.
+
+Do not generalize one result to a region or TPU family. If the exact target worked
+previously, pause it and investigate before changing eligibility. Treat simultaneous
+results across previously valid targets as a systemic problem.
+
+## Make Every Dispatch Unique
+
+- Assign attempt numbers in SQLite.
+- Use a unique Iris job name, such as `<opaque-wandb-id>-<slice>-a<attempt>`.
+- Never recover attempt numbers or metadata by parsing that name.
+- Give every Iris job one immutable dispatch row.
+- Stop the current dispatch before replacing it.
+- Allow at most one active dispatch per regional run.
+
+Resume comes from the regional checkpoint, not the Iris name.
+
+## Classify Failures Before Retry
+
+Observe the whole W&B fleet before acting on a `failed` run.
+
+- If the failure is isolated, stop its dispatch if still running and immediately submit a
+  unique replacement on the same region and slice from the regional checkpoint.
+- If failures recur after replacement or cluster across otherwise independent trials,
+  regions, or targets, pause replacements and investigate a shared cause. Inspect deeper
+  Iris details only with this reason recorded.
+- Resume with a concrete basis, contain or stop affected work, or wait for operator
+  direction when the safe response is unclear. Do not blindly retry.
+
+## Rebalance Every Heartbeat
+
+No command reveals available TRC capacity. Submission is the measurement. Begin an
+unknown two-week sweep with:
+
+```text
+heartbeat_every = 30 minutes
+reslice_after = 1 hour
+restart_after = 3 hours
+relocate_after = 3 days
+pending_target_limit = 1
+```
+
+Confirm the four timing settings during the interview; record them and
+`pending_target_limit` in Operating Policy. Retain the defaults unless a concrete
+condition warrants changing them. Each heartbeat preserves dispatches with progress
+within `reslice_after` and considers every other dispatch for reslicing. A dispatch
+becomes restart-eligible after neither moving nor progressing for `restart_after`;
+its regional run becomes relocation-eligible after no progress for `relocate_after`.
+Only a new W&B `run_progress` high-water mark proves progress.
+
+A replacement starts a new dispatch clock. Restarting or reslicing never resets the
+regional clock; only progress does.
+
+### Admit Destinations
+
+A target's pending count is its active dispatches without progress during
+`reslice_after`; productive dispatches do not count. Treat a planned dispatch as
+pending until it proves progress. Its placement must leave the count at or below
+`pending_target_limit`.
+
+Build one fleet plan, reserving pending headroom after each proposed placement so
+later decisions see it. This limit controls admission only: never stop progressing
+work or evict dispatches merely because the count later rises.
+
+### Choose An Action
+
+For each reslice candidate:
+
+1. Search for a different eligible target in the same region with pending headroom.
+2. Rank credible targets with `target_rate` and judgment informed by current
+   progress, prior experiments, optional fleet utilization, and useful exploration.
+3. If no same-region move is justified and relocation is due, repeat the search in a
+   different validated region.
+4. If no move is justified and restart is due, restart the current target.
+5. Otherwise leave the dispatch unchanged and state the reason.
+
+Reslice by default when a credible alternative exists; a no-op requires a concrete
+reason. Apply the same target accounting to new trials and requested replicas. Stop
+before replacing, and replan when an action changes material facts.
+
+- **Restart:** same region, slice, and regional checkpoint.
+- **Reslice:** different target in the same region, same checkpoint.
+- **Relocate:** different validated region, separate regional run from zero, no
+  transferred data.
+
+Recompute evidence every heartbeat and never copy rankings into Operations. Probe
+with real trials; never change the priority band to solve scarcity.
+
+## Race Regions Optionally
+
+Default to one live regional run per logical trial.
+
+With two replicas:
+
+- Start distinct validated regions.
+- Maintain two live regional runs while the trial is incomplete and resources permit.
+- Let both run until one fully completes.
+- Stop every nonterminal sibling only after `run_progress >= 1` and the expected
+  checkpoint is reachable.
+- Record siblings as race losses.
+
+Discourage more than two replicas without a specific operator reason.
+
+With one replica, relocation remains allowed after its timeout. It replaces the active region
+and starts from zero.
+
+## Handle Client Revision Rejections
+
+Apply this only when a new dispatch fails with an error like
+`marin-iris client is too old (build <date>; minimum <date>)`; exact wording may
+vary. Do not check the revision on every loop.
+
+On rejection:
+
+1. Record `client_floor_failed`.
+2. Stop new submissions and recovery-driven stops.
+3. Follow `marin-experiment` to resolve a coherent current Marin and Iris dependency
+   set, regenerate the lockfile, and validate the launch import.
+4. Verify the runtime-reported date and prove a canary submission is accepted.
+5. Resume on acceptance; otherwise stop and give the operator the dates, failure,
+   and options.
+
+Do not change `BUILD_DATE` alone or restart or reconfigure the shared Iris cluster.
+If the dependency update is outside the approved task scope, stop and ask the
+operator with the reported and required dates.

--- a/.agents/skills/run-training-sweep-trc/references/operations.md
+++ b/.agents/skills/run-training-sweep-trc/references/operations.md
@@ -1,0 +1,84 @@
+# Operations
+
+Create one living `expXXX_operations.md` per sweep. Default to
+`scratch/<sweep>/`. The agent must read it completely at the start of every heartbeat.
+
+Use terse English for rules, choices, constraints, exceptions, and operating
+conclusions not reliably recovered from code or data. Never restate code or
+configuration; reference its source. Never write heartbeat observations, job
+status, progress, rankings, action queues, reports, or next-check times here.
+
+## Required Structure
+
+```markdown
+# expXXX Sweep Operations
+
+> This document governs a training sweep managed with the `run-training-sweep-trc`
+> skill. Read it in full at the start of every heartbeat before inspecting code,
+> SQLite, W&B, or Iris.
+
+## Invariants
+
+State the constraints that must hold throughout the sweep.
+
+## Sweep Definition
+
+Point to the training entry point and configuration catalog. State only regional
+data, initialization, and checkpoint constraints not clear from code or SQLite.
+
+## Operator Choices
+
+Record the time limit, regional replica count, approved chip limit, approved
+regions and TPU families, exclusions, whether cross-family reslicing is allowed,
+priority band, and document location.
+
+## Operating Policy
+
+State `heartbeat_every`, `reslice_after`, `restart_after`, `relocate_after`, and
+`pending_target_limit`; isolated/systemic failure handling; regional racing; and
+completion behavior.
+
+Maintain the authoritative target grid here:
+
+| Region | Bucket | Slice | Chips | State | Reason |
+| --- | --- | --- | ---: | --- | --- |
+| `<canonical region>` | `<configured bucket>` | `<exact Iris slice>` | `<count>` | `unvalidated` | — |
+
+Create the candidate rows from `targets.md`, then validate them. State is
+`unvalidated` while validation is pending, `eligible` when dispatch is permitted, or
+`ineligible` when a verified restriction prohibits dispatch. `Reason` is required
+only for `ineligible` targets and names that restriction.
+
+Keep every considered region and slice visible. Only `eligible` targets may be
+dispatched. A trial-specific failure does not make a target globally ineligible. A
+verified invalid-target result, including Iris `unschedulable`, makes only its exact
+target ineligible. Treat `unschedulable` on a previously working target as an anomaly
+to investigate rather than routine grid pruning.
+
+## Change Record
+
+Only while the autonomous loop is running, record important, unexpected changes
+made in response to unusual conditions. Every entry must correspond to an actual
+change to this document, the SQLite data model, or execution code. Give UTC time,
+cause, exact change, and operational effect. Do not duplicate SQLite event details
+or session reports.
+
+None.
+```
+
+## Keep A Selective Change Record
+
+Use `Change Record` only during the autonomous loop, never during setup or validation,
+or ordinary development. Require an unexpected or unusual condition to cause an
+actual change to Operations, the SQLite model, or execution code. Examples include
+a validated token cache disappearing, changing a recovery timeout, or changing an
+Iris `BUILD_DATE`.
+
+Update the relevant Operations section in place so it states the current rule. Then
+add one terse entry with the cause, change, and effect. Ask before changing Operator
+Choices or experiment semantics.
+
+Never record routine dispatches, retries, progress, utilization, or placement
+rankings here. In particular, never turn a region/slice throughput advantage into
+Operations policy or target eligibility; recompute rankings from SQLite every loop.
+Consolidate related changes rather than preserving a blow-by-blow sequence.

--- a/.agents/skills/run-training-sweep-trc/references/persistence.md
+++ b/.agents/skills/run-training-sweep-trc/references/persistence.md
@@ -1,0 +1,108 @@
+# Persistence
+
+One local SQLite database is the durable record of dynamic sweep state. Its model
+covers heartbeat reconciliation, placement ranking, recovery, regional racing,
+completion, and reporting.
+
+## Concepts
+
+The bundled SQLite schema represents these concepts:
+
+| Concept | Essential facts |
+| --- | --- |
+| Sweep | Identity, schema version, creation and start times |
+| Trial | Opaque ID, experiment parameters, current status |
+| Run | Trial, region, W&B ID, checkpoint root, status, winner flag, `run_progress` high-water state, regional progress clock |
+| Dispatch | Immutable attempt, run, Iris ID, actual TPU slice and chips, priority, redacted command, submission, progress clock, and end state |
+| Observation | UTC time, run and dispatch, W&B state, `run_progress`, and binary Iris running state |
+| Event | UTC time, kind, associated identities, concise evidence |
+
+Current status and high-water fields may be materialized for simple heartbeat
+queries; timestamped observations, immutable dispatches, and events preserve the
+evidence behind them.
+
+## Relationships And Invariants
+
+- A trial has at most one run per region and at most one winning run.
+- A run has a sequence of uniquely numbered dispatches and at most one active
+  dispatch.
+- All persisted times are UTC.
+- W&B and Iris IDs remain opaque and unique. Attempt numbers come from persisted
+  state, never parsed names.
+- A dispatch's run supplies its region; the dispatch supplies the slice
+  and chip count actually submitted. Historical placement therefore survives
+  changes to the Operations target grid.
+- Dispatches, observations, and events retain stopped, failed, superseded, and
+  losing history. Stop-and-replace, winner-and-cancel, and completion transitions
+  are atomic.
+- Commands and experiment parameters contain no API keys, tokens, or secret values.
+
+Operations owns target eligibility and policy. SQLite owns observed facts and
+action history; it does not own transient rankings or duplicate the Operations
+`Change Record`.
+
+## Supported Decisions
+
+The model supports these recurring queries:
+
+- **Placement:** each target combines historical `target_rate` with current productive
+  and pending dispatch counts. Rates include zero-progress and pre-W&B wall time;
+  rankings remain ephemeral.
+- **Recovery:** a dispatch clock begins at submission or its latest progress. The
+  regional clock begins at first submission or the regional run's latest progress;
+  same-region replacements preserve it.
+- **Liveness:** the latest observation attributed to the active dispatch establishes
+  its W&B state and progress; its Iris flag answers only whether it is running.
+- **Accounting:** active dispatch placement yields submitted chips; that dispatch's
+  W&B state separates submitted chips from chips currently training.
+- **Failures:** attempt history, end state, failure events, and placement make
+  isolated retries and correlated failures distinguishable.
+- **Racing and completion:** run high-water progress, winner state, and
+  checkpoint verification identify race winners and completed trials.
+- **Reporting:** observation history supports progress since the prior heartbeat,
+  time since progress, time to first progress, and action history.
+
+## Control Snapshot
+
+Rebuild a compact snapshot at the start of a heartbeat to inventory work, then
+again after recording fresh observations to support decisions:
+
+```bash
+uv run .agents/skills/run-training-sweep-trc/scripts/persistence.py \
+  snapshot scratch/<sweep>/expXXX_sweep.sqlite --reslice-after-hours <hours>
+```
+
+The JSON includes every unfinished trial and its runs, current dispatches, regional
+and dispatch progress clocks, latest observations, target rates and current
+productive/pending counts, fleet accounting, actionable conditions, event counts,
+and a bounded recent-event window. Coverage counts expose omitted stable history.
+
+The snapshot is read-only and ephemeral. It summarizes history inside SQLite; it
+does not become another status file or durable report. Query raw rows only to
+investigate a specific decision. Snapshot generation fails when core identities,
+dispatch intervals, progress high-water marks, or completion state are inconsistent.
+
+## Event History
+
+Expected event kinds include:
+
+- `dispatch_submitted`, `dispatch_stopped`, `dispatch_terminal`
+- `target_unschedulable`
+- `wandb_registered`, `progress`, `stall_started`
+- `failure_retryable`, `systemic_failure`
+- `restart`, `reslice`, `relocate`
+- `race_won`, `race_lost`
+- `trial_completed`, `checkpoint_verified`
+- `client_floor_failed`
+
+Action events carry concise evidence. Heartbeat prose and no-change explanations
+remain in session chat.
+
+## Helper
+
+The bundled helper initializes the model, records events, emits snapshots, and
+checks integrity:
+
+```bash
+uv run .agents/skills/run-training-sweep-trc/scripts/persistence.py --help
+```

--- a/.agents/skills/run-training-sweep-trc/references/targets.md
+++ b/.agents/skills/run-training-sweep-trc/references/targets.md
@@ -1,0 +1,20 @@
+# Targets
+
+Translate the operator's plain-English TPU scope into the complete candidate grid
+before validating placement. By default, include every 4–16-chip TPU target in all
+otherwise allowed regions.
+
+Read the current Marin and Iris configuration. Expand the requested scope into
+exact `(region, bucket, slice, chips)` rows and remove duplicate rows. Normalize
+region aliases such as `euw4` to `europe-west4`; resolve buckets from configuration,
+never by convention.
+
+Scopes may select purpose, chip count, TPU family, region, or exclusions. Examples
+include “training chips only,” “4–16-chip inference TPUs in `euw4`,” and “32+-chip
+TPUs in any region.” Resolve terms such as training and inference from current Iris
+pool definitions, not TPU-family assumptions. Show the interpretation when it is
+ambiguous.
+
+Add every candidate to Operations as `unvalidated`. Only validation or a verified
+invalid-target result changes eligibility. Fleet utilization and measured throughput
+rank eligible targets; they never define or narrow the candidate grid.

--- a/.agents/skills/run-training-sweep-trc/references/throughput.md
+++ b/.agents/skills/run-training-sweep-trc/references/throughput.md
@@ -1,0 +1,85 @@
+# Throughput
+
+## Placement Rates
+
+A target's `target_rate` measures how quickly it advances training after charging
+all wall-clock time spent on that target. Assume all trials in the sweep are
+comparable for placement.
+
+```text
+target_rate = total increase in run_progress high-water / total dispatch hours
+```
+
+Each high-water increase counts once, on the target whose dispatch first establishes
+it. Dispatch hours run from submission through the current heartbeat for active work,
+or through the recorded end and final observation for ended work. Queueing, startup,
+compilation, evaluation, checkpoints, preemption, stalls, failures, and zero-progress
+attempts all count.
+
+For example, `0.12` progress across eight dispatch-hours gives a `target_rate` of
+`0.015` progress per hour, including any zero-progress time in those eight hours.
+
+The persistence helper calculates one rate per `(region, slice, chips)` across the
+sweep. Use the emitted value; do not reconstruct it with routine SQL. Recompute every
+heartbeat and prefer a higher rate when other evidence is comparable, but combine it
+with current target progress, pending headroom, and agent judgment. Never normalize
+by chip count.
+
+For fleet progress under regional racing, use the maximum regional `run_progress`
+for each logical trial. Do not sum replicas.
+
+## Determine Liveness
+
+- `training now`: W&B state is `running`.
+- `recent progress`: the `run_progress` high-water mark increased within
+  `reslice_after`.
+- `pending`: the current dispatch has not made progress within `reslice_after`.
+- Iris running: the dispatch may execute; never proof of training.
+
+Completion requires `run_progress >= 1` and a reachable expected checkpoint.
+
+## Report Every Heartbeat
+
+Report in the session chat. Choose the clearest format for the current fleet; do not
+follow a fixed template. Include enough detail that the operator can audit what is
+running, what changed, and what will happen next.
+
+Always include:
+
+- **Control context:** UTC observation time.
+- **Fleet accounting:** submitted dispatches and chips, W&B-running regional runs
+  and chips, and the gap between submitted and training capacity.
+- **Trial accounting:** counts of complete, recently progressing, pending, and
+  not-yet-running trials. Identify affected trials, not only aggregate counts.
+- **Active progress:** for each live or recently active regional run, give trial,
+  region, slice, W&B state, current and high-water `run_progress`, change since the
+  prior heartbeat, and time since the last increase.
+- **Actions:** every submit, stop, restart, reslice, relocate, or race cancellation
+  since the prior heartbeat, with its operational reason. If nothing changed, say
+  why waiting is still the best action.
+- **Recovery:** every failed, stalled, or unregistered run; whether failures appear
+  isolated or systemic; its time since progress; the next restart/reslice/relocate
+  threshold; and the action due.
+- **Placement evidence:** each relevant target's productive and pending dispatches,
+  `target_rate`, time to first progress when known, and any eligibility or regional
+  input blocker affecting the next placement.
+- **Next check:** a specific UTC time backed by a scheduled trigger, plus the actions
+  expected if progress remains unchanged.
+
+Include when relevant:
+
+- Replica progress and the condition for ending a regional race.
+- Checkpoint or resume status when recovering, reslicing, relocating, or completing.
+- Iris `unschedulable` targets, client-floor failures, priority constraints, or
+  decisions needing operator approval.
+- An apparent leader when useful. Let experiment context determine what “leader”
+  means; this skill does not define or require an optimization metric.
+
+Do not hide a problem inside aggregate counts. Omit facts only when genuinely
+inapplicable, not because they are unchanged.
+
+## Keep The Heartbeat In Chat
+
+- Never copy observations, status, progress, actions, or the next check into Operations.
+- Never store the heartbeat report in SQLite.
+- Never create another log, runbook, or recurring status file.

--- a/.agents/skills/run-training-sweep-trc/references/utilization.md
+++ b/.agents/skills/run-training-sweep-trc/references/utilization.md
@@ -1,0 +1,31 @@
+# Utilization
+
+Use this optional snapshot for cold starts or when measured placements stop working.
+It is a hint, never capacity truth or a source of target eligibility.
+
+Run from an environment that provides the `iris` executable:
+
+```bash
+uv run --project <marin-checkout> --package marin-iris \
+  python <skill-path>/scripts/utilization.py --cluster marin
+```
+
+Pass exactly one of `--cluster <name>` or `--config <path>`. Use `--iris-bin
+<path>` only when `iris` is not on `PATH`.
+
+The script emits JSON to stdout with:
+
+- `observed_at_utc`, fleet and per-region ready/in-use totals.
+- One target per `(region, TPU slice)` currently represented by ready slices.
+- Ready/in-use counts, percent in use, and average slice age per target.
+- Slice-capacity counts plus autoscaler status and any reasons.
+
+Priority-band mix is intentionally omitted: it does not guide placement and requires
+a second, independently timed scheduler snapshot.
+
+It calls Iris `get-autoscaler-status` and requires structured TPU variant, region,
+slice state, and capacity fields. It exits nonzero on CLI failure, malformed JSON,
+missing fields, inconsistent counts, or unknown Iris states. Extra fields are safe.
+
+Investigate failures when useful, but do not block placement if an accurate snapshot
+cannot be obtained. Continue with measured throughput and grid exploration.

--- a/.agents/skills/run-training-sweep-trc/references/validation.md
+++ b/.agents/skills/run-training-sweep-trc/references/validation.md
@@ -1,0 +1,103 @@
+# Validation
+
+Establish which experiment-defined configurations and regional targets can be
+launched, observed, and checkpointed safely. Derive the needed facts from the
+training entry point, its configuration, and existing framework behavior before
+the first sweep dispatch.
+
+## Minimum From The Script
+
+The script needs only to launch one selected, experiment-defined configuration from
+explicit parameters. Environment variables are preferred. Region and TPU placement
+may instead be inputs to the existing launcher or training framework.
+
+If the agent cannot select one configuration unambiguously, propose the smallest
+script change and ask before making it. Do not add fields merely to simplify
+orchestration.
+
+## Inspect Before Launch
+
+Read the script and the helpers it calls. Verify:
+
+- Configuration inputs and the exact one-trial command.
+- How data, token caches, initialization inputs, and checkpoints resolve by region.
+- How a same-region restart resumes and how a cross-region restart begins separately.
+- Which TPU slices the script and training framework can actually run.
+
+Do not transcribe code or configuration into Operations. Prefer source references;
+record only resulting constraints, exceptions, and operating conclusions.
+
+## Validate Regional Inputs First
+
+Before treating a region as eligible:
+
+1. Resolve its data and token-cache locations from code or configuration.
+2. Confirm the needed objects exist and are usable using cheap existing metadata,
+   manifests, counts, or framework validation.
+3. Confirm initialization inputs, such as checkpoints used when not starting from
+   scratch, are available in that region.
+4. Update the target state in Operations; give a reason only when it is ineligible.
+
+Never copy or move data between regions. A missing cache makes the region ineligible;
+it does not make the region disappear. Keep the resulting restriction visible in
+Operations.
+
+Use configured bucket mappings. In particular, `europe-west4` uses
+`marin-eu-west4`; never derive its bucket name.
+
+## Validate Checkpoint Locality
+
+Determine the resolved checkpoint location from the script, framework configuration,
+preview, or a cheap smoke run.
+
+- A same-region reslice must resume from the same regional checkpoint storage.
+- A cross-region relocation must use separate regional storage and start from the
+  beginning unless the required state already exists there.
+- Never allow two live jobs to write the same checkpoint location.
+
+Do not impose a checkpoint naming scheme. Stop before launch if the location or
+writer ownership is ambiguous.
+
+## Validate Placement
+
+Start from the complete candidate grid defined by
+[targets.md](targets.md). Determine eligibility from:
+
+- Known platform restrictions.
+- The script or training framework's placement check.
+- A smoke run when static checks are insufficient.
+
+Do not guess memory feasibility. Mark combinations `eligible`, `ineligible`, or
+`unvalidated` in the operations-document target grid; only submit eligible
+combinations.
+
+## Assess Parallelism Fit
+
+Compare the target grid's chip counts and per-chip HBM with how the script chooses
+data, tensor, context, or equivalent parallelism. Warn, but do not block, when a
+broad grid appears unsupported. For example, if global batch size is smaller than
+the chip count of a target and no tensor or context parallelism makes that target
+usable, ask the operator to verify it. Apply judgment to narrow grids; this advisory
+alone does not change target eligibility.
+
+## Validate W&B Observation
+
+Assume training runs provide W&B `state` and `run_progress`. Use `state` for current
+liveness and the `run_progress` high-water mark for progress, completion, stall timing,
+and placement throughput.
+
+Use the sweep's normal W&B routing and group. Follow `wandb-reporting` and require
+MarinDNA run names to map back to `dna-exp<N>`. Require region as a structured W&B
+field or tag so regional runs can be distinguished. Treat run IDs as opaque; never
+extract metadata from an ID or display name.
+
+## Validate Submission
+
+Before the first launch:
+
+- Confirm the Iris client meets the required revision floor.
+- Confirm the exact command and secrets that must be forwarded; keep secrets out of
+  Operations and SQLite.
+- Record the existing priority band. Never change it without explicit operator
+  approval.
+- Show the first submission command to the operator for review.

--- a/.agents/skills/run-training-sweep-trc/scripts/persistence.py
+++ b/.agents/skills/run-training-sweep-trc/scripts/persistence.py
@@ -1,0 +1,901 @@
+"""Initialize, inspect, and check training-sweep persistence."""
+
+import argparse
+import json
+import sqlite3
+from collections import Counter, defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+
+SCHEMA_VERSION = 2
+
+SCHEMA = """
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS trials (
+    trial_id TEXT PRIMARY KEY,
+    env_json TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'planned'
+);
+
+CREATE TABLE IF NOT EXISTS runs (
+    regional_run_id TEXT PRIMARY KEY,
+    trial_id TEXT NOT NULL REFERENCES trials(trial_id),
+    region TEXT NOT NULL,
+    wandb_run_id TEXT NOT NULL,
+    wandb_url TEXT,
+    checkpoint_root TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'planned',
+    high_water_progress REAL NOT NULL DEFAULT 0 CHECK (high_water_progress >= 0),
+    checkpoint_verified_at TEXT,
+    is_winner INTEGER NOT NULL DEFAULT 0 CHECK (is_winner IN (0, 1)),
+    UNIQUE (trial_id, region),
+    UNIQUE (wandb_run_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS one_winner_per_trial
+ON runs(trial_id) WHERE is_winner = 1;
+
+CREATE TABLE IF NOT EXISTS dispatches (
+    dispatch_id TEXT PRIMARY KEY,
+    regional_run_id TEXT NOT NULL REFERENCES runs(regional_run_id),
+    attempt INTEGER NOT NULL CHECK (attempt > 0),
+    iris_job_id TEXT NOT NULL UNIQUE,
+    tpu_slice TEXT NOT NULL,
+    chips INTEGER NOT NULL CHECK (chips > 0),
+    priority_band TEXT NOT NULL,
+    command_redacted TEXT NOT NULL,
+    submitted_at TEXT NOT NULL,
+    ended_at TEXT,
+    active INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0, 1)),
+    outcome TEXT,
+    stop_reason TEXT,
+    UNIQUE (regional_run_id, attempt)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS one_active_dispatch_per_regional_run
+ON dispatches(regional_run_id) WHERE active = 1;
+
+CREATE INDEX IF NOT EXISTS dispatch_target_history
+ON dispatches(regional_run_id, tpu_slice, chips, submitted_at);
+
+CREATE TABLE IF NOT EXISTS observations (
+    observation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    regional_run_id TEXT NOT NULL REFERENCES runs(regional_run_id),
+    dispatch_id TEXT NOT NULL REFERENCES dispatches(dispatch_id),
+    observed_at TEXT NOT NULL,
+    wandb_state TEXT,
+    run_progress REAL CHECK (run_progress IS NULL OR run_progress >= 0),
+    iris_running INTEGER CHECK (iris_running IS NULL OR iris_running IN (0, 1)),
+    UNIQUE (regional_run_id, observed_at)
+);
+
+CREATE INDEX IF NOT EXISTS observations_by_dispatch_time
+ON observations(dispatch_id, observed_at);
+
+CREATE TABLE IF NOT EXISTS events (
+    event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    recorded_at TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    trial_id TEXT REFERENCES trials(trial_id),
+    regional_run_id TEXT REFERENCES runs(regional_run_id),
+    dispatch_id TEXT REFERENCES dispatches(dispatch_id),
+    detail TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS events_by_time
+ON events(recorded_at);
+
+"""
+
+REQUIRED_COLUMNS = {
+    "meta": {"key", "value"},
+    "trials": {"trial_id", "env_json", "status"},
+    "runs": {
+        "regional_run_id",
+        "trial_id",
+        "region",
+        "wandb_run_id",
+        "checkpoint_root",
+        "status",
+        "high_water_progress",
+        "checkpoint_verified_at",
+        "is_winner",
+    },
+    "dispatches": {
+        "dispatch_id",
+        "regional_run_id",
+        "attempt",
+        "iris_job_id",
+        "tpu_slice",
+        "chips",
+        "priority_band",
+        "command_redacted",
+        "submitted_at",
+        "ended_at",
+        "active",
+        "outcome",
+        "stop_reason",
+    },
+    "observations": {
+        "observation_id",
+        "regional_run_id",
+        "dispatch_id",
+        "observed_at",
+        "wandb_state",
+        "run_progress",
+        "iris_running",
+    },
+    "events": {
+        "event_id",
+        "recorded_at",
+        "kind",
+        "trial_id",
+        "regional_run_id",
+        "dispatch_id",
+        "detail",
+    },
+}
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _parse_time(value: str, field: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise RuntimeError(
+            f"{field} is not an ISO-8601 timestamp: {value!r}"
+        ) from error
+    if parsed.tzinfo is None:
+        raise RuntimeError(f"{field} has no timezone: {value!r}")
+    return parsed.astimezone(UTC)
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(path)
+    connection.execute("PRAGMA foreign_keys = ON")
+    return connection
+
+
+def _user_tables(connection: sqlite3.Connection) -> set[str]:
+    return {
+        row[0]
+        for row in connection.execute(
+            """
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+            """
+        )
+    }
+
+
+def _schema_errors(connection: sqlite3.Connection) -> list[str]:
+    errors: list[str] = []
+    version = connection.execute("PRAGMA user_version").fetchone()[0]
+    if version != SCHEMA_VERSION:
+        errors.append(f"schema version {version}; expected {SCHEMA_VERSION}")
+
+    for table, required in REQUIRED_COLUMNS.items():
+        actual = {row[1] for row in connection.execute(f'PRAGMA table_info("{table}")')}
+        missing = required - actual
+        if missing:
+            errors.append(f"{table}: missing columns {sorted(missing)}")
+    return errors
+
+
+def init(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with _connect(path) as connection:
+        version = connection.execute("PRAGMA user_version").fetchone()[0]
+        if _user_tables(connection) and version != SCHEMA_VERSION:
+            raise RuntimeError(
+                f"{path} has schema version {version}; expected {SCHEMA_VERSION}"
+            )
+        connection.executescript(SCHEMA)
+        connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+        connection.execute(
+            "INSERT OR IGNORE INTO meta(key, value) VALUES (?, ?)",
+            ("created_at", _now()),
+        )
+        errors = _schema_errors(connection)
+        if errors:
+            raise RuntimeError("; ".join(errors))
+
+
+def record_event(
+    path: Path,
+    kind: str,
+    detail: str,
+    trial_id: str | None,
+    regional_run_id: str | None,
+    dispatch_id: str | None,
+) -> None:
+    with _connect(path) as connection:
+        connection.execute(
+            """
+            INSERT INTO events(
+                recorded_at, kind, trial_id, regional_run_id, dispatch_id, detail
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (_now(), kind, trial_id, regional_run_id, dispatch_id, detail),
+        )
+
+
+def _structural_errors(path: Path) -> list[str]:
+    errors: list[str] = []
+    if not path.is_file():
+        return [f"database does not exist: {path}"]
+    with _connect(path) as connection:
+        integrity = connection.execute("PRAGMA integrity_check").fetchone()
+        if integrity != ("ok",):
+            errors.append(f"integrity_check: {integrity}")
+        for row in connection.execute("PRAGMA foreign_key_check"):
+            errors.append(f"foreign_key_check: {row}")
+        errors.extend(_schema_errors(connection))
+        if errors:
+            return errors
+        duplicate_active = connection.execute(
+            """
+            SELECT regional_run_id, COUNT(*)
+            FROM dispatches
+            WHERE active = 1
+            GROUP BY regional_run_id
+            HAVING COUNT(*) > 1
+            """
+        ).fetchall()
+        for row in duplicate_active:
+            errors.append(f"multiple active dispatches: {row}")
+        inconsistent_dispatches = connection.execute(
+            """
+            SELECT dispatch_id, active, ended_at
+            FROM dispatches
+            WHERE (active = 1 AND ended_at IS NOT NULL)
+               OR (active = 0 AND ended_at IS NULL)
+            """
+        ).fetchall()
+        for row in inconsistent_dispatches:
+            errors.append(f"inconsistent dispatch end state: {row}")
+        mismatched_observations = connection.execute(
+            """
+            SELECT observations.observation_id
+            FROM observations
+            JOIN dispatches USING (dispatch_id)
+            WHERE observations.regional_run_id != dispatches.regional_run_id
+            """
+        ).fetchall()
+        for row in mismatched_observations:
+            errors.append(f"observation dispatch/run mismatch: {row[0]}")
+    return errors
+
+
+def _build_snapshot(
+    path: Path, recent_event_limit: int, reslice_after_hours: float
+) -> dict[str, object]:
+    if recent_event_limit < 0:
+        raise RuntimeError("recent event limit must be nonnegative")
+    if reslice_after_hours <= 0:
+        raise RuntimeError("reslice-after hours must be positive")
+
+    snapshot_at = datetime.now(UTC)
+    reslice_after_seconds = reslice_after_hours * 3600
+    with _connect(path) as connection:
+        connection.row_factory = sqlite3.Row
+        trials = list(connection.execute("SELECT * FROM trials ORDER BY trial_id"))
+        runs = list(connection.execute("SELECT * FROM runs ORDER BY regional_run_id"))
+        dispatches = list(
+            connection.execute(
+                "SELECT * FROM dispatches ORDER BY submitted_at, dispatch_id"
+            )
+        )
+        observations = list(
+            connection.execute(
+                """
+                SELECT *
+                FROM observations
+                ORDER BY regional_run_id, observed_at, observation_id
+                """
+            )
+        )
+        event_counts = {
+            row["kind"]: row["count"]
+            for row in connection.execute(
+                "SELECT kind, COUNT(*) AS count FROM events GROUP BY kind ORDER BY kind"
+            )
+        }
+        event_total = connection.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+        recent_events = list(
+            connection.execute(
+                """
+                SELECT event_id, recorded_at, kind, trial_id, regional_run_id,
+                       dispatch_id, detail
+                FROM events
+                ORDER BY event_id DESC
+                LIMIT ?
+                """,
+                (recent_event_limit,),
+            )
+        )
+
+    run_by_id = {row["regional_run_id"]: row for row in runs}
+    dispatch_by_id = {row["dispatch_id"]: row for row in dispatches}
+    runs_by_trial: dict[str, list[sqlite3.Row]] = defaultdict(list)
+    dispatches_by_run: dict[str, list[sqlite3.Row]] = defaultdict(list)
+    observations_by_run: dict[str, list[tuple[sqlite3.Row, datetime]]] = defaultdict(
+        list
+    )
+
+    for run in runs:
+        runs_by_trial[run["trial_id"]].append(run)
+    for dispatch in dispatches:
+        dispatches_by_run[dispatch["regional_run_id"]].append(dispatch)
+    for observation in observations:
+        observed_at = _parse_time(
+            observation["observed_at"],
+            f"observation {observation['observation_id']} observed_at",
+        )
+        if observed_at > snapshot_at:
+            raise RuntimeError(
+                f"observation {observation['observation_id']} is in the future"
+            )
+        if observation["dispatch_id"] is not None:
+            dispatch = dispatch_by_id[observation["dispatch_id"]]
+            submitted_at = _parse_time(
+                dispatch["submitted_at"],
+                f"dispatch {dispatch['dispatch_id']} submitted_at",
+            )
+            if observed_at < submitted_at:
+                raise RuntimeError(
+                    f"observation {observation['observation_id']} predates its dispatch"
+                )
+        observations_by_run[observation["regional_run_id"]].append(
+            (observation, observed_at)
+        )
+    for run_observations in observations_by_run.values():
+        run_observations.sort(key=lambda item: (item[1], item[0]["observation_id"]))
+
+    progress_by_dispatch: dict[str, float] = defaultdict(float)
+    first_progress_at_by_dispatch: dict[str, datetime] = {}
+    last_progress_at_by_dispatch: dict[str, datetime] = {}
+    for run_observations in observations_by_run.values():
+        progress_high_water = 0.0
+        for observation, observed_at in run_observations:
+            progress = observation["run_progress"]
+            if progress is None or progress <= progress_high_water:
+                continue
+            progress_delta = progress - progress_high_water
+            progress_high_water = progress
+            dispatch_id = observation["dispatch_id"]
+            if dispatch_id is None:
+                continue
+            progress_by_dispatch[dispatch_id] += progress_delta
+            first_progress_at_by_dispatch.setdefault(dispatch_id, observed_at)
+            last_progress_at_by_dispatch[dispatch_id] = observed_at
+
+    completed_trial_ids = {
+        trial["trial_id"]
+        for trial in trials
+        if trial["status"].casefold() == "completed"
+    }
+    for trial_id in completed_trial_ids:
+        trial_runs = runs_by_trial[trial_id]
+        winners = [run for run in trial_runs if run["is_winner"]]
+        if len(winners) != 1:
+            raise RuntimeError(
+                f"completed trial {trial_id!r} has {len(winners)} winning runs"
+            )
+        winner = winners[0]
+        if winner["high_water_progress"] < 1:
+            raise RuntimeError(
+                f"completed trial {trial_id!r} has winner progress below 1"
+            )
+        if winner["checkpoint_verified_at"] is None:
+            raise RuntimeError(
+                f"completed trial {trial_id!r} has no verified checkpoint"
+            )
+        if any(
+            dispatch["active"]
+            for run in trial_runs
+            for dispatch in dispatches_by_run[run["regional_run_id"]]
+        ):
+            raise RuntimeError(f"completed trial {trial_id!r} has an active dispatch")
+
+    run_snapshots: list[dict[str, object]] = []
+    current_run_by_id: dict[str, dict[str, object]] = {}
+    conditions: list[dict[str, object]] = []
+    latest_observation_times: list[datetime] = []
+
+    for run in runs:
+        run_id = run["regional_run_id"]
+        run_observations = observations_by_run[run_id]
+        progress_values = [
+            observation["run_progress"]
+            for observation, _ in run_observations
+            if observation["run_progress"] is not None
+        ]
+        observed_progress_high_water = max(progress_values, default=0.0)
+        if abs(observed_progress_high_water - run["high_water_progress"]) > 1e-12:
+            raise RuntimeError(
+                f"run {run_id!r} progress high-water does not match observations"
+            )
+
+        progress_high_water = 0.0
+        last_progress_at = None
+        for observation, observed_at in run_observations:
+            progress = observation["run_progress"]
+            if progress is not None and progress > progress_high_water:
+                progress_high_water = progress
+                last_progress_at = observed_at
+        if last_progress_at is None and dispatches_by_run[run_id]:
+            last_progress_at = min(
+                _parse_time(
+                    dispatch["submitted_at"],
+                    f"dispatch {dispatch['dispatch_id']} submitted_at",
+                )
+                for dispatch in dispatches_by_run[run_id]
+            )
+
+        latest_observation = run_observations[-1] if run_observations else None
+        latest_row = latest_observation[0] if latest_observation else None
+        latest_at = latest_observation[1] if latest_observation else None
+        if latest_at is not None:
+            latest_observation_times.append(latest_at)
+
+        prior_progress_high_water = max(
+            (
+                observation["run_progress"]
+                for observation, _ in run_observations[:-1]
+                if observation["run_progress"] is not None
+            ),
+            default=0.0,
+        )
+        active_dispatches = [
+            dispatch for dispatch in dispatches_by_run[run_id] if dispatch["active"]
+        ]
+        if len(active_dispatches) > 1:
+            raise RuntimeError(f"run {run_id!r} has multiple active dispatches")
+        active_dispatch = active_dispatches[0] if active_dispatches else None
+
+        stall_seconds = None
+        if last_progress_at is not None:
+            stall_seconds = (snapshot_at - last_progress_at).total_seconds()
+            if stall_seconds < 0:
+                raise RuntimeError(f"run {run_id!r} stall clock is in the future")
+
+        active_dispatch_snapshot = None
+        active_latest_row = None
+        active_latest_at = None
+        if active_dispatch is not None:
+            submitted_at = _parse_time(
+                active_dispatch["submitted_at"],
+                f"dispatch {active_dispatch['dispatch_id']} submitted_at",
+            )
+            if submitted_at > snapshot_at:
+                raise RuntimeError(
+                    f"dispatch {active_dispatch['dispatch_id']!r} is in the future"
+                )
+            active_observations = [
+                (observation, observed_at)
+                for observation, observed_at in run_observations
+                if observation["dispatch_id"] == active_dispatch["dispatch_id"]
+                and observed_at >= submitted_at
+            ]
+            if active_observations:
+                active_latest_row, active_latest_at = active_observations[-1]
+            active_last_progress_at = last_progress_at_by_dispatch.get(
+                active_dispatch["dispatch_id"]
+            )
+            dispatch_stall_since = active_last_progress_at or submitted_at
+            dispatch_stall_seconds = (
+                snapshot_at - dispatch_stall_since
+            ).total_seconds()
+            active_dispatch_snapshot = {
+                "dispatch_id": active_dispatch["dispatch_id"],
+                "attempt": active_dispatch["attempt"],
+                "iris_job_id": active_dispatch["iris_job_id"],
+                "slice": active_dispatch["tpu_slice"],
+                "chips": active_dispatch["chips"],
+                "submitted_at": active_dispatch["submitted_at"],
+                "age_seconds": round((snapshot_at - submitted_at).total_seconds(), 3),
+                "last_progress_at": (
+                    None
+                    if active_last_progress_at is None
+                    else active_last_progress_at.isoformat()
+                ),
+                "stall_since": dispatch_stall_since.isoformat(),
+                "stall_seconds": round(dispatch_stall_seconds, 3),
+                "recent_progress": (
+                    active_last_progress_at is not None
+                    and dispatch_stall_seconds <= reslice_after_seconds
+                ),
+                "latest_observation": (
+                    None
+                    if active_latest_row is None or active_latest_at is None
+                    else {
+                        "observed_at": active_latest_row["observed_at"],
+                        "age_seconds": round(
+                            (snapshot_at - active_latest_at).total_seconds(), 3
+                        ),
+                        "wandb_state": active_latest_row["wandb_state"],
+                        "run_progress": active_latest_row["run_progress"],
+                        "iris_running": (
+                            None
+                            if active_latest_row["iris_running"] is None
+                            else bool(active_latest_row["iris_running"])
+                        ),
+                    }
+                ),
+            }
+
+        latest_observation_snapshot = None
+        if latest_row is not None and latest_at is not None:
+            latest_observation_snapshot = {
+                "dispatch_id": latest_row["dispatch_id"],
+                "observed_at": latest_row["observed_at"],
+                "age_seconds": round((snapshot_at - latest_at).total_seconds(), 3),
+                "wandb_state": latest_row["wandb_state"],
+                "run_progress": latest_row["run_progress"],
+                "iris_running": (
+                    None
+                    if latest_row["iris_running"] is None
+                    else bool(latest_row["iris_running"])
+                ),
+            }
+
+        run_snapshot = {
+            "run_id": run_id,
+            "trial_id": run["trial_id"],
+            "region": run["region"],
+            "status": run["status"],
+            "wandb_run_id": run["wandb_run_id"],
+            "checkpoint_root": run["checkpoint_root"],
+            "is_winner": bool(run["is_winner"]),
+            "run_progress_high_water": run["high_water_progress"],
+            "progress_delta_since_previous_observation": round(
+                max(0.0, observed_progress_high_water - prior_progress_high_water), 12
+            ),
+            "stall_since": None
+            if last_progress_at is None
+            else last_progress_at.isoformat(),
+            "stall_seconds": None if stall_seconds is None else round(stall_seconds, 3),
+            "checkpoint_verified_at": run["checkpoint_verified_at"],
+            "dispatch_count": len(dispatches_by_run[run_id]),
+            "active_dispatch": active_dispatch_snapshot,
+            "latest_observation": latest_observation_snapshot,
+        }
+        current_run_by_id[run_id] = run_snapshot
+        if run["trial_id"] not in completed_trial_ids:
+            run_snapshots.append(run_snapshot)
+
+        run_conditions: list[str] = []
+        state_row = active_latest_row if active_dispatch is not None else latest_row
+        latest_state = (
+            state_row["wandb_state"].casefold()
+            if state_row is not None and state_row["wandb_state"] is not None
+            else None
+        )
+        if active_dispatch is not None and active_latest_row is None:
+            run_conditions.append("active_dispatch_unobserved")
+        if latest_state == "failed":
+            run_conditions.append("wandb_failed")
+        if latest_state == "finished" and run["high_water_progress"] < 1:
+            run_conditions.append("wandb_finished_incomplete")
+        if (
+            active_dispatch is not None
+            and active_latest_row is not None
+            and active_latest_row["iris_running"] == 0
+        ):
+            run_conditions.append("iris_not_running")
+        if run["high_water_progress"] >= 1 and run["checkpoint_verified_at"] is None:
+            run_conditions.append("checkpoint_unverified")
+        if (
+            active_dispatch is None
+            and run["trial_id"] not in completed_trial_ids
+            and run["status"].casefold() in {"planned", "active", "running", "failed"}
+        ):
+            run_conditions.append("no_active_dispatch")
+        if run["trial_id"] not in completed_trial_ids:
+            conditions.extend(
+                {
+                    "kind": kind,
+                    "trial_id": run["trial_id"],
+                    "run_id": run_id,
+                }
+                for kind in run_conditions
+            )
+
+    trial_snapshots: list[dict[str, object]] = []
+    for trial in trials:
+        trial_id = trial["trial_id"]
+        if trial_id in completed_trial_ids:
+            continue
+        trial_runs = runs_by_trial[trial_id]
+        trial_snapshots.append(
+            {
+                "trial_id": trial_id,
+                "status": trial["status"],
+                "run_count": len(trial_runs),
+                "active_dispatch_count": sum(
+                    1
+                    for run in trial_runs
+                    for dispatch in dispatches_by_run[run["regional_run_id"]]
+                    if dispatch["active"]
+                ),
+                "run_progress_high_water": max(
+                    (run["high_water_progress"] for run in trial_runs), default=0.0
+                ),
+                "winning_run_id": next(
+                    (run["regional_run_id"] for run in trial_runs if run["is_winner"]),
+                    None,
+                ),
+            }
+        )
+
+    placement_groups: dict[tuple[str, str, int], dict[str, object]] = {}
+    for dispatch in dispatches:
+        run = run_by_id[dispatch["regional_run_id"]]
+        run_observations = observations_by_run[run["regional_run_id"]]
+        submitted_at = _parse_time(
+            dispatch["submitted_at"], f"dispatch {dispatch['dispatch_id']} submitted_at"
+        )
+        dispatch_observations = [
+            (observation, observed_at)
+            for observation, observed_at in run_observations
+            if observation["dispatch_id"] == dispatch["dispatch_id"]
+            and observed_at >= submitted_at
+        ]
+        if dispatch["active"]:
+            measured_at = snapshot_at
+        else:
+            measured_at = _parse_time(
+                dispatch["ended_at"], f"dispatch {dispatch['dispatch_id']} ended_at"
+            )
+            if dispatch_observations:
+                measured_at = max(
+                    measured_at,
+                    max(observed_at for _, observed_at in dispatch_observations),
+                )
+        if measured_at < submitted_at:
+            raise RuntimeError(
+                f"dispatch {dispatch['dispatch_id']!r} ends before submission"
+            )
+
+        progress_delta = progress_by_dispatch[dispatch["dispatch_id"]]
+        wall_seconds = (measured_at - submitted_at).total_seconds()
+        first_progress_at = first_progress_at_by_dispatch.get(dispatch["dispatch_id"])
+        first_progress_seconds = (
+            None
+            if first_progress_at is None
+            else (first_progress_at - submitted_at).total_seconds()
+        )
+
+        key = (
+            run["region"],
+            dispatch["tpu_slice"],
+            dispatch["chips"],
+        )
+        group = placement_groups.setdefault(
+            key,
+            {
+                "region": run["region"],
+                "slice": dispatch["tpu_slice"],
+                "chips": dispatch["chips"],
+                "dispatch_count": 0,
+                "dispatches_with_progress": 0,
+                "zero_progress_dispatches": 0,
+                "active_dispatches": 0,
+                "productive_dispatches": 0,
+                "pending_dispatches": 0,
+                "total_progress": 0.0,
+                "total_wall_time_seconds": 0.0,
+                "first_progress_seconds": [],
+            },
+        )
+        group["dispatch_count"] += 1
+        group["total_progress"] += progress_delta
+        group["total_wall_time_seconds"] += wall_seconds
+        if progress_delta > 0:
+            group["dispatches_with_progress"] += 1
+        else:
+            group["zero_progress_dispatches"] += 1
+        if first_progress_seconds is not None:
+            group["first_progress_seconds"].append(first_progress_seconds)
+        if dispatch["active"]:
+            group["active_dispatches"] += 1
+            last_progress_at = last_progress_at_by_dispatch.get(dispatch["dispatch_id"])
+            if (
+                last_progress_at is not None
+                and (snapshot_at - last_progress_at).total_seconds()
+                <= reslice_after_seconds
+            ):
+                group["productive_dispatches"] += 1
+            else:
+                group["pending_dispatches"] += 1
+
+    placement_snapshots: list[dict[str, object]] = []
+    for group in placement_groups.values():
+        wall_seconds = group.pop("total_wall_time_seconds")
+        progress = group.pop("total_progress")
+        first_progress_values = group.pop("first_progress_seconds")
+        group["total_progress"] = round(progress, 12)
+        group["total_wall_time_seconds"] = round(wall_seconds, 3)
+        group["target_rate"] = (
+            None if wall_seconds <= 0 else round(progress * 3600 / wall_seconds, 12)
+        )
+        group["average_time_to_first_progress_seconds"] = (
+            None
+            if not first_progress_values
+            else round(sum(first_progress_values) / len(first_progress_values), 3)
+        )
+        placement_snapshots.append(group)
+    placement_snapshots.sort(
+        key=lambda group: (
+            -1.0 if group["target_rate"] is None else -group["target_rate"],
+            group["region"],
+            group["slice"],
+            group["chips"],
+        )
+    )
+
+    trial_status_counts = Counter(trial["status"] for trial in trials)
+    run_status_counts = Counter(run["status"] for run in runs)
+    active_dispatches = [dispatch for dispatch in dispatches if dispatch["active"]]
+    training_chips = 0
+    training_runs = 0
+    for dispatch in active_dispatches:
+        current_run = current_run_by_id[dispatch["regional_run_id"]]
+        active = current_run["active_dispatch"]
+        latest = None if active is None else active["latest_observation"]
+        if (
+            latest is not None
+            and latest["wandb_state"] is not None
+            and latest["wandb_state"].casefold() == "running"
+        ):
+            training_runs += 1
+            training_chips += dispatch["chips"]
+
+    recent_event_snapshots = [
+        {
+            "event_id": event["event_id"],
+            "recorded_at": event["recorded_at"],
+            "kind": event["kind"],
+            "trial_id": event["trial_id"],
+            "run_id": event["regional_run_id"],
+            "dispatch_id": event["dispatch_id"],
+            "detail": event["detail"],
+        }
+        for event in recent_events
+    ]
+
+    return {
+        "snapshot_at_utc": snapshot_at.isoformat(),
+        "reslice_after_seconds": reslice_after_seconds,
+        "coverage": {
+            "trials_total": len(trials),
+            "unfinished_trials_included": len(trial_snapshots),
+            "completed_trials_omitted": len(completed_trial_ids),
+            "runs_total": len(runs),
+            "unfinished_runs_included": len(run_snapshots),
+            "dispatches_total": len(dispatches),
+            "observations_total": len(observations),
+            "events_total": event_total,
+            "recent_events_included": len(recent_event_snapshots),
+            "recent_events_omitted": event_total - len(recent_event_snapshots),
+            "latest_observation_at_utc": (
+                None
+                if not latest_observation_times
+                else max(latest_observation_times).isoformat()
+            ),
+            "unfinished_runs_without_observations": sum(
+                1
+                for run_snapshot in run_snapshots
+                if run_snapshot["latest_observation"] is None
+            ),
+        },
+        "fleet": {
+            "trial_status_counts": dict(sorted(trial_status_counts.items())),
+            "run_status_counts": dict(sorted(run_status_counts.items())),
+            "active_dispatches": len(active_dispatches),
+            "submitted_chips": sum(dispatch["chips"] for dispatch in active_dispatches),
+            "wandb_running_runs": training_runs,
+            "wandb_running_chips": training_chips,
+        },
+        "trials": trial_snapshots,
+        "runs": run_snapshots,
+        "conditions": conditions,
+        "placements": placement_snapshots,
+        "event_counts": event_counts,
+        "recent_events": recent_event_snapshots,
+    }
+
+
+def check(path: Path) -> list[str]:
+    errors = _structural_errors(path)
+    if errors:
+        return errors
+    try:
+        _build_snapshot(path, recent_event_limit=0, reslice_after_hours=1)
+    except (RuntimeError, sqlite3.Error) as error:
+        errors.append(f"semantic_check: {error}")
+    return errors
+
+
+def snapshot(
+    path: Path, recent_event_limit: int, reslice_after_hours: float = 1
+) -> dict[str, object]:
+    errors = _structural_errors(path)
+    if errors:
+        raise RuntimeError("; ".join(errors))
+    return _build_snapshot(path, recent_event_limit, reslice_after_hours)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init")
+    init_parser.add_argument("database", type=Path)
+
+    event_parser = subparsers.add_parser("event")
+    event_parser.add_argument("database", type=Path)
+    event_parser.add_argument("--kind", required=True)
+    event_parser.add_argument("--detail", required=True)
+    event_parser.add_argument("--trial-id")
+    event_parser.add_argument("--regional-run-id")
+    event_parser.add_argument("--dispatch-id")
+
+    check_parser = subparsers.add_parser("check")
+    check_parser.add_argument("database", type=Path)
+
+    snapshot_parser = subparsers.add_parser("snapshot")
+    snapshot_parser.add_argument("database", type=Path)
+    snapshot_parser.add_argument("--recent-events", type=int, default=20)
+    snapshot_parser.add_argument("--reslice-after-hours", type=float, default=1)
+
+    args = parser.parse_args()
+    if args.command == "init":
+        init(args.database)
+        print(f"OK: initialized {args.database}")
+        return 0
+    if args.command == "event":
+        record_event(
+            args.database,
+            args.kind,
+            args.detail,
+            args.trial_id,
+            args.regional_run_id,
+            args.dispatch_id,
+        )
+        print("OK: event recorded")
+        return 0
+    if args.command == "check":
+        errors = check(args.database)
+        if errors:
+            for error in errors:
+                print(f"ERROR: {error}")
+            return 1
+        print(f"OK: {args.database}")
+        return 0
+    if args.command == "snapshot":
+        try:
+            result = snapshot(
+                args.database, args.recent_events, args.reslice_after_hours
+            )
+        except (RuntimeError, sqlite3.Error) as error:
+            print(f"ERROR: {error}")
+            return 1
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/run-training-sweep-trc/scripts/utilization.py
+++ b/.agents/skills/run-training-sweep-trc/scripts/utilization.py
@@ -1,0 +1,398 @@
+"""Emit a strict TPU utilization snapshot from Iris autoscaler status."""
+
+import argparse
+import json
+import re
+import shlex
+import subprocess
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SLICE_STATES = {"requesting", "booting", "initializing", "ready", "failed"}
+CAPACITY_STATES = {"available", "in_use", "idle", "degraded"}
+AVAILABILITY_STATES = {
+    "available",
+    "cooldown",
+    "requesting",
+    "backoff",
+    "quota_exceeded",
+    "at_max_slices",
+}
+AVAILABILITY_RANK = {
+    "available": 0,
+    "cooldown": 1,
+    "requesting": 2,
+    "backoff": 3,
+    "at_max_slices": 4,
+    "quota_exceeded": 5,
+}
+TPU_VARIANT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*-(?P<chips>[1-9][0-9]*)$")
+
+JsonObject = dict[str, Any]
+
+
+class SnapshotError(RuntimeError):
+    """Raised when Iris output cannot support an accurate snapshot."""
+
+
+@dataclass
+class Target:
+    region: str
+    tpu_slice: str
+    chips_per_slice: int
+    ready_slices: int = 0
+    in_use_slices: int = 0
+    ages_ms: list[int] = field(default_factory=list)
+    capacity_counts: Counter[str] = field(default_factory=Counter)
+    availability_counts: Counter[str] = field(default_factory=Counter)
+    availability_reasons: set[str] = field(default_factory=set)
+
+
+def _object(value: Any, path: str) -> JsonObject:
+    if not isinstance(value, dict):
+        raise SnapshotError(f"{path} must be an object, got {type(value).__name__}")
+    return value
+
+
+def _list(value: Any, path: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise SnapshotError(f"{path} must be a list, got {type(value).__name__}")
+    return value
+
+
+def _string(value: Any, path: str) -> str:
+    if not isinstance(value, str) or not value.strip() or value != value.strip():
+        raise SnapshotError(f"{path} must be a nonempty trimmed string")
+    return value
+
+
+def _integer(value: Any, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise SnapshotError(f"{path} must be an integer")
+    if value < 0:
+        raise SnapshotError(f"{path} must be nonnegative")
+    return value
+
+
+def _epoch_ms(value: Any, path: str) -> int:
+    timestamp = _object(value, path)
+    epoch_ms = timestamp.get("epoch_ms")
+    if isinstance(epoch_ms, str) and epoch_ms.isdigit():
+        epoch_ms = int(epoch_ms)
+    return _integer(epoch_ms, f"{path}.epoch_ms")
+
+
+def _optional_list(parent: JsonObject, key: str, path: str) -> list[Any]:
+    if key not in parent:
+        return []
+    return _list(parent[key], f"{path}.{key}")
+
+
+def _optional_counts(parent: JsonObject, key: str, path: str) -> Counter[str]:
+    if key not in parent:
+        return Counter()
+    values = _object(parent[key], f"{path}.{key}")
+    counts: Counter[str] = Counter()
+    for name, count in values.items():
+        state = _string(name, f"{path}.{key} key")
+        counts[state] = _integer(count, f"{path}.{key}.{state}")
+    return counts
+
+
+def _run_iris(command: list[str], timeout_seconds: float) -> JsonObject:
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except FileNotFoundError as exc:
+        raise SnapshotError(f"Iris executable not found: {command[0]}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise SnapshotError(f"Iris timed out after {timeout_seconds:g}s") from exc
+
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no output"
+        raise SnapshotError(
+            f"Iris exited {result.returncode}: {shlex.join(command)}\n{detail}"
+        )
+    if result.stderr.strip():
+        print(result.stderr.rstrip(), file=sys.stderr)
+
+    try:
+        return _object(json.loads(result.stdout), "response")
+    except json.JSONDecodeError as exc:
+        raise SnapshotError(
+            f"Iris stdout is not JSON at line {exc.lineno}, column {exc.colno}"
+        ) from exc
+
+
+def _variant(value: Any, path: str) -> tuple[str, int]:
+    variant = _string(value, path)
+    match = TPU_VARIANT.fullmatch(variant)
+    if match is None:
+        raise SnapshotError(
+            f"{path} is not a TPU slice with a trailing chip count: {variant!r}"
+        )
+    return variant, int(match.group("chips"))
+
+
+def _availability(group: JsonObject, path: str) -> tuple[str, str | None]:
+    status = _string(group.get("availability_status"), f"{path}.availability_status")
+    if status not in AVAILABILITY_STATES:
+        raise SnapshotError(
+            f"{path}.availability_status has unknown value {status!r}; "
+            f"expected one of {sorted(AVAILABILITY_STATES)}"
+        )
+    reason_value = group.get("availability_reason")
+    reason = (
+        None
+        if reason_value in (None, "")
+        else _string(reason_value, f"{path}.availability_reason")
+    )
+    return status, reason
+
+
+def _slice_age_and_use(
+    slice_info: JsonObject, path: str, now_ms: int
+) -> tuple[int | None, bool, str]:
+    capacity = _string(slice_info.get("capacity_status"), f"{path}.capacity_status")
+    if capacity not in CAPACITY_STATES:
+        raise SnapshotError(
+            f"{path}.capacity_status has unknown value {capacity!r}; "
+            f"expected one of {sorted(CAPACITY_STATES)}"
+        )
+
+    vms = _optional_list(slice_info, "vms", path)
+    created_at: list[int] = []
+    running_tasks = 0
+    for vm_index, vm_value in enumerate(vms):
+        vm_path = f"{path}.vms[{vm_index}]"
+        vm = _object(vm_value, vm_path)
+        created_at.append(_epoch_ms(vm.get("created_at"), f"{vm_path}.created_at"))
+        running_tasks += _integer(
+            vm.get("running_task_count", 0), f"{vm_path}.running_task_count"
+        )
+
+    if capacity != "degraded" and not vms:
+        raise SnapshotError(f"{path}.vms is empty for ready {capacity!r} slice")
+    in_use = running_tasks > 0
+    if capacity == "in_use" and not in_use:
+        raise SnapshotError(f"{path} says in_use but has no running tasks")
+    if capacity in {"available", "idle"} and in_use:
+        raise SnapshotError(f"{path} says {capacity!r} but has running tasks")
+
+    if not created_at:
+        return None, in_use, capacity
+    age_ms = now_ms - min(created_at)
+    if age_ms < 0:
+        raise SnapshotError(f"{path} has a future VM creation timestamp")
+    return age_ms, in_use, capacity
+
+
+def _group_slices(
+    group: JsonObject, path: str, now_ms: int
+) -> tuple[int, int, list[int], Counter[str]]:
+    slices = _optional_list(group, "slices", path)
+    actual_states: Counter[str] = Counter()
+    ready: list[tuple[JsonObject, str]] = []
+
+    for slice_index, slice_value in enumerate(slices):
+        slice_path = f"{path}.slices[{slice_index}]"
+        slice_info = _object(slice_value, slice_path)
+        state = _string(slice_info.get("state"), f"{slice_path}.state")
+        if state not in SLICE_STATES:
+            raise SnapshotError(
+                f"{slice_path}.state has unknown value {state!r}; "
+                f"expected one of {sorted(SLICE_STATES)}"
+            )
+        actual_states[state] += 1
+        if state == "ready":
+            ready.append((slice_info, slice_path))
+
+    declared_states = _optional_counts(group, "slice_state_counts", path)
+    unknown_declared = set(declared_states) - SLICE_STATES
+    if unknown_declared:
+        raise SnapshotError(
+            f"{path}.slice_state_counts has unknown states {sorted(unknown_declared)}"
+        )
+    if actual_states != declared_states:
+        raise SnapshotError(
+            f"{path} slice counts disagree: slices={dict(actual_states)}, "
+            f"slice_state_counts={dict(declared_states)}"
+        )
+
+    in_use = 0
+    ages_ms: list[int] = []
+    capacity_counts: Counter[str] = Counter()
+    for slice_info, slice_path in ready:
+        age_ms, slice_in_use, capacity = _slice_age_and_use(
+            slice_info, slice_path, now_ms
+        )
+        in_use += int(slice_in_use)
+        capacity_counts[capacity] += 1
+        if age_ms is not None:
+            ages_ms.append(age_ms)
+    return len(ready), in_use, ages_ms, capacity_counts
+
+
+def summarize(response: JsonObject, observed_at: datetime) -> JsonObject:
+    status = _object(response.get("status"), "response.status")
+    groups = _list(status.get("groups"), "response.status.groups")
+    if not groups:
+        raise SnapshotError("response.status.groups is empty")
+
+    now_ms = int(observed_at.timestamp() * 1000)
+    targets: dict[tuple[str, str], Target] = {}
+    saw_tpu_group = False
+
+    for group_index, group_value in enumerate(groups):
+        path = f"response.status.groups[{group_index}]"
+        group = _object(group_value, path)
+        _string(group.get("name"), f"{path}.name")
+        device_type = _string(group.get("device_type"), f"{path}.device_type").lower()
+        if device_type != "tpu":
+            continue
+        saw_tpu_group = True
+
+        tpu_slice, chips = _variant(
+            group.get("device_variant"), f"{path}.device_variant"
+        )
+        region = _string(group.get("region"), f"{path}.region")
+        availability, reason = _availability(group, path)
+        ready, in_use, ages_ms, capacity_counts = _group_slices(group, path, now_ms)
+        if ready == 0:
+            continue
+
+        key = (region, tpu_slice)
+        target = targets.setdefault(key, Target(region, tpu_slice, chips))
+        if target.chips_per_slice != chips:
+            raise SnapshotError(f"conflicting chip counts for target {key}")
+        target.ready_slices += ready
+        target.in_use_slices += in_use
+        target.ages_ms.extend(ages_ms)
+        target.capacity_counts.update(capacity_counts)
+        target.availability_counts[availability] += 1
+        if reason is not None:
+            target.availability_reasons.add(reason)
+
+    if not saw_tpu_group:
+        raise SnapshotError("response contains no structured TPU groups")
+    if not targets:
+        raise SnapshotError("response contains no ready TPU slices")
+
+    output_targets: list[JsonObject] = []
+    region_totals: defaultdict[str, Counter[str]] = defaultdict(Counter)
+    fleet_ready = 0
+    fleet_in_use = 0
+
+    for target in sorted(
+        targets.values(),
+        key=lambda item: (-item.ready_slices, item.region, item.tpu_slice),
+    ):
+        if len(target.ages_ms) != target.ready_slices:
+            raise SnapshotError(
+                f"cannot compute complete average age for "
+                f"{target.region}/{target.tpu_slice}: "
+                f"{len(target.ages_ms)} of {target.ready_slices} ready slices"
+            )
+        fleet_ready += target.ready_slices
+        fleet_in_use += target.in_use_slices
+        region_totals[target.region]["ready_slices"] += target.ready_slices
+        region_totals[target.region]["in_use_slices"] += target.in_use_slices
+        worst_status = max(
+            target.availability_counts, key=AVAILABILITY_RANK.__getitem__
+        )
+        average_age_seconds = round(sum(target.ages_ms) / len(target.ages_ms) / 1000)
+        output_targets.append(
+            {
+                "region": target.region,
+                "tpu_slice": target.tpu_slice,
+                "chips_per_slice": target.chips_per_slice,
+                "ready_slices": target.ready_slices,
+                "in_use_slices": target.in_use_slices,
+                "in_use_percent": round(
+                    100 * target.in_use_slices / target.ready_slices, 1
+                ),
+                "average_age_seconds": average_age_seconds,
+                "slice_capacity_counts": dict(sorted(target.capacity_counts.items())),
+                "autoscaler_status": worst_status,
+                "autoscaler_reasons": sorted(target.availability_reasons),
+            }
+        )
+
+    return {
+        "observed_at_utc": observed_at.isoformat(),
+        "fleet": {
+            "ready_slices": fleet_ready,
+            "in_use_slices": fleet_in_use,
+            "in_use_percent": round(100 * fleet_in_use / fleet_ready, 1),
+            "regions": {
+                region: dict(counts)
+                for region, counts in sorted(
+                    region_totals.items(),
+                    key=lambda item: (-item[1]["ready_slices"], item[0]),
+                )
+            },
+        },
+        "targets": output_targets,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Emit strict JSON describing current Iris TPU fleet utilization."
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--cluster", help="Named Iris cluster, for example marin")
+    source.add_argument("--config", type=Path, help="Exact Iris cluster config path")
+    parser.add_argument(
+        "--iris-bin",
+        default="iris",
+        help="Iris executable path (default: iris from PATH)",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=60,
+        help="RPC command timeout (default: 60)",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if args.timeout_seconds <= 0:
+        print("ERROR: --timeout-seconds must be positive", file=sys.stderr)
+        return 2
+    if args.config is not None and not args.config.is_file():
+        print(f"ERROR: config does not exist: {args.config}", file=sys.stderr)
+        return 2
+
+    command = [args.iris_bin]
+    if args.cluster is not None:
+        command.extend(["--cluster", args.cluster])
+    else:
+        command.extend(["--config", str(args.config)])
+    command.extend(["rpc", "controller", "get-autoscaler-status"])
+
+    try:
+        response = _run_iris(command, args.timeout_seconds)
+        snapshot = summarize(response, datetime.now(UTC))
+    except SnapshotError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    json.dump(snapshot, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/run-training-sweep-trc/tests/test_tools.py
+++ b/.agents/skills/run-training-sweep-trc/tests/test_tools.py
@@ -1,0 +1,339 @@
+# Copyright The MarinFold Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+import importlib.util
+import sqlite3
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SKILL_ROOT = Path(__file__).parents[1]
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+persistence = _load_module(
+    "run_training_sweep_persistence",
+    SKILL_ROOT / "scripts" / "persistence.py",
+)
+utilization = _load_module(
+    "run_training_sweep_utilization",
+    SKILL_ROOT / "scripts" / "utilization.py",
+)
+
+
+def _insert_trial_run(
+    connection: sqlite3.Connection,
+    trial_id: str,
+    run_id: str,
+    wandb_id: str,
+    progress: float,
+) -> None:
+    connection.execute(
+        "INSERT INTO trials(trial_id, env_json, status) VALUES (?, '{}', 'active')",
+        (trial_id,),
+    )
+    connection.execute(
+        """
+        INSERT INTO runs(
+            regional_run_id, trial_id, region, wandb_run_id,
+            checkpoint_root, status, high_water_progress
+        ) VALUES (?, ?, 'us-central1', ?, 'gs://checkpoints', 'running', ?)
+        """,
+        (run_id, trial_id, wandb_id, progress),
+    )
+
+
+def _insert_dispatch(
+    connection: sqlite3.Connection,
+    dispatch_id: str,
+    run_id: str,
+    attempt: int,
+    tpu_slice: str,
+    chips: int,
+    submitted_at: str,
+    ended_at: str | None,
+) -> None:
+    connection.execute(
+        """
+        INSERT INTO dispatches(
+            dispatch_id, regional_run_id, attempt, iris_job_id, tpu_slice,
+            chips, priority_band, command_redacted, submitted_at, ended_at,
+            active, outcome
+        ) VALUES (?, ?, ?, ?, ?, ?, 'batch', 'launch', ?, ?, ?, ?)
+        """,
+        (
+            dispatch_id,
+            run_id,
+            attempt,
+            f"iris-{dispatch_id}",
+            tpu_slice,
+            chips,
+            submitted_at,
+            ended_at,
+            int(ended_at is None),
+            None if ended_at is None else "stopped",
+        ),
+    )
+
+
+def _insert_observation(
+    connection: sqlite3.Connection,
+    run_id: str,
+    dispatch_id: str,
+    observed_at: str,
+    progress: float,
+    iris_running: bool,
+) -> None:
+    connection.execute(
+        """
+        INSERT INTO observations(
+            regional_run_id, dispatch_id, observed_at,
+            wandb_state, run_progress, iris_running
+        ) VALUES (?, ?, ?, 'running', ?, ?)
+        """,
+        (run_id, dispatch_id, observed_at, progress, int(iris_running)),
+    )
+
+
+def test_target_rate_pools_trials_and_zero_progress_time(tmp_path: Path) -> None:
+    database = tmp_path / "sweep.sqlite"
+    persistence.init(database)
+    with sqlite3.connect(database) as connection:
+        _insert_trial_run(connection, "trial-1", "run-1", "wandb-1", 0.12)
+        _insert_trial_run(connection, "trial-2", "run-2", "wandb-2", 0.0)
+        _insert_dispatch(
+            connection,
+            "dispatch-1",
+            "run-1",
+            1,
+            "v5p-8",
+            8,
+            "2026-01-01T00:00:00+00:00",
+            "2026-01-01T01:00:00+00:00",
+        )
+        _insert_dispatch(
+            connection,
+            "dispatch-2",
+            "run-2",
+            1,
+            "v5p-8",
+            8,
+            "2026-01-01T00:00:00+00:00",
+            "2026-01-01T02:00:00+00:00",
+        )
+        _insert_observation(
+            connection,
+            "run-1",
+            "dispatch-1",
+            "2026-01-01T00:30:00+00:00",
+            0.12,
+            True,
+        )
+
+    placement = persistence.snapshot(database, recent_event_limit=0)["placements"]
+
+    assert placement == [
+        {
+            "region": "us-central1",
+            "slice": "v5p-8",
+            "chips": 8,
+            "dispatch_count": 2,
+            "dispatches_with_progress": 1,
+            "zero_progress_dispatches": 1,
+            "active_dispatches": 0,
+            "productive_dispatches": 0,
+            "pending_dispatches": 0,
+            "total_progress": 0.12,
+            "total_wall_time_seconds": 10800.0,
+            "target_rate": 0.04,
+            "average_time_to_first_progress_seconds": 1800.0,
+        }
+    ]
+
+
+def test_replacement_uses_only_its_own_observations(tmp_path: Path) -> None:
+    database = tmp_path / "sweep.sqlite"
+    persistence.init(database)
+    with sqlite3.connect(database) as connection:
+        _insert_trial_run(connection, "trial", "run", "wandb", 0.2)
+        _insert_dispatch(
+            connection,
+            "old",
+            "run",
+            1,
+            "v5p-8",
+            8,
+            "2026-01-01T00:00:00+00:00",
+            "2026-01-01T00:10:00+00:00",
+        )
+        _insert_dispatch(
+            connection,
+            "new",
+            "run",
+            2,
+            "v5p-16",
+            16,
+            "2026-01-01T00:10:00+00:00",
+            None,
+        )
+        _insert_observation(
+            connection,
+            "run",
+            "old",
+            "2026-01-01T00:05:00+00:00",
+            0.1,
+            True,
+        )
+        _insert_observation(
+            connection,
+            "run",
+            "old",
+            "2026-01-01T00:11:00+00:00",
+            0.2,
+            False,
+        )
+
+    before = persistence.snapshot(database, recent_event_limit=0)
+    assert before["fleet"]["wandb_running_chips"] == 0
+    assert before["runs"][0]["active_dispatch"]["latest_observation"] is None
+    assert before["conditions"][0]["kind"] == "active_dispatch_unobserved"
+
+    with sqlite3.connect(database) as connection:
+        _insert_observation(
+            connection,
+            "run",
+            "new",
+            "2026-01-01T00:12:00+00:00",
+            0.3,
+            True,
+        )
+        connection.execute(
+            "UPDATE runs SET high_water_progress = 0.3 WHERE regional_run_id = 'run'"
+        )
+
+    after = persistence.snapshot(database, recent_event_limit=0)
+    progress_by_slice = {
+        placement["slice"]: placement["total_progress"]
+        for placement in after["placements"]
+    }
+    assert progress_by_slice == {"v5p-8": 0.2, "v5p-16": 0.1}
+    assert after["fleet"]["wandb_running_chips"] == 16
+
+
+def test_snapshot_classifies_current_target_headroom(tmp_path: Path) -> None:
+    database = tmp_path / "sweep.sqlite"
+    persistence.init(database)
+    now = datetime.now(UTC)
+    old = (now.replace(microsecond=0) - timedelta(hours=2)).isoformat()
+    recent = (now.replace(microsecond=0) - timedelta(minutes=30)).isoformat()
+    with sqlite3.connect(database) as connection:
+        _insert_trial_run(connection, "trial-1", "run-1", "wandb-1", 0.1)
+        _insert_trial_run(connection, "trial-2", "run-2", "wandb-2", 0.0)
+        _insert_dispatch(connection, "dispatch-1", "run-1", 1, "v5p-8", 8, old, None)
+        _insert_dispatch(connection, "dispatch-2", "run-2", 1, "v5p-8", 8, old, None)
+        _insert_observation(connection, "run-1", "dispatch-1", recent, 0.1, True)
+        _insert_observation(connection, "run-2", "dispatch-2", recent, 0.0, True)
+
+    result = persistence.snapshot(database, recent_event_limit=0)
+    placement = result["placements"][0]
+
+    assert placement["active_dispatches"] == 2
+    assert placement["productive_dispatches"] == 1
+    assert placement["pending_dispatches"] == 1
+    assert result["runs"][0]["active_dispatch"]["recent_progress"] is True
+    assert result["runs"][1]["active_dispatch"]["recent_progress"] is False
+
+    shorter_window = persistence.snapshot(
+        database, recent_event_limit=0, reslice_after_hours=0.25
+    )["placements"][0]
+    assert shorter_window["productive_dispatches"] == 0
+    assert shorter_window["pending_dispatches"] == 2
+
+
+def test_check_and_snapshot_reject_the_same_semantic_error(tmp_path: Path) -> None:
+    database = tmp_path / "sweep.sqlite"
+    persistence.init(database)
+    with sqlite3.connect(database) as connection:
+        _insert_trial_run(connection, "trial", "run", "wandb", 0.5)
+
+    assert persistence.check(database) == [
+        "semantic_check: run 'run' progress high-water does not match observations"
+    ]
+    with pytest.raises(RuntimeError, match="progress high-water"):
+        persistence.snapshot(database, recent_event_limit=0)
+
+
+def _utilization_response() -> dict[str, object]:
+    def group(name: str, capacity: str, tasks: int, created_at: int, availability: str):
+        return {
+            "name": name,
+            "device_type": "tpu",
+            "device_variant": "v5p-8",
+            "region": "us-central1",
+            "availability_status": availability,
+            "slice_state_counts": {"ready": 1},
+            "slices": [
+                {
+                    "state": "ready",
+                    "capacity_status": capacity,
+                    "vms": [
+                        {
+                            "created_at": {"epoch_ms": created_at},
+                            "running_task_count": tasks,
+                        }
+                    ],
+                }
+            ],
+        }
+
+    return {
+        "status": {
+            "groups": [
+                group("one", "in_use", 1, 1_767_225_600_000, "available"),
+                group("two", "available", 0, 1_767_222_000_000, "cooldown"),
+            ]
+        }
+    }
+
+
+def test_utilization_summarizes_structured_groups() -> None:
+    observed_at = datetime(2026, 1, 1, 2, tzinfo=UTC)
+
+    result = utilization.summarize(_utilization_response(), observed_at)
+
+    assert result["fleet"]["ready_slices"] == 2
+    assert result["fleet"]["in_use_percent"] == 50.0
+    assert result["targets"] == [
+        {
+            "region": "us-central1",
+            "tpu_slice": "v5p-8",
+            "chips_per_slice": 8,
+            "ready_slices": 2,
+            "in_use_slices": 1,
+            "in_use_percent": 50.0,
+            "average_age_seconds": 9000,
+            "slice_capacity_counts": {"available": 1, "in_use": 1},
+            "autoscaler_status": "cooldown",
+            "autoscaler_reasons": [],
+        }
+    ]
+
+
+def test_utilization_rejects_inconsistent_slice_counts() -> None:
+    response = copy.deepcopy(_utilization_response())
+    response["status"]["groups"][0]["slice_state_counts"] = {"ready": 2}
+
+    with pytest.raises(utilization.SnapshotError, match="slice counts disagree"):
+        utilization.summarize(response, datetime(2026, 1, 1, 2, tzinfo=UTC))

--- a/tests/test_compare_vendored_skills.py
+++ b/tests/test_compare_vendored_skills.py
@@ -1,0 +1,102 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).parents[1]
+    / ".agents/skills/maintain-vendored-skills/scripts/compare_upstream.py"
+)
+SKILL_ROOT = Path(__file__).parents[1] / ".agents/skills"
+MANIFEST_ROOT = SKILL_ROOT / "maintain-vendored-skills/references"
+
+
+def _run(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _make_upstream(tmp_path: Path) -> tuple[Path, str]:
+    upstream = tmp_path / "upstream"
+    skill = upstream / ".agents/skills/demo"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("demo\n")
+    _run(["git", "init", "-q"], upstream)
+    _run(["git", "add", "."], upstream)
+    _run(
+        [
+            "git",
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-qm",
+            "fixture",
+        ],
+        upstream,
+    )
+    commit = _run(["git", "rev-parse", "HEAD"], upstream).stdout.strip()
+    return upstream, commit
+
+
+def test_custom_manifest_reports_exact_and_changed_vendors(tmp_path: Path) -> None:
+    upstream, commit = _make_upstream(tmp_path)
+    local_root = tmp_path / "local"
+    local_skill = local_root / ".agents/skills/demo"
+    local_skill.mkdir(parents=True)
+    local_file = local_skill / "SKILL.md"
+    local_file.write_text("demo\n")
+
+    manifest = tmp_path / "vendor.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "upstream_repo": "example/upstream",
+                "commit": commit,
+                "unchanged": ["demo"],
+                "adapted": [],
+                "local": [],
+            }
+        )
+    )
+    command = [
+        sys.executable,
+        str(SCRIPT),
+        "--manifest",
+        str(manifest),
+        "--upstream-root",
+        str(upstream),
+        "--repo-root",
+        str(local_root),
+    ]
+
+    generated_cache = upstream / ".agents/skills/demo/__pycache__"
+    generated_cache.mkdir()
+    (generated_cache / "noise.pyc").write_bytes(b"generated")
+
+    exact = subprocess.run(command, check=False, capture_output=True, text=True)
+    assert exact.returncode == 0
+    assert "# example/upstream vendored-skill deltas" in exact.stdout
+    assert "`demo`: byte-identical" in exact.stdout
+
+    local_file.write_text("changed\n")
+    changed = subprocess.run(command, check=False, capture_output=True, text=True)
+    assert changed.returncode == 1
+    assert "example/upstream/.agents/skills/demo/SKILL.md" in changed.stdout
+    assert "Open-Athena/marin-dna/.agents/skills/demo/SKILL.md" in changed.stdout
+    assert "demo is classified unchanged but has a diff" in changed.stdout
+
+
+def test_every_repository_skill_has_one_provenance_classification() -> None:
+    classified: list[str] = []
+    for path in MANIFEST_ROOT.glob("*manifest.json"):
+        manifest = json.loads(path.read_text())
+        classified.extend(manifest["unchanged"])
+        classified.extend(item["name"] for item in manifest["adapted"])
+        classified.extend(manifest["local"])
+
+    actual = sorted(path.parent.name for path in SKILL_ROOT.glob("*/SKILL.md"))
+    assert sorted(classified) == actual
+    assert len(classified) == len(set(classified))


### PR DESCRIPTION
Add the CoreWeave GPU and Google TRC TPU sweep operators from MarinFold at `ac4a41b70e4b2b3900c4778f3f40b8418fab673f`. The skills keep trial configuration in experiment code while adding durable placement state, Iris recovery, W&B progress tracking, and capacity-aware reslicing.

Adapt the operators to MarinDNA’s remote-compute approval, W&B identity, coherent Marin/Iris versioning, and hardware-lineage requirements. Cross-family continuation is disabled unless the operator approves its reproducibility cost. `marin-experiment` continues to own project setup and hands an existing trial catalog to the platform-specific sweep skill.

Extend the vendored-skill audit to support multiple pinned sources. The import retains the 14 passing upstream helper tests, both exact-delta reports pass against verified Git checkouts, and every repository skill now has exactly one provenance classification.