### PR TITLE
[agents] Validate skills in pre-commit and add scheduled scrubs

### DIFF
--- a/.agents/skills/develop-snakemake-pipelines/SKILL.md
+++ b/.agents/skills/develop-snakemake-pipelines/SKILL.md
@@ -11,15 +11,9 @@ Treat each runnable pipeline as an independent Python project and execution boun
 
 1. Find the nearest pipeline root containing `pyproject.toml`, `uv.lock`, `README.md`, `src/`, `tests/`, and `workflow/Snakefile`.
 2. Read its README, manifest, and `workflow/profiles/default/config.yaml` before changing or running it.
-3. Run commands from that project root through its committed environment:
+3. Run the per-workflow setup, test, and dry-run commands from `AGENTS.md` (Development Setup) from that project root, with the targets intended for the task.
 
-```bash
-uv sync --locked --group dev
-uv run --locked pytest
-uv run --locked snakemake -n <targets>
-```
-
-Use the targets intended for the task. Put pipeline-wide defaults such as cores, Conda use, and storage providers in the checked-in profile. Keep external bioinformatics tools in rule-specific Conda environments.
+Put pipeline-wide defaults such as cores, Conda use, and storage providers in the checked-in profile. Keep external bioinformatics tools in rule-specific Conda environments.
 
 ## Keep Python Testable
 
@@ -52,4 +46,4 @@ Do not keep a runnable template project on `main`. If pipeline creation becomes 
 
 ## Document Changes
 
-Update the owning README when behavior, configuration, dependencies, execution, outputs, or recovery procedures change. Keep run results and research findings in the tracking issue or research record.
+Follow the README and research-record rules in `AGENTS.md` (Verification And Documentation) when behavior, configuration, dependencies, execution, outputs, or recovery procedures change.

--- a/.agents/skills/draft-weekly-research-update/SKILL.md
+++ b/.agents/skills/draft-weekly-research-update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: draft-weekly-research-update
-description: Create a reviewable weekly MarinDNA public-research draft as a temporary Markdown file from experiment interpretation pages first added to main. Use for the scheduled Monday research update or an explicit request for that draft; do not use for issue activity, infrastructure, bugs, or edits to existing experiment pages.
+description: Create a reviewable weekly MarinDNA public-research draft as a temporary Markdown file from experiment interpretation pages first added to main. Use only from its scheduler (the Monday research update) or an explicit request for that draft; do not use for issue activity, infrastructure, bugs, or edits to existing experiment pages.
 ---
 
 # Draft Weekly Research Update

--- a/.agents/skills/maintain-vendored-skills/SKILL.md
+++ b/.agents/skills/maintain-vendored-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maintain-vendored-skills
-description: Compare, refresh, and audit externally derived skills in MarinDNA. Use when checking a pinned source commit, showing exact upstream-to-local modifications, performing the monthly upstream review, updating vendored skills, or triaging newly available upstream skills.
+description: Compare, refresh, and audit externally derived skills in MarinDNA only when explicitly requested or from the monthly upstream review. Use for checking a pinned source commit, showing exact upstream-to-local modifications, updating vendored skills, or triaging newly available upstream skills; do not select it during ordinary feature or documentation work.
 ---
 
 # Maintain Vendored Skills
@@ -45,7 +45,7 @@ Load the source-specific manifest under `references/` only when comparing or upd
 3. Replace unchanged vendors content-for-content while preserving regular-file, symlink, and executable modes.
 4. Start each adapted vendor from the new upstream file, then reapply only the deviations in the manifest.
 5. Run the comparison script against the new upstream checkout and inspect every adapted diff.
-6. Validate every changed skill with the standard skill validator.
+6. Validate every changed skill with `uv run --locked python infra/check_skill_metadata.py`.
 7. Update the manifest commit and `vendored_on` date.
 8. Open a draft PR only when content or recorded provenance changed.
 

--- a/.agents/skills/maintain-vendored-skills/SKILL.md
+++ b/.agents/skills/maintain-vendored-skills/SKILL.md
@@ -12,6 +12,7 @@ Load the source-specific manifest under `references/` only when comparing or upd
 
 - Treat every skill listed under `unchanged` or `adapted` in a vendor manifest as vendor-owned. Do not edit those skill directories in ordinary feature, documentation, or repository-guidance work.
 - Change vendored content only in a dedicated vendor-maintenance task that explicitly owns the upstream comparison and provenance update.
+  One exception: when a repository path that an adapted skill links to moves, update that link and record the deviation in the manifest in the same change so the skill validator stays green.
 - Put MarinDNA-specific behavior in a local skill that composes with the vendored skill. The local skill may route to the vendor, add repository-specific constraints, or coordinate it with other skills.
 - Register composing skills under `local` in the manifest. If composition cannot express a required change, report the limitation and propose a vendor adaptation instead of modifying the vendor implicitly.
 

--- a/.agents/skills/maintain-vendored-skills/references/manifest.json
+++ b/.agents/skills/maintain-vendored-skills/references/manifest.json
@@ -45,6 +45,22 @@
       "deviations": [
         "Route accepted research findings and their provenance through maintain-knowledge-base instead of generic experiment reports."
       ]
+    },
+    {
+      "name": "scrub-reflection-self-improvement",
+      "deviations": [
+        "Target Open-Athena/marin-dna and search AGENTS.md, .agents/skills/, docs/, and workflow READMEs for stale guidance.",
+        "Publish through the delivery steps in AGENTS.md instead of the unavailable commit skill, and route vendored-skill changes through maintain-vendored-skills.",
+        "Use the upstream #8494 routing-contract description, a standard five-field cron expression, and a prose status line instead of the HARNESS_SCRUB_LOOP footer."
+      ]
+    },
+    {
+      "name": "scrub-docs-code-parity",
+      "deviations": [
+        "Target Open-Athena/marin-dna: README.md, docs/, workflow READMEs, AGENTS.md, .agents/skills/, skill scripts, and the skill validator.",
+        "Publish through the delivery steps in AGENTS.md instead of the unavailable commit skill, and route vendored-skill corrections through maintain-vendored-skills.",
+        "Use the upstream #8494 routing-contract description, a standard five-field cron expression, and a prose status line instead of the HARNESS_SCRUB_LOOP footer."
+      ]
     }
   ],
   "local": [

--- a/.agents/skills/maintain-vendored-skills/references/manifest.json
+++ b/.agents/skills/maintain-vendored-skills/references/manifest.json
@@ -49,17 +49,24 @@
     {
       "name": "scrub-reflection-self-improvement",
       "deviations": [
-        "Target Open-Athena/marin-dna and search AGENTS.md, .agents/skills/, docs/, and workflow READMEs for stale guidance.",
-        "Publish through the delivery steps in AGENTS.md instead of the unavailable commit skill, and route vendored-skill changes through maintain-vendored-skills.",
-        "Use the upstream #8494 routing-contract description, a standard five-field cron expression, and a prose status line instead of the HARNESS_SCRUB_LOOP footer."
+        "Target Open-Athena/marin-dna; search AGENTS.md, .agents/skills/, docs/, and workflow READMEs for stale guidance.",
+        "Name workflow READMEs, pipelines, repository tooling, and skills in the candidate signals and output where upstream names recipes, scripts, infra operations, and recipe docs.",
+        "Publish through the delivery steps in AGENTS.md instead of the unavailable commit skill; follow the AGENTS.md skill conventions and record vendored-skill corrections with file-issue instead of editing vendor directories.",
+        "Use the routing-contract description from upstream #8494 (later than the pinned commit).",
+        "Schedule daily at 10:00 America/New_York as a five-field cron expression; upstream uses a six-field form.",
+        "Report status in prose instead of the HARNESS_SCRUB_LOOP footer and needs_followup_at protocol.",
+        "Keep each sentence on its own source line."
       ]
     },
     {
       "name": "scrub-docs-code-parity",
       "deviations": [
-        "Target Open-Athena/marin-dna: README.md, docs/, workflow READMEs, AGENTS.md, .agents/skills/, skill scripts, and the skill validator.",
-        "Publish through the delivery steps in AGENTS.md instead of the unavailable commit skill, and route vendored-skill corrections through maintain-vendored-skills.",
-        "Use the upstream #8494 routing-contract description, a standard five-field cron expression, and a prose status line instead of the HARNESS_SCRUB_LOOP footer."
+        "Target Open-Athena/marin-dna: README.md, docs/, workflow READMEs under snakemake/, AGENTS.md, .agents/skills/, skill scripts, and the skill validator, with the repository's uv --locked conventions.",
+        "Publish through the delivery steps in AGENTS.md instead of the unavailable commit skill; record vendored-skill corrections with file-issue instead of editing vendor directories.",
+        "Use the routing-contract description from upstream #8494 (later than the pinned commit).",
+        "Schedule daily at 00:00 America/New_York as a five-field cron expression; upstream uses a six-field form.",
+        "Report status in prose instead of the HARNESS_SCRUB_LOOP footer and needs_followup_at protocol.",
+        "Keep each sentence on its own source line."
       ]
     }
   ],

--- a/.agents/skills/scrub-docs-code-parity/SKILL.md
+++ b/.agents/skills/scrub-docs-code-parity/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: scrub-docs-code-parity
+description: Run the docs/code-parity scrub only from its scheduler or an explicit request for that scrub.
+schedule_cron: "0 0 * * *"
+schedule_tz: America/New_York
+---
+
+# scrub-docs-code-parity
+
+Use this skill on scheduled scrub turns for docs/code parity in `Open-Athena/marin-dna`.
+
+## Focus
+
+- Prioritize high-confidence drift in `README.md`, `docs/`, workflow READMEs under `snakemake/`, `AGENTS.md`, and `.agents/skills/`.
+- Confirm command examples match current tooling conventions (`uv run --locked`, `uv run --locked snakemake -n`, pre-commit, and the skill validator in `infra/check_skill_metadata.py`).
+- Confirm that skill scripts under `.agents/skills/*/scripts/` still behave as their `SKILL.md` describes.
+- Apply concrete corrections when drift is real; avoid status-only updates.
+
+## Decision Heuristics
+
+- Prefer updating docs when current behavior is clear and intentional.
+- If implementation is clearly wrong relative to documented intent, update code and docs together.
+- Keep scope small and land one useful parity improvement per run when possible.
+- Route a correction to a vendored skill through `maintain-vendored-skills` instead of editing it directly.
+- If no material drift is found, choose a no-op outcome and keep cadence near daily.
+
+## Output
+
+- Keep the final scrub response concise and action-focused.
+- Treat local-only edits as incomplete work. If you modify files, publish the result (commit, push, and open or update a draft pull request following the delivery steps in `AGENTS.md`) before finishing this scrub run.
+- If publish is blocked (auth, permissions, CI infra, etc.), report the blocker and when the next attempt should happen instead of ending silently.
+- If no material drift is found, explicitly report inspected scope and why no change was needed.
+- End the run with a short status: the PR link, or the no-op rationale, plus any blocker and its retry time.

--- a/.agents/skills/scrub-docs-code-parity/SKILL.md
+++ b/.agents/skills/scrub-docs-code-parity/SKILL.md
@@ -29,7 +29,7 @@ Use this skill on scheduled scrub turns for docs/code parity in `Open-Athena/mar
 
 - Keep the final scrub response concise and action-focused.
 - Treat local-only edits as incomplete work.
-  If you modify files, publish the result (commit, push, and open or update a draft pull request following the delivery steps in `AGENTS.md`) before finishing this scrub run.
-- If publish is blocked (auth, permissions, CI infra, etc.), report the blocker and when the next attempt should happen instead of ending silently.
+  If you modify files, publish the result through the Repository Lifecycle delivery steps in `AGENTS.md` before finishing this scrub run.
+- If publishing is blocked, report the blocker and when the next attempt should happen instead of ending silently.
 - If no material drift is found, explicitly report inspected scope and why no change was needed.
 - End the run with a short status: the PR link, or the no-op rationale, plus any blocker and its retry time.

--- a/.agents/skills/scrub-docs-code-parity/SKILL.md
+++ b/.agents/skills/scrub-docs-code-parity/SKILL.md
@@ -21,13 +21,15 @@ Use this skill on scheduled scrub turns for docs/code parity in `Open-Athena/mar
 - Prefer updating docs when current behavior is clear and intentional.
 - If implementation is clearly wrong relative to documented intent, update code and docs together.
 - Keep scope small and land one useful parity improvement per run when possible.
-- Route a correction to a vendored skill through `maintain-vendored-skills` instead of editing it directly.
+- Do not edit a vendored skill (one listed under `unchanged` or `adapted` in a vendor manifest).
+  Record the needed correction with `file-issue` for the next vendor refresh instead.
 - If no material drift is found, choose a no-op outcome and keep cadence near daily.
 
 ## Output
 
 - Keep the final scrub response concise and action-focused.
-- Treat local-only edits as incomplete work. If you modify files, publish the result (commit, push, and open or update a draft pull request following the delivery steps in `AGENTS.md`) before finishing this scrub run.
+- Treat local-only edits as incomplete work.
+  If you modify files, publish the result (commit, push, and open or update a draft pull request following the delivery steps in `AGENTS.md`) before finishing this scrub run.
 - If publish is blocked (auth, permissions, CI infra, etc.), report the blocker and when the next attempt should happen instead of ending silently.
 - If no material drift is found, explicitly report inspected scope and why no change was needed.
 - End the run with a short status: the PR link, or the no-op rationale, plus any blocker and its retry time.

--- a/.agents/skills/scrub-reflection-self-improvement/SKILL.md
+++ b/.agents/skills/scrub-reflection-self-improvement/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: scrub-reflection-self-improvement
+description: Run the repository self-improvement scrub only from its scheduler or an explicit request for that scrub.
+schedule_cron: "0 10 * * *"
+schedule_tz: America/New_York
+---
+
+# scrub-reflection-self-improvement
+
+Use this skill on scheduled scrub turns to identify and land high-leverage improvements in `Open-Athena/marin-dna`.
+
+## Focus
+
+- Look for improvements from recent issues, PR feedback, and recurring operational friction.
+- Prefer one concrete implementation per run when feasible.
+- If implementation is blocked, produce a concrete plan and capture follow-up work in GitHub.
+
+## Candidate Signals
+
+- Repeated confusion in docs, workflow READMEs, or contributor workflows.
+- Recurring failures or avoidable manual steps in experiments, pipelines, and repository tooling.
+- Capability gaps that reduce the value of agent-assisted contributions.
+
+## Triage Checklist
+
+Run a lightweight, repeatable scan before choosing work:
+
+1. Review recent open issues and open PRs for repeated friction clusters.
+2. Explicitly check for already-open scrub-generated issues/PRs touching the same area; prefer advancing or deferring to that existing artifact instead of creating a parallel one.
+3. Review the latest commits on `main` for changes that imply follow-on docs/workflow updates.
+4. Search `AGENTS.md`, `.agents/skills/`, `docs/`, and workflow READMEs for stale workflow guidance related to those clusters.
+5. De-duplicate against existing issues/PRs before creating new artifacts.
+
+When possible, prefer improvements that remove recurring operator time (for example,
+turning ad-hoc scrub judgment into explicit repeatable guidance).
+
+## Decision Heuristics
+
+- Pick the highest-leverage change with the lowest coordination overhead.
+- Treat open scrub-generated issues/PRs as first-class prior art during triage; if one already covers the candidate improvement, avoid opening a second artifact unless the new scope is clearly distinct.
+- De-duplicate against existing issues/PRs before opening new work.
+- When an improvement changes recurring workflow guidance, codify it in durable repo instructions:
+  `AGENTS.md` for cross-cutting agent behavior, or `.agents/skills/` for repeatable task workflows.
+  Follow the skill conventions in `AGENTS.md`; route changes to vendored skills through `maintain-vendored-skills` instead of editing them directly.
+- If no justified improvement exists now, choose a no-op outcome.
+- Prefer direct implementation over opening new issues when the change is fully in-repo and low-risk.
+
+## Output
+
+- Keep rationale explicit: observed gap, change made (or plan), and expected impact.
+- Prefer durable artifacts over transient notes: land guidance updates in `AGENTS.md`, skills, or workflow READMEs when that is the primary improvement.
+- Treat local-only edits as incomplete work. If you modify files, publish the result (commit, push, and open or update a draft pull request following the delivery steps in `AGENTS.md`) before finishing this scrub run.
+- If publish is blocked (auth, permissions, CI infra, etc.), report the blocker and when the next attempt should happen instead of ending silently.
+- If you choose no-op, include explicit inspected signals and why no justified improvement exists now.
+- End the run with a short status: the PR link or plan, or the no-op rationale, plus any blocker and its retry time.
+
+For no-op outcomes, include at minimum:
+
+- which issue/PR/commit windows were inspected,
+- why each candidate was not suitable for this run,
+- and why deferring to the next scheduled run is preferable to opening a low-signal artifact now.

--- a/.agents/skills/scrub-reflection-self-improvement/SKILL.md
+++ b/.agents/skills/scrub-reflection-self-improvement/SKILL.md
@@ -50,8 +50,8 @@ When possible, prefer improvements that remove recurring operator time (for exam
 - Keep rationale explicit: observed gap, change made (or plan), and expected impact.
 - Prefer durable artifacts over transient notes: land guidance updates in `AGENTS.md`, skills, or workflow READMEs when that is the primary improvement.
 - Treat local-only edits as incomplete work.
-  If you modify files, publish the result (commit, push, and open or update a draft pull request following the delivery steps in `AGENTS.md`) before finishing this scrub run.
-- If publish is blocked (auth, permissions, CI infra, etc.), report the blocker and when the next attempt should happen instead of ending silently.
+  If you modify files, publish the result through the Repository Lifecycle delivery steps in `AGENTS.md` before finishing this scrub run.
+- If publishing is blocked, report the blocker and when the next attempt should happen instead of ending silently.
 - If you choose no-op, include explicit inspected signals and why no justified improvement exists now.
 - End the run with a short status: the PR link or plan, or the no-op rationale, plus any blocker and its retry time.
 

--- a/.agents/skills/scrub-reflection-self-improvement/SKILL.md
+++ b/.agents/skills/scrub-reflection-self-improvement/SKILL.md
@@ -31,17 +31,17 @@ Run a lightweight, repeatable scan before choosing work:
 4. Search `AGENTS.md`, `.agents/skills/`, `docs/`, and workflow READMEs for stale workflow guidance related to those clusters.
 5. De-duplicate against existing issues/PRs before creating new artifacts.
 
-When possible, prefer improvements that remove recurring operator time (for example,
-turning ad-hoc scrub judgment into explicit repeatable guidance).
+When possible, prefer improvements that remove recurring operator time (for example, turning ad-hoc scrub judgment into explicit repeatable guidance).
 
 ## Decision Heuristics
 
 - Pick the highest-leverage change with the lowest coordination overhead.
 - Treat open scrub-generated issues/PRs as first-class prior art during triage; if one already covers the candidate improvement, avoid opening a second artifact unless the new scope is clearly distinct.
 - De-duplicate against existing issues/PRs before opening new work.
-- When an improvement changes recurring workflow guidance, codify it in durable repo instructions:
-  `AGENTS.md` for cross-cutting agent behavior, or `.agents/skills/` for repeatable task workflows.
-  Follow the skill conventions in `AGENTS.md`; route changes to vendored skills through `maintain-vendored-skills` instead of editing them directly.
+- When an improvement changes recurring workflow guidance, codify it in durable repo instructions: `AGENTS.md` for cross-cutting agent behavior, or `.agents/skills/` for repeatable task workflows.
+  Follow the skill conventions in `AGENTS.md`.
+- Do not edit a vendored skill (one listed under `unchanged` or `adapted` in a vendor manifest).
+  Record the needed correction with `file-issue` for the next vendor refresh instead.
 - If no justified improvement exists now, choose a no-op outcome.
 - Prefer direct implementation over opening new issues when the change is fully in-repo and low-risk.
 
@@ -49,7 +49,8 @@ turning ad-hoc scrub judgment into explicit repeatable guidance).
 
 - Keep rationale explicit: observed gap, change made (or plan), and expected impact.
 - Prefer durable artifacts over transient notes: land guidance updates in `AGENTS.md`, skills, or workflow READMEs when that is the primary improvement.
-- Treat local-only edits as incomplete work. If you modify files, publish the result (commit, push, and open or update a draft pull request following the delivery steps in `AGENTS.md`) before finishing this scrub run.
+- Treat local-only edits as incomplete work.
+  If you modify files, publish the result (commit, push, and open or update a draft pull request following the delivery steps in `AGENTS.md`) before finishing this scrub run.
 - If publish is blocked (auth, permissions, CI infra, etc.), report the blocker and when the next attempt should happen instead of ending silently.
 - If you choose no-op, include explicit inspected signals and why no justified improvement exists now.
 - End the run with a short status: the PR link or plan, or the no-op rationale, plus any blocker and its retry time.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,8 @@ jobs:
                   or path == ".github/workflows/quality.yml"
                   or path.startswith("src/marin_dna/")
                   or path.startswith("tests/")
+                  or path.startswith("infra/")
+                  or path.startswith(".agents/")
                   for path in changed
               )
               if core_changed:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,15 @@ repos:
         language: system
         pass_filenames: false
         files: ^src/marin_dna/.*\.py$
+
+      # Validates every .agents/skills/*/SKILL.md (frontmatter, unique names,
+      # schedule fields, path cross-references, drift traps) whenever anything
+      # under .agents/skills/ changes. `pass_filenames: false` because one
+      # skill's links can break when another skill's file moves or a skill is
+      # renamed; the script docstring lists the rules.
+      - id: check-skill-metadata
+        name: check skill metadata
+        entry: uv run --locked python infra/check_skill_metadata.py
+        language: system
+        pass_filenames: false
+        files: ^\.agents/skills/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,16 +41,16 @@ repos:
         entry: uv run --locked mypy
         language: system
         pass_filenames: false
-        files: ^src/marin_dna/.*\.py$
+        files: ^(src/marin_dna/|infra/).*\.py$
 
       # Validates every .agents/skills/*/SKILL.md (frontmatter, unique names,
-      # schedule fields, path cross-references, drift traps) whenever anything
-      # under .agents/skills/ changes. `pass_filenames: false` because one
-      # skill's links can break when another skill's file moves or a skill is
-      # renamed; the script docstring lists the rules.
+      # schedule fields, path cross-references, drift traps) on every commit.
+      # `always_run` because the links a skill holds break when a target
+      # anywhere in the repository moves or is deleted, and deletions never
+      # appear in the staged-file list; the script docstring lists the rules.
       - id: check-skill-metadata
         name: check skill metadata
         entry: uv run --locked python infra/check_skill_metadata.py
         language: system
         pass_filenames: false
-        files: ^\.agents/skills/
+        always_run: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Before non-trivial work, check for a matching skill and follow it.
   The fields document intent; the scheduler itself runs outside the repository.
 - Keep a skill's entry point compact.
   Put detail it needs only sometimes in `references/` files it loads on demand, and put runnable helpers in `scripts/` gated by the root pytest suite.
-- `uv run --locked python infra/check_skill_metadata.py` validates every skill: YAML frontmatter, `name` equal to the directory and unique, a single-line description, paired schedule fields, a string `allowed-tools`, every repository path in code spans, fenced blocks, or relative links, and drift traps for retired paths and skill names.
+- `uv run --locked python infra/check_skill_metadata.py` validates every skill: YAML frontmatter, `name` equal to the directory and unique, a single-line description, paired schedule fields, a string `allowed-tools`, every repository path or well-known root file (`AGENTS.md`, `README.md`, `pyproject.toml`, …) in code spans, fenced blocks, or relative links, and drift traps for retired paths and skill names.
   Pre-commit runs it on every commit and the Quality workflow on every pull request, so a moved path fails lint until every skill linking it is updated.
   Bare skill-name mentions are not path-checked: when renaming or retiring a skill, add its old name to `DRIFT_TRAPS` in the checker and grep for remaining mentions.
 - Do not edit vendored skills directly; follow `maintain-vendored-skills`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,23 @@ MarinDNA develops genomic language models. Prioritize reproducibility and correc
   Keep chronological experiment records in tracking issues and branches, and keep accepted interpretations in `docs/research/`.
 - In Markdown prose, put each sentence on its own source line and do not hard-wrap at a fixed column.
 
+## Skills
+
+Skills are task playbooks in `.agents/skills/<name>/SKILL.md`, also reachable as `.claude/skills/`.
+Before non-trivial work, check for a matching skill and follow it.
+
+- Keep repository-wide rules only in this file, prose rules only in `writing-style`, and commit, pull-request, review, and monitoring steps only in Repository Lifecycle below.
+  A skill points at those sources instead of restating them, and names the skills it composes with rather than copying their content.
+- Treat the frontmatter `description` as the routing contract: one line stating what the skill does and when to select it.
+  Direct-task skills say when to use them; skills a task must not pull in on its own say `only when explicitly requested`; scheduled scrubs say `only from its scheduler or an explicit request`; skills that other skills invoke say `delegated by another selected workflow`.
+- Give a scheduled skill `schedule_cron` (five-field cron) and `schedule_tz` (IANA zone) together.
+- Keep a skill's entry point compact.
+  Put detail it needs only sometimes in `references/` files it loads on demand, and put runnable helpers in `scripts/` gated by the root pytest suite.
+- `uv run --locked python infra/check_skill_metadata.py` validates every skill: YAML frontmatter, `name` equal to the directory and unique, a single-line description, paired schedule fields, and every backticked or linked repository path.
+  Pre-commit runs it on any change under `.agents/skills/` and the Quality workflow runs it on every push and pull request, so a rename fails lint until every referring skill is updated.
+- Do not edit vendored skills directly; follow `maintain-vendored-skills`.
+- `scrub-reflection-self-improvement` and `scrub-docs-code-parity` hunt for stale guidance on their schedules, and `update-docs` covers skill docs whenever work changes behavior.
+
 ## Development Setup
 
 Use `uv` for Python dependencies. Set up and test the lightweight root project with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,13 +32,16 @@ Before non-trivial work, check for a matching skill and follow it.
   A skill points at those sources instead of restating them, and names the skills it composes with rather than copying their content.
 - Treat the frontmatter `description` as the routing contract: one line stating what the skill does and when to select it.
   Direct-task skills say when to use them; skills a task must not pull in on its own say `only when explicitly requested`; scheduled scrubs say `only from its scheduler or an explicit request`; skills that other skills invoke say `delegated by another selected workflow`.
-- Give a scheduled skill `schedule_cron` (five-field cron) and `schedule_tz` (IANA zone) together.
+- Declare `schedule_cron` (five-field cron) and `schedule_tz` (IANA zone) together on a skill whose cadence this repository defines.
+  The fields document intent; the scheduler itself runs outside the repository.
 - Keep a skill's entry point compact.
   Put detail it needs only sometimes in `references/` files it loads on demand, and put runnable helpers in `scripts/` gated by the root pytest suite.
-- `uv run --locked python infra/check_skill_metadata.py` validates every skill: YAML frontmatter, `name` equal to the directory and unique, a single-line description, paired schedule fields, and every backticked or linked repository path.
-  Pre-commit runs it on any change under `.agents/skills/` and the Quality workflow runs it on every push and pull request, so a rename fails lint until every referring skill is updated.
+- `uv run --locked python infra/check_skill_metadata.py` validates every skill: YAML frontmatter, `name` equal to the directory and unique, a single-line description, paired schedule fields, a string `allowed-tools`, every repository path in code spans, fenced blocks, or relative links, and drift traps for retired paths and skill names.
+  Pre-commit runs it on every commit and the Quality workflow on every pull request, so a moved path fails lint until every skill linking it is updated.
+  Bare skill-name mentions are not path-checked: when renaming or retiring a skill, add its old name to `DRIFT_TRAPS` in the checker and grep for remaining mentions.
 - Do not edit vendored skills directly; follow `maintain-vendored-skills`.
-- `scrub-reflection-self-improvement` and `scrub-docs-code-parity` hunt for stale guidance on their schedules, and `update-docs` covers skill docs whenever work changes behavior.
+  When a local path an adapted vendored skill links to moves, update that link and record the deviation in the manifest in the same change.
+- `scrub-reflection-self-improvement` and `scrub-docs-code-parity` hunt for stale guidance on their declared schedules, and `update-docs` covers skill docs whenever work changes behavior.
 
 ## Development Setup
 

--- a/infra/check_skill_metadata.py
+++ b/infra/check_skill_metadata.py
@@ -1,33 +1,39 @@
 #!/usr/bin/env python3
 """Validate every skill under ``.agents/skills/``.
 
-The pre-commit hook runs this whenever anything under ``.agents/skills/``
-changes, and the Quality workflow runs it on every push and pull request.
-One skill change re-validates all skills because skills link to each other
-and to the repository layout, so a rename anywhere can break a link elsewhere.
+The pre-commit hook runs this on every commit and the Quality workflow runs it
+on every pull request and push to ``main``. Every run validates every skill
+because skills link to each other and to the repository layout, so a rename
+anywhere can break a link elsewhere.
 
-Per ``SKILL.md`` the check enforces:
+Per skill directory the check enforces:
 
-- the frontmatter is a YAML mapping;
-- ``name`` is a non-empty string equal to the skill directory name, and no two
+- the directory holds ``SKILL.md`` whose frontmatter is a YAML mapping with
+  identifier-like keys, closed by a ``---`` line;
+- ``name`` is a non-empty string equal to the directory name, and no two
   skills share a name;
 - ``description`` is a non-empty single-line string;
 - ``schedule_cron`` and ``schedule_tz`` appear together, as a five-field cron
   expression and an IANA time zone;
 - ``allowed-tools`` is a string;
-- every backticked repository path and every relative Markdown link resolves
-  from the skill directory or the repository root;
+- every repository path in inline code, fenced code, or a relative Markdown
+  link resolves from the skill directory or the repository root, with exact
+  case and without escaping the repository;
 - known drift traps: paths and skill names that moved or were retired.
 
 Skills a vendor manifest lists as ``unchanged`` are upstream content that
-``maintain-vendored-skills`` verifies byte-for-byte, so their local path
-references and drift traps are not checked; their frontmatter still is.
+``maintain-vendored-skills`` verifies byte-for-byte, so their path references
+and drift traps are not checked; their frontmatter still is. ``adapted``
+vendored skills are checked in full: when a local path one of them links to
+moves, update the link and record the deviation in the manifest in the same
+change.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 import zoneinfo
@@ -38,8 +44,7 @@ import yaml
 SKILLS_DIR = Path(".agents") / "skills"
 VENDOR_MANIFEST_GLOB = "maintain-vendored-skills/references/*manifest.json"
 
-# Top-level directories a skill may reference. The last four were removed from
-# ``main`` in #333, so a reference to them is stale by construction.
+# Top-level directories a skill may reference.
 REPOSITORY_PATH_PREFIXES = (
     ".agents",
     ".claude",
@@ -50,19 +55,37 @@ REPOSITORY_PATH_PREFIXES = (
     "snakemake",
     "src",
     "tests",
-    "experiments",
-    "lib",
-    "plots",
-    "scripts",
 )
 _PREFIX_ALTERNATION = "|".join(re.escape(prefix) for prefix in REPOSITORY_PATH_PREFIXES)
-BACKTICK_PATH_PATTERN = re.compile(rf"`((?:{_PREFIX_ALTERNATION})/[^`\s,;:)]*)`")
-MARKDOWN_LINK_PATTERN = re.compile(r"\]\(([^)\s]+)\)")
+# A repository path token inside code: not glued to a preceding path or word
+# (so ``s3://bucket/docs/x`` and ``a/docs/x`` do not match) and running to the
+# next whitespace or quote.
+PATH_TOKEN_PATTERN = re.compile(rf"(?<![\w./-])((?:{_PREFIX_ALTERNATION})/[^\s`'\"|]*)")
+INLINE_CODE_PATTERN = re.compile(r"`([^`\n]+)`")
+FENCED_BLOCK_PATTERN = re.compile(
+    r"^```[^\n]*\n(.*?)^```[ \t]*$", re.MULTILINE | re.DOTALL
+)
+MARKDOWN_LINK_PATTERN = re.compile(r"\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+LINE_SUFFIX_PATTERN = re.compile(r":\d+(?:-\d+)?$")
+TRAILING_REFERENCE_PUNCTUATION = ".,;:)"
 REFERENCE_PLACEHOLDER_TOKENS = ("<", ">", "*", "{", "}", "...", "YYYY", "XXXX", "$")
 URL_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 
+FRONTMATTER_KEY_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
+CRON_FIELD_COUNT = 5
+_CRON_NUMERIC_TOKEN = r"(?:\*|\d+(?:-\d+)?)(?:/\d+)?"
+_CRON_NAMED_TOKEN = r"(?:\*|[0-9A-Za-z]+(?:-[0-9A-Za-z]+)?)(?:/\d+)?"
+CRON_FIELD_PATTERNS = (
+    re.compile(rf"^{_CRON_NUMERIC_TOKEN}(?:,{_CRON_NUMERIC_TOKEN})*$"),  # minute
+    re.compile(rf"^{_CRON_NUMERIC_TOKEN}(?:,{_CRON_NUMERIC_TOKEN})*$"),  # hour
+    re.compile(rf"^{_CRON_NUMERIC_TOKEN}(?:,{_CRON_NUMERIC_TOKEN})*$"),  # day of month
+    re.compile(rf"^{_CRON_NAMED_TOKEN}(?:,{_CRON_NAMED_TOKEN})*$"),  # month
+    re.compile(rf"^{_CRON_NAMED_TOKEN}(?:,{_CRON_NAMED_TOKEN})*$"),  # day of week
+)
+
 # Drift traps for mistakes this repository has already made once. Each entry
-# is (pattern, message); a match anywhere in the skill text is an error.
+# is (pattern, message); a match anywhere in the skill text is an error. When
+# a skill is renamed or retired, add its old name here so bare mentions fail.
 DRIFT_TRAPS: tuple[tuple[re.Pattern[str], str], ...] = (
     (
         re.compile(r"src/marin_dna/pipelines/"),
@@ -70,6 +93,13 @@ DRIFT_TRAPS: tuple[tuple[re.Pattern[str], str], ...] = (
             "src/marin_dna/pipelines/ no longer exists; pipeline packages live under "
             "snakemake/<pipeline>/src/ since pipelines became independently locked "
             "projects"
+        ),
+    ),
+    (
+        re.compile(r"(?<![\w./-])(?:experiments|plots)/"),
+        (
+            "top-level experiments/ and plots/ were removed from main (#333); "
+            "one-off code and figures live on permanent branches"
         ),
     ),
     (
@@ -92,13 +122,12 @@ DRIFT_TRAPS: tuple[tuple[re.Pattern[str], str], ...] = (
     ),
 )
 
-CRON_FIELD_COUNT = 5
-
 Error = tuple[Path, str]
 
 
 def split_frontmatter(text: str) -> tuple[str, str] | None:
     """Return ``(frontmatter, body)`` or ``None`` when the delimiters are missing."""
+    text = text.removeprefix("﻿")
     if not text.startswith("---\n"):
         return None
     lines = text.split("\n")
@@ -112,16 +141,23 @@ def is_placeholder_reference(reference: str) -> bool:
     return any(token in reference for token in REFERENCE_PLACEHOLDER_TOKENS)
 
 
-def reference_exists(skill_dir: Path, root: Path, reference: str) -> bool:
-    return (skill_dir / reference).exists() or (root / reference).exists()
+def normalize_reference(raw: str) -> str:
+    """Strip fragments, ``:line`` suffixes, and trailing punctuation."""
+    reference = raw.split("#", 1)[0]
+    reference = LINE_SUFFIX_PATTERN.sub("", reference)
+    return reference.rstrip(TRAILING_REFERENCE_PUNCTUATION)
 
 
 def iter_path_references(text: str) -> list[str]:
-    """Backticked repository paths and relative Markdown link targets in ``text``."""
+    """Repository paths in code spans and fenced blocks, plus relative link targets."""
     references: list[str] = []
-    for match in BACKTICK_PATH_PATTERN.finditer(text):
-        references.append(match.group(1))
-    for match in MARKDOWN_LINK_PATTERN.finditer(text):
+    fenced_blocks = FENCED_BLOCK_PATTERN.findall(text)
+    prose = FENCED_BLOCK_PATTERN.sub("", text)
+    inline_code = INLINE_CODE_PATTERN.findall(prose)
+    prose = INLINE_CODE_PATTERN.sub("", prose)
+    for code in [*fenced_blocks, *inline_code]:
+        references.extend(match.group(1) for match in PATH_TOKEN_PATTERN.finditer(code))
+    for match in MARKDOWN_LINK_PATTERN.finditer(prose):
         target = match.group(1)
         if target.startswith("#") or URL_SCHEME_PATTERN.match(target):
             continue
@@ -129,20 +165,103 @@ def iter_path_references(text: str) -> list[str]:
     return references
 
 
-def vendored_unchanged_skills(root: Path) -> set[str]:
+def locate_reference(skill_dir: Path, root: Path, reference: str) -> str | None:
+    """Return an error message when ``reference`` does not resolve inside ``root``.
+
+    A leading ``/`` is repository-root relative, as GitHub renders it. Paths are
+    compared component by component so a reference passes only with the exact
+    case recorded on disk, which keeps macOS and Linux CI in agreement.
+    """
+    if reference.startswith("/"):
+        candidates = [root / reference.lstrip("/")]
+    else:
+        candidates = [skill_dir / reference, root / reference]
+    problems: list[str] = []
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve(strict=True)
+        except (FileNotFoundError, NotADirectoryError, RuntimeError):
+            problems.append("missing local reference")
+            continue
+        if not resolved.is_relative_to(root):
+            problems.append("reference escapes the repository")
+            continue
+        current = root
+        exact = True
+        for part in resolved.relative_to(root).parts:
+            if part not in os.listdir(current):
+                exact = False
+                break
+            current = current / part
+        if exact:
+            return None
+        problems.append("reference case differs from the file system")
+    # Report the most specific problem: an escape or case mismatch beats "missing".
+    for message in (
+        "reference escapes the repository",
+        "reference case differs from the file system",
+    ):
+        if message in problems:
+            return f"{message}: {reference}"
+    return f"missing local reference: {reference}"
+
+
+def vendored_unchanged_skills(root: Path) -> tuple[set[str], list[Error]]:
     """Skill names every vendor manifest classifies as ``unchanged``."""
     names: set[str] = set()
+    errors: list[Error] = []
     for manifest_path in sorted((root / SKILLS_DIR).glob(VENDOR_MANIFEST_GLOB)):
-        manifest = json.loads(manifest_path.read_text())
-        unchanged = manifest.get("unchanged", [])
-        assert isinstance(unchanged, list), f"{manifest_path}: unchanged must be a list"
-        names.update(unchanged)
-    return names
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        for entry in manifest["unchanged"]:
+            if not isinstance(entry, str):
+                errors.append(
+                    (manifest_path, f"unchanged entries must be names, got {entry!r}")
+                )
+                continue
+            if not (root / SKILLS_DIR / entry / "SKILL.md").is_file():
+                errors.append(
+                    (manifest_path, f"unchanged skill {entry!r} has no SKILL.md")
+                )
+                continue
+            names.add(entry)
+    return names, errors
+
+
+def check_schedule(metadata: dict[str, object]) -> list[str]:
+    errors: list[str] = []
+    has_cron = "schedule_cron" in metadata
+    has_tz = "schedule_tz" in metadata
+    if has_cron != has_tz:
+        errors.append("schedule_cron and schedule_tz must be specified together")
+    if has_cron:
+        cron = metadata["schedule_cron"]
+        if not isinstance(cron, str):
+            errors.append(f"schedule_cron must be a string, got {type(cron).__name__}")
+        else:
+            fields = cron.split()
+            valid = len(fields) == CRON_FIELD_COUNT and all(
+                pattern.match(field)
+                for pattern, field in zip(CRON_FIELD_PATTERNS, fields)
+            )
+            if not valid:
+                errors.append(
+                    f"schedule_cron must be a {CRON_FIELD_COUNT}-field cron expression, "
+                    f"got {cron!r}"
+                )
+    if has_tz:
+        tz = metadata["schedule_tz"]
+        if not isinstance(tz, str):
+            errors.append(f"schedule_tz must be a string, got {type(tz).__name__}")
+        else:
+            try:
+                zoneinfo.ZoneInfo(tz)
+            except (zoneinfo.ZoneInfoNotFoundError, ValueError):
+                errors.append(f"schedule_tz must be an IANA time zone, got {tz!r}")
+    return errors
 
 
 def check_metadata(skill_file: Path, frontmatter: str) -> tuple[list[str], str | None]:
     """Validate the frontmatter mapping; return ``(errors, name)``."""
-    errors: list[str] = []
     try:
         metadata = yaml.safe_load(frontmatter)
     except yaml.YAMLError as error:
@@ -151,7 +270,17 @@ def check_metadata(skill_file: Path, frontmatter: str) -> tuple[list[str], str |
         return [
             f"frontmatter must be a YAML mapping, got {type(metadata).__name__}"
         ], None
+    bad_keys = [
+        key
+        for key in metadata
+        if not isinstance(key, str) or not FRONTMATTER_KEY_PATTERN.match(key)
+    ]
+    if bad_keys:
+        return [
+            f"frontmatter key {bad_keys[0]!r} is not an identifier; is the closing --- missing?"
+        ], None
 
+    errors: list[str] = []
     name = metadata.get("name")
     if not isinstance(name, str) or not name.strip():
         errors.append(f"frontmatter must include a non-empty string name, got {name!r}")
@@ -164,33 +293,12 @@ def check_metadata(skill_file: Path, frontmatter: str) -> tuple[list[str], str |
     description = metadata.get("description")
     if not isinstance(description, str) or not description.strip():
         errors.append(
-            "frontmatter must include a non-empty string description, "
-            f"got {description!r}"
+            f"frontmatter must include a non-empty string description, got {description!r}"
         )
     elif "\n" in description.strip():
         errors.append("description must be a single-line string")
 
-    has_cron = "schedule_cron" in metadata
-    has_tz = "schedule_tz" in metadata
-    if has_cron != has_tz:
-        errors.append("schedule_cron and schedule_tz must be specified together")
-    if has_cron:
-        cron = metadata["schedule_cron"]
-        if not isinstance(cron, str):
-            errors.append(f"schedule_cron must be a string, got {type(cron).__name__}")
-        elif len(cron.split()) != CRON_FIELD_COUNT:
-            errors.append(
-                f"schedule_cron must be a {CRON_FIELD_COUNT}-field cron expression, "
-                f"got {cron!r}"
-            )
-    if has_tz:
-        tz = metadata["schedule_tz"]
-        if not isinstance(tz, str):
-            errors.append(f"schedule_tz must be a string, got {type(tz).__name__}")
-        else:
-            known_zones = zoneinfo.available_timezones()
-            if known_zones and tz not in known_zones:
-                errors.append(f"schedule_tz must be an IANA time zone, got {tz!r}")
+    errors.extend(check_schedule(metadata))
 
     allowed_tools = metadata.get("allowed-tools")
     if allowed_tools is not None and not isinstance(allowed_tools, str):
@@ -207,31 +315,38 @@ def check_references(skill_file: Path, root: Path, text: str) -> list[str]:
             errors.append(message)
     seen: set[str] = set()
     for raw_reference in iter_path_references(text):
-        reference = raw_reference.split("#", 1)[0]
-        if not reference or reference in seen or is_placeholder_reference(reference):
+        if is_placeholder_reference(raw_reference):
+            continue
+        reference = normalize_reference(raw_reference)
+        if not reference or reference in seen:
             continue
         seen.add(reference)
-        if not reference_exists(skill_file.parent, root, reference):
-            errors.append(f"missing local reference: {reference}")
+        problem = locate_reference(skill_file.parent, root, reference)
+        if problem is not None:
+            errors.append(problem)
     return errors
 
 
-def check_skills(root: Path, changed: list[Path] | None = None) -> list[Error]:
-    """Validate every skill under ``root``.
-
-    ``changed`` narrows the report to those SKILL.md paths when any of them has
-    an error; otherwise every error is reported so a broken untouched skill
-    cannot hide behind a clean one.
-    """
+def check_skills(root: Path) -> list[Error]:
+    """Validate every skill under ``root``; return ``(path, message)`` errors."""
     root = root.resolve()
-    skill_files = sorted((root / SKILLS_DIR).glob("*/SKILL.md"))
-    assert skill_files, f"no skills found under {root / SKILLS_DIR}"
-    unchanged_vendors = vendored_unchanged_skills(root)
+    skills_dir = root / SKILLS_DIR
+    skill_dirs = sorted(
+        path
+        for path in skills_dir.iterdir()
+        if path.is_dir() and not path.name.startswith((".", "__"))
+    )
+    if not skill_dirs:
+        return [(skills_dir, "no skill directories found")]
+    unchanged_vendors, errors = vendored_unchanged_skills(root)
 
-    errors: list[Error] = []
     names: dict[str, list[Path]] = {}
-    for skill_file in skill_files:
-        text = skill_file.read_text()
+    for skill_dir in skill_dirs:
+        skill_file = skill_dir / "SKILL.md"
+        if skill_file.name not in os.listdir(skill_dir):
+            errors.append((skill_dir, "skill directory has no SKILL.md"))
+            continue
+        text = skill_file.read_text(encoding="utf-8")
         parts = split_frontmatter(text)
         if parts is None:
             errors.append((skill_file, "missing frontmatter delimiters"))
@@ -241,7 +356,7 @@ def check_skills(root: Path, changed: list[Path] | None = None) -> list[Error]:
         errors.extend((skill_file, error) for error in metadata_errors)
         if name is not None:
             names.setdefault(name, []).append(skill_file)
-        if skill_file.parent.name in unchanged_vendors:
+        if skill_dir.name in unchanged_vendors:
             continue
         errors.extend(
             (skill_file, error) for error in check_references(skill_file, root, text)
@@ -254,34 +369,24 @@ def check_skills(root: Path, changed: list[Path] | None = None) -> list[Error]:
         errors.extend(
             (path, f"duplicate skill name {name!r}: {joined}") for path in paths
         )
-
-    if changed:
-        changed_set = {path.resolve() for path in changed}
-        relevant = [(path, error) for path, error in errors if path in changed_set]
-        if relevant:
-            return relevant
     return errors
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    parser = argparse.ArgumentParser(
+        description="Validate every skill under .agents/skills/."
+    )
     parser.add_argument(
         "--root",
         type=Path,
         default=Path(__file__).resolve().parent.parent,
         help="repository root (default: the parent of infra/)",
     )
-    parser.add_argument(
-        "files",
-        nargs="*",
-        type=Path,
-        help="changed SKILL.md files; every skill is validated regardless",
-    )
     args = parser.parse_args(argv)
-    errors = check_skills(args.root, args.files or None)
+    root = args.root.resolve()
+    errors = check_skills(root)
     if not errors:
         return 0
-    root = args.root.resolve()
     print(f"Skill metadata check failed ({len(errors)} error(s)):")
     for path, error in errors:
         print(f"  - {path.relative_to(root)}: {error}")

--- a/infra/check_skill_metadata.py
+++ b/infra/check_skill_metadata.py
@@ -74,12 +74,13 @@ ROOT_FILE_NAMES = (
     "pyproject.toml",
     "uv.lock",
     ".pre-commit-config.yaml",
+    ".python-version",
 )
 _ROOT_FILE_ALTERNATION = "|".join(re.escape(name) for name in ROOT_FILE_NAMES)
 ROOT_FILE_PATTERN = re.compile(rf"(?<![\w./-])({_ROOT_FILE_ALTERNATION})(?![\w-])")
 INLINE_CODE_PATTERN = re.compile(r"`([^`\n]+)`")
 FENCED_BLOCK_PATTERN = re.compile(
-    r"^```[^\n]*\n(.*?)^```[ \t]*$", re.MULTILINE | re.DOTALL
+    r"^ {0,3}```[^\n]*\n(.*?)^ {0,3}```[ \t]*$", re.MULTILINE | re.DOTALL
 )
 MARKDOWN_LINK_PATTERN = re.compile(r"\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
 LINE_SUFFIX_PATTERN = re.compile(r":\d+(?:-\d+)?$")

--- a/infra/check_skill_metadata.py
+++ b/infra/check_skill_metadata.py
@@ -66,9 +66,11 @@ URL_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 DRIFT_TRAPS: tuple[tuple[re.Pattern[str], str], ...] = (
     (
         re.compile(r"src/marin_dna/pipelines/"),
-        "src/marin_dna/pipelines/ no longer exists; pipeline packages live under "
-        "snakemake/<pipeline>/src/ since pipelines became independently locked "
-        "projects",
+        (
+            "src/marin_dna/pipelines/ no longer exists; pipeline packages live under "
+            "snakemake/<pipeline>/src/ since pipelines became independently locked "
+            "projects"
+        ),
     ),
     (
         re.compile(r"\bagent-research\b"),
@@ -76,13 +78,17 @@ DRIFT_TRAPS: tuple[tuple[re.Pattern[str], str], ...] = (
     ),
     (
         re.compile(r"\bgh-upload-asset\b"),
-        "the gh-upload-asset skill was retired (#466); commit artifacts under "
-        ".agents/artifacts/<topic>/ on the permanent branch instead",
+        (
+            "the gh-upload-asset skill was retired (#466); commit artifacts under "
+            ".agents/artifacts/<topic>/ on the permanent branch instead"
+        ),
     ),
     (
         re.compile(r"\bmaintain-research-question\b"),
-        "the maintain-research-question skill was replaced by "
-        "maintain-knowledge-base (#476)",
+        (
+            "the maintain-research-question skill was replaced by "
+            "maintain-knowledge-base (#476)"
+        ),
     ),
 )
 

--- a/infra/check_skill_metadata.py
+++ b/infra/check_skill_metadata.py
@@ -17,8 +17,9 @@ Per skill directory the check enforces:
   expression and an IANA time zone;
 - ``allowed-tools`` is a string;
 - every repository path in inline code, fenced code, or a relative Markdown
-  link resolves from the skill directory or the repository root, with exact
-  case and without escaping the repository;
+  link — and every well-known root file cited by bare name — resolves from the
+  skill directory or the repository root, with exact case and without escaping
+  the repository;
 - known drift traps: paths and skill names that moved or were retired.
 
 Skills a vendor manifest lists as ``unchanged`` are upstream content that
@@ -61,6 +62,21 @@ _PREFIX_ALTERNATION = "|".join(re.escape(prefix) for prefix in REPOSITORY_PATH_P
 # (so ``s3://bucket/docs/x`` and ``a/docs/x`` do not match) and running to the
 # next whitespace or quote.
 PATH_TOKEN_PATTERN = re.compile(rf"(?<![\w./-])((?:{_PREFIX_ALTERNATION})/[^\s`'\"|]*)")
+# Well-known files referenced by bare name; validated like paths so renaming
+# one fails lint in every skill that cites it. SKILL.md resolves to the citing
+# skill's own file, the rest to the repository root.
+ROOT_FILE_NAMES = (
+    "AGENTS.md",
+    "CLAUDE.md",
+    "README.md",
+    "SKILL.md",
+    "LICENSE",
+    "pyproject.toml",
+    "uv.lock",
+    ".pre-commit-config.yaml",
+)
+_ROOT_FILE_ALTERNATION = "|".join(re.escape(name) for name in ROOT_FILE_NAMES)
+ROOT_FILE_PATTERN = re.compile(rf"(?<![\w./-])({_ROOT_FILE_ALTERNATION})(?![\w-])")
 INLINE_CODE_PATTERN = re.compile(r"`([^`\n]+)`")
 FENCED_BLOCK_PATTERN = re.compile(
     r"^```[^\n]*\n(.*?)^```[ \t]*$", re.MULTILINE | re.DOTALL
@@ -73,15 +89,51 @@ URL_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 
 FRONTMATTER_KEY_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
 CRON_FIELD_COUNT = 5
-_CRON_NUMERIC_TOKEN = r"(?:\*|\d+(?:-\d+)?)(?:/\d+)?"
-_CRON_NAMED_TOKEN = r"(?:\*|[0-9A-Za-z]+(?:-[0-9A-Za-z]+)?)(?:/\d+)?"
-CRON_FIELD_PATTERNS = (
-    re.compile(rf"^{_CRON_NUMERIC_TOKEN}(?:,{_CRON_NUMERIC_TOKEN})*$"),  # minute
-    re.compile(rf"^{_CRON_NUMERIC_TOKEN}(?:,{_CRON_NUMERIC_TOKEN})*$"),  # hour
-    re.compile(rf"^{_CRON_NUMERIC_TOKEN}(?:,{_CRON_NUMERIC_TOKEN})*$"),  # day of month
-    re.compile(rf"^{_CRON_NAMED_TOKEN}(?:,{_CRON_NAMED_TOKEN})*$"),  # month
-    re.compile(rf"^{_CRON_NAMED_TOKEN}(?:,{_CRON_NAMED_TOKEN})*$"),  # day of week
+_CRON_MONTHS = (
+    "jan",
+    "feb",
+    "mar",
+    "apr",
+    "may",
+    "jun",
+    "jul",
+    "aug",
+    "sep",
+    "oct",
+    "nov",
+    "dec",
 )
+_CRON_DAYS = ("sun", "mon", "tue", "wed", "thu", "fri", "sat")
+# (low, high, names) per field: minute, hour, day of month, month, day of week.
+CRON_FIELD_SPECS: tuple[tuple[int, int, tuple[str, ...]], ...] = (
+    (0, 59, ()),
+    (0, 23, ()),
+    (1, 31, ()),
+    (1, 12, _CRON_MONTHS),
+    (0, 7, _CRON_DAYS),
+)
+
+
+def _cron_value_valid(value: str, low: int, high: int, names: tuple[str, ...]) -> bool:
+    if value.lower() in names:
+        return True
+    return value.isdigit() and low <= int(value) <= high
+
+
+def _cron_field_valid(field: str, low: int, high: int, names: tuple[str, ...]) -> bool:
+    for token in field.split(","):
+        value, slash, step = token.partition("/")
+        if slash and not (step.isdigit() and int(step) > 0):
+            return False
+        if value == "*":
+            continue
+        bounds = value.split("-")
+        if len(bounds) > 2:
+            return False
+        if not all(_cron_value_valid(bound, low, high, names) for bound in bounds):
+            return False
+    return True
+
 
 # Drift traps for mistakes this repository has already made once. Each entry
 # is (pattern, message); a match anywhere in the skill text is an error. When
@@ -157,6 +209,7 @@ def iter_path_references(text: str) -> list[str]:
     prose = INLINE_CODE_PATTERN.sub("", prose)
     for code in [*fenced_blocks, *inline_code]:
         references.extend(match.group(1) for match in PATH_TOKEN_PATTERN.finditer(code))
+        references.extend(match.group(1) for match in ROOT_FILE_PATTERN.finditer(code))
     for match in MARKDOWN_LINK_PATTERN.finditer(prose):
         target = match.group(1)
         if target.startswith("#") or URL_SCHEME_PATTERN.match(target):
@@ -240,8 +293,8 @@ def check_schedule(metadata: dict[str, object]) -> list[str]:
         else:
             fields = cron.split()
             valid = len(fields) == CRON_FIELD_COUNT and all(
-                pattern.match(field)
-                for pattern, field in zip(CRON_FIELD_PATTERNS, fields)
+                _cron_field_valid(field, low, high, names)
+                for field, (low, high, names) in zip(fields, CRON_FIELD_SPECS)
             )
             if not valid:
                 errors.append(

--- a/infra/check_skill_metadata.py
+++ b/infra/check_skill_metadata.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Validate every skill under ``.agents/skills/``.
+
+The pre-commit hook runs this whenever anything under ``.agents/skills/``
+changes, and the Quality workflow runs it on every push and pull request.
+One skill change re-validates all skills because skills link to each other
+and to the repository layout, so a rename anywhere can break a link elsewhere.
+
+Per ``SKILL.md`` the check enforces:
+
+- the frontmatter is a YAML mapping;
+- ``name`` is a non-empty string equal to the skill directory name, and no two
+  skills share a name;
+- ``description`` is a non-empty single-line string;
+- ``schedule_cron`` and ``schedule_tz`` appear together, as a five-field cron
+  expression and an IANA time zone;
+- ``allowed-tools`` is a string;
+- every backticked repository path and every relative Markdown link resolves
+  from the skill directory or the repository root;
+- known drift traps: paths and skill names that moved or were retired.
+
+Skills a vendor manifest lists as ``unchanged`` are upstream content that
+``maintain-vendored-skills`` verifies byte-for-byte, so their local path
+references and drift traps are not checked; their frontmatter still is.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import zoneinfo
+from pathlib import Path
+
+import yaml
+
+SKILLS_DIR = Path(".agents") / "skills"
+VENDOR_MANIFEST_GLOB = "maintain-vendored-skills/references/*manifest.json"
+
+# Top-level directories a skill may reference. The last four were removed from
+# ``main`` in #333, so a reference to them is stale by construction.
+REPOSITORY_PATH_PREFIXES = (
+    ".agents",
+    ".claude",
+    ".github",
+    "dashboard",
+    "docs",
+    "infra",
+    "snakemake",
+    "src",
+    "tests",
+    "experiments",
+    "lib",
+    "plots",
+    "scripts",
+)
+_PREFIX_ALTERNATION = "|".join(re.escape(prefix) for prefix in REPOSITORY_PATH_PREFIXES)
+BACKTICK_PATH_PATTERN = re.compile(rf"`((?:{_PREFIX_ALTERNATION})/[^`\s,;:)]*)`")
+MARKDOWN_LINK_PATTERN = re.compile(r"\]\(([^)\s]+)\)")
+REFERENCE_PLACEHOLDER_TOKENS = ("<", ">", "*", "{", "}", "...", "YYYY", "XXXX", "$")
+URL_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
+
+# Drift traps for mistakes this repository has already made once. Each entry
+# is (pattern, message); a match anywhere in the skill text is an error.
+DRIFT_TRAPS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"src/marin_dna/pipelines/"),
+        "src/marin_dna/pipelines/ no longer exists; pipeline packages live under "
+        "snakemake/<pipeline>/src/ since pipelines became independently locked "
+        "projects",
+    ),
+    (
+        re.compile(r"\bagent-research\b"),
+        "the agent-research skill was replaced by run-research (#455)",
+    ),
+    (
+        re.compile(r"\bgh-upload-asset\b"),
+        "the gh-upload-asset skill was retired (#466); commit artifacts under "
+        ".agents/artifacts/<topic>/ on the permanent branch instead",
+    ),
+    (
+        re.compile(r"\bmaintain-research-question\b"),
+        "the maintain-research-question skill was replaced by "
+        "maintain-knowledge-base (#476)",
+    ),
+)
+
+CRON_FIELD_COUNT = 5
+
+Error = tuple[Path, str]
+
+
+def split_frontmatter(text: str) -> tuple[str, str] | None:
+    """Return ``(frontmatter, body)`` or ``None`` when the delimiters are missing."""
+    if not text.startswith("---\n"):
+        return None
+    lines = text.split("\n")
+    for index in range(1, len(lines)):
+        if lines[index].rstrip() == "---":
+            return "\n".join(lines[1:index]), "\n".join(lines[index + 1 :])
+    return None
+
+
+def is_placeholder_reference(reference: str) -> bool:
+    return any(token in reference for token in REFERENCE_PLACEHOLDER_TOKENS)
+
+
+def reference_exists(skill_dir: Path, root: Path, reference: str) -> bool:
+    return (skill_dir / reference).exists() or (root / reference).exists()
+
+
+def iter_path_references(text: str) -> list[str]:
+    """Backticked repository paths and relative Markdown link targets in ``text``."""
+    references: list[str] = []
+    for match in BACKTICK_PATH_PATTERN.finditer(text):
+        references.append(match.group(1))
+    for match in MARKDOWN_LINK_PATTERN.finditer(text):
+        target = match.group(1)
+        if target.startswith("#") or URL_SCHEME_PATTERN.match(target):
+            continue
+        references.append(target)
+    return references
+
+
+def vendored_unchanged_skills(root: Path) -> set[str]:
+    """Skill names every vendor manifest classifies as ``unchanged``."""
+    names: set[str] = set()
+    for manifest_path in sorted((root / SKILLS_DIR).glob(VENDOR_MANIFEST_GLOB)):
+        manifest = json.loads(manifest_path.read_text())
+        unchanged = manifest.get("unchanged", [])
+        assert isinstance(unchanged, list), f"{manifest_path}: unchanged must be a list"
+        names.update(unchanged)
+    return names
+
+
+def check_metadata(skill_file: Path, frontmatter: str) -> tuple[list[str], str | None]:
+    """Validate the frontmatter mapping; return ``(errors, name)``."""
+    errors: list[str] = []
+    try:
+        metadata = yaml.safe_load(frontmatter)
+    except yaml.YAMLError as error:
+        return [f"invalid YAML frontmatter: {error}"], None
+    if not isinstance(metadata, dict):
+        return [
+            f"frontmatter must be a YAML mapping, got {type(metadata).__name__}"
+        ], None
+
+    name = metadata.get("name")
+    if not isinstance(name, str) or not name.strip():
+        errors.append(f"frontmatter must include a non-empty string name, got {name!r}")
+        name = None
+    elif name != skill_file.parent.name:
+        errors.append(
+            f"name {name!r} must match directory name {skill_file.parent.name!r}"
+        )
+
+    description = metadata.get("description")
+    if not isinstance(description, str) or not description.strip():
+        errors.append(
+            "frontmatter must include a non-empty string description, "
+            f"got {description!r}"
+        )
+    elif "\n" in description.strip():
+        errors.append("description must be a single-line string")
+
+    has_cron = "schedule_cron" in metadata
+    has_tz = "schedule_tz" in metadata
+    if has_cron != has_tz:
+        errors.append("schedule_cron and schedule_tz must be specified together")
+    if has_cron:
+        cron = metadata["schedule_cron"]
+        if not isinstance(cron, str):
+            errors.append(f"schedule_cron must be a string, got {type(cron).__name__}")
+        elif len(cron.split()) != CRON_FIELD_COUNT:
+            errors.append(
+                f"schedule_cron must be a {CRON_FIELD_COUNT}-field cron expression, "
+                f"got {cron!r}"
+            )
+    if has_tz:
+        tz = metadata["schedule_tz"]
+        if not isinstance(tz, str):
+            errors.append(f"schedule_tz must be a string, got {type(tz).__name__}")
+        else:
+            known_zones = zoneinfo.available_timezones()
+            if known_zones and tz not in known_zones:
+                errors.append(f"schedule_tz must be an IANA time zone, got {tz!r}")
+
+    allowed_tools = metadata.get("allowed-tools")
+    if allowed_tools is not None and not isinstance(allowed_tools, str):
+        errors.append(
+            f"allowed-tools must be a string, got {type(allowed_tools).__name__}"
+        )
+    return errors, name
+
+
+def check_references(skill_file: Path, root: Path, text: str) -> list[str]:
+    errors: list[str] = []
+    for pattern, message in DRIFT_TRAPS:
+        if pattern.search(text):
+            errors.append(message)
+    seen: set[str] = set()
+    for raw_reference in iter_path_references(text):
+        reference = raw_reference.split("#", 1)[0]
+        if not reference or reference in seen or is_placeholder_reference(reference):
+            continue
+        seen.add(reference)
+        if not reference_exists(skill_file.parent, root, reference):
+            errors.append(f"missing local reference: {reference}")
+    return errors
+
+
+def check_skills(root: Path, changed: list[Path] | None = None) -> list[Error]:
+    """Validate every skill under ``root``.
+
+    ``changed`` narrows the report to those SKILL.md paths when any of them has
+    an error; otherwise every error is reported so a broken untouched skill
+    cannot hide behind a clean one.
+    """
+    root = root.resolve()
+    skill_files = sorted((root / SKILLS_DIR).glob("*/SKILL.md"))
+    assert skill_files, f"no skills found under {root / SKILLS_DIR}"
+    unchanged_vendors = vendored_unchanged_skills(root)
+
+    errors: list[Error] = []
+    names: dict[str, list[Path]] = {}
+    for skill_file in skill_files:
+        text = skill_file.read_text()
+        parts = split_frontmatter(text)
+        if parts is None:
+            errors.append((skill_file, "missing frontmatter delimiters"))
+            continue
+        frontmatter, _body = parts
+        metadata_errors, name = check_metadata(skill_file, frontmatter)
+        errors.extend((skill_file, error) for error in metadata_errors)
+        if name is not None:
+            names.setdefault(name, []).append(skill_file)
+        if skill_file.parent.name in unchanged_vendors:
+            continue
+        errors.extend(
+            (skill_file, error) for error in check_references(skill_file, root, text)
+        )
+
+    for name, paths in names.items():
+        if len(paths) <= 1:
+            continue
+        joined = ", ".join(str(path.relative_to(root)) for path in paths)
+        errors.extend(
+            (path, f"duplicate skill name {name!r}: {joined}") for path in paths
+        )
+
+    if changed:
+        changed_set = {path.resolve() for path in changed}
+        relevant = [(path, error) for path, error in errors if path in changed_set]
+        if relevant:
+            return relevant
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="repository root (default: the parent of infra/)",
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        type=Path,
+        help="changed SKILL.md files; every skill is validated regardless",
+    )
+    args = parser.parse_args(argv)
+    errors = check_skills(args.root, args.files or None)
+    if not errors:
+        return 0
+    root = args.root.resolve()
+    print(f"Skill metadata check failed ({len(errors)} error(s)):")
+    for path, error in errors:
+        print(f"  - {path.relative_to(root)}: {error}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infra/check_skill_metadata.py
+++ b/infra/check_skill_metadata.py
@@ -57,7 +57,14 @@ REPOSITORY_PATH_PREFIXES = (
     "src",
     "tests",
 )
-_PREFIX_ALTERNATION = "|".join(re.escape(prefix) for prefix in REPOSITORY_PATH_PREFIXES)
+# Directories a skill references relative to its own directory.
+SKILL_RELATIVE_PREFIXES = (
+    "references",
+    "scripts",
+)
+_PREFIX_ALTERNATION = "|".join(
+    re.escape(prefix) for prefix in REPOSITORY_PATH_PREFIXES + SKILL_RELATIVE_PREFIXES
+)
 # A repository path token inside code: not glued to a preceding path or word
 # (so ``s3://bucket/docs/x`` and ``a/docs/x`` do not match) and running to the
 # next whitespace or quote.
@@ -75,6 +82,7 @@ ROOT_FILE_NAMES = (
     "uv.lock",
     ".pre-commit-config.yaml",
     ".python-version",
+    ".gitignore",
 )
 _ROOT_FILE_ALTERNATION = "|".join(re.escape(name) for name in ROOT_FILE_NAMES)
 ROOT_FILE_PATTERN = re.compile(rf"(?<![\w./-])({_ROOT_FILE_ALTERNATION})(?![\w-])")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
     "pre-commit>=4.6.1",
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
+    "pyyaml>=6.0",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ environments = [
 packages = ["src/marin_dna"]
 
 [tool.mypy]
-files = "src/marin_dna"
+files = ["src/marin_dna", "infra"]
 ignore_missing_imports = true
 strict_optional = false
 

--- a/snakemake/analysis/evals_v2/uv.lock
+++ b/snakemake/analysis/evals_v2/uv.lock
@@ -784,6 +784,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.6.1" },
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]

--- a/snakemake/training_dataset/dataset_creation/uv.lock
+++ b/snakemake/training_dataset/dataset_creation/uv.lock
@@ -580,6 +580,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.6.1" },
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]

--- a/snakemake/training_dataset/genome_selection/uv.lock
+++ b/snakemake/training_dataset/genome_selection/uv.lock
@@ -369,6 +369,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.6.1" },
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]

--- a/snakemake/vertebrate_projection_dataset/uv.lock
+++ b/snakemake/vertebrate_projection_dataset/uv.lock
@@ -479,6 +479,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.6.1" },
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]

--- a/tests/test_check_skill_metadata.py
+++ b/tests/test_check_skill_metadata.py
@@ -172,15 +172,25 @@ def test_schedule_fields_are_validated(tmp_path: Path) -> None:
     scheduled("macro", '"@daily"', "America/New_York")
     scheduled("bad-zone", '"0 10 * * *"', "Mars/Olympus_Mons")
     scheduled("typed", "5", "[a]")
+    scheduled("range-dom", '"0 0 32 * *"', "America/New_York")
+    scheduled("range-dow", '"0 0 * * 8"', "America/New_York")
+    scheduled("range-minute", '"99 0 * * *"', "America/New_York")
+    scheduled("range-month", '"0 0 1 13 *"', "America/New_York")
+    scheduled("zero-step", '"*/0 0 * * *"', "America/New_York")
     scheduled("good", '"*/15 0-6,22 1,15 jan-jun mon-fri"', "America/New_York")
 
     assert messages(checker.check_skills(tmp_path)) == [
         "schedule_tz must be an IANA time zone, got 'Mars/Olympus_Mons'",
         "schedule_cron must be a 5-field cron expression, got 'a b c d e'",
         "schedule_cron must be a 5-field cron expression, got '@daily'",
+        "schedule_cron must be a 5-field cron expression, got '0 0 32 * *'",
+        "schedule_cron must be a 5-field cron expression, got '0 0 * * 8'",
+        "schedule_cron must be a 5-field cron expression, got '99 0 * * *'",
+        "schedule_cron must be a 5-field cron expression, got '0 0 1 13 *'",
         "schedule_cron must be a 5-field cron expression, got '0 10 2 * * *'",
         "schedule_cron must be a string, got int",
         "schedule_tz must be a string, got list",
+        "schedule_cron must be a 5-field cron expression, got '*/0 0 * * *'",
     ]
 
 
@@ -233,13 +243,16 @@ def test_missing_references_are_reported_once_each(tmp_path: Path) -> None:
         "Read `docs/missing.md` twice: `docs/missing.md:7`.\n"
         "Link [gone](references/gone.md) and [root](tests/nope.py).\n"
         "Anchored `.agents/skills/demo/SKILL.md#section` resolves.\n"
+        "Root files: follow `AGENTS.md`, then `pyproject.toml`.\n"
         "```bash\npython3 .agents/skills/demo/scripts/absent.py --flag\n```\n"
     )
     write_skill(tmp_path, "demo", body)
+    write_file(tmp_path, "AGENTS.md")
 
     assert messages(checker.check_skills(tmp_path)) == [
         "missing local reference: .agents/skills/demo/scripts/absent.py",
         "missing local reference: docs/missing.md",
+        "missing local reference: pyproject.toml",
         "missing local reference: references/gone.md",
         "missing local reference: tests/nope.py",
     ]
@@ -260,6 +273,15 @@ def test_placeholders_urls_anchors_and_code_span_links_are_skipped(
     write_file(tmp_path, "docs/present.md")
 
     assert checker.check_skills(tmp_path) == []
+
+
+def test_root_file_references_are_validated(tmp_path: Path) -> None:
+    write_skill(tmp_path, "demo", "Follow `AGENTS.md`; see `SKILL.md` and `README.md`.")
+    write_file(tmp_path, "AGENTS.md")
+
+    assert messages(checker.check_skills(tmp_path)) == [
+        "missing local reference: README.md"
+    ]
 
 
 def test_references_must_stay_inside_the_repository(tmp_path: Path) -> None:

--- a/tests/test_check_skill_metadata.py
+++ b/tests/test_check_skill_metadata.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[1]
+SCRIPT_PATH = REPO_ROOT / "infra/check_skill_metadata.py"
+
+
+def load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_skill_metadata", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = load_script()
+
+VALID_FRONTMATTER = "---\nname: {name}\ndescription: Do the thing.\n---\n"
+
+
+def write_skill(
+    root: Path, name: str, body: str = "", frontmatter: str | None = None
+) -> Path:
+    skill_dir = root / ".agents/skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_file = skill_dir / "SKILL.md"
+    header = (
+        frontmatter if frontmatter is not None else VALID_FRONTMATTER.format(name=name)
+    )
+    skill_file.write_text(header + f"\n# {name}\n\n{body}")
+    return skill_file
+
+
+def messages(errors: list[tuple[Path, str]]) -> list[str]:
+    return [message for _path, message in errors]
+
+
+def test_valid_skill_has_no_errors(tmp_path: Path) -> None:
+    write_skill(tmp_path, "demo", "Uses `docs/guide.md` and [ref](references/a.md).")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs/guide.md").write_text("guide\n")
+    (tmp_path / ".agents/skills/demo/references").mkdir()
+    (tmp_path / ".agents/skills/demo/references/a.md").write_text("a\n")
+
+    assert checker.check_skills(tmp_path) == []
+
+
+def test_missing_frontmatter_delimiters(tmp_path: Path) -> None:
+    write_skill(tmp_path, "demo", frontmatter="")
+    write_skill(tmp_path, "open", frontmatter="---\nname: open\ndescription: x\n")
+
+    assert messages(checker.check_skills(tmp_path)) == [
+        "missing frontmatter delimiters",
+        "missing frontmatter delimiters",
+    ]
+
+
+def test_frontmatter_must_be_mapping(tmp_path: Path) -> None:
+    write_skill(tmp_path, "demo", frontmatter="---\n- not\n- a mapping\n---\n")
+
+    assert messages(checker.check_skills(tmp_path)) == [
+        "frontmatter must be a YAML mapping, got list"
+    ]
+
+
+def test_invalid_yaml_is_reported(tmp_path: Path) -> None:
+    write_skill(tmp_path, "demo", frontmatter="---\nname: [unclosed\n---\n")
+
+    (message,) = messages(checker.check_skills(tmp_path))
+    assert message.startswith("invalid YAML frontmatter:")
+
+
+def test_name_must_match_directory(tmp_path: Path) -> None:
+    write_skill(tmp_path, "demo", frontmatter="---\nname: other\ndescription: x\n---\n")
+
+    assert messages(checker.check_skills(tmp_path)) == [
+        "name 'other' must match directory name 'demo'"
+    ]
+
+
+def test_name_and_description_must_be_non_empty_strings(tmp_path: Path) -> None:
+    write_skill(tmp_path, "demo", frontmatter="---\nname: ''\ndescription: 3\n---\n")
+
+    assert messages(checker.check_skills(tmp_path)) == [
+        "frontmatter must include a non-empty string name, got ''",
+        "frontmatter must include a non-empty string description, got 3",
+    ]
+
+
+def test_description_must_be_single_line(tmp_path: Path) -> None:
+    frontmatter = "---\nname: demo\ndescription: |\n  first line\n  second line\n---\n"
+    write_skill(tmp_path, "demo", frontmatter=frontmatter)
+
+    assert messages(checker.check_skills(tmp_path)) == [
+        "description must be a single-line string"
+    ]
+
+
+def test_schedule_fields_must_appear_together(tmp_path: Path) -> None:
+    write_skill(
+        tmp_path,
+        "cron-only",
+        frontmatter='---\nname: cron-only\ndescription: x\nschedule_cron: "0 10 * * *"\n---\n',
+    )
+    write_skill(
+        tmp_path,
+        "tz-only",
+        frontmatter="---\nname: tz-only\ndescription: x\nschedule_tz: America/New_York\n---\n",
+    )
+
+    assert messages(checker.check_skills(tmp_path)) == [
+        "schedule_cron and schedule_tz must be specified together",
+        "schedule_cron and schedule_tz must be specified together",
+    ]
+
+
+def test_schedule_fields_are_validated(tmp_path: Path) -> None:
+    write_skill(
+        tmp_path,
+        "bad",
+        frontmatter=(
+            "---\nname: bad\ndescription: x\n"
+            'schedule_cron: "0 10 2 * * *"\nschedule_tz: Mars/Olympus_Mons\n---\n'
+        ),
+    )
+    write_skill(
+        tmp_path,
+        "typed",
+        frontmatter="---\nname: typed\ndescription: x\nschedule_cron: 5\nschedule_tz: [a]\n---\n",
+    )
+    write_skill(
+        tmp_path,
+        "good",
+        frontmatter=(
+            "---\nname: good\ndescription: x\n"
+            'schedule_cron: "0 10 * * *"\nschedule_tz: America/New_York\n---\n'
+        ),
+    )
+
+    assert messages(checker.check_skills(tmp_path)) == [
+        "schedule_cron must be a 5-field cron expression, got '0 10 2 * * *'",
+        "schedule_tz must be an IANA time zone, got 'Mars/Olympus_Mons'",
+        "schedule_cron must be a string, got int",
+        "schedule_tz must be a string, got list",
+    ]
+
+
+def test_allowed_tools_must_be_string(tmp_path: Path) -> None:
+    write_skill(
+        tmp_path,
+        "demo",
+        frontmatter="---\nname: demo\ndescription: x\nallowed-tools:\n  - Bash\n---\n",
+    )
+    write_skill(
+        tmp_path,
+        "ok",
+        frontmatter="---\nname: ok\ndescription: x\nallowed-tools: Bash(git status:*)\n---\n",
+    )
+
+    assert messages(checker.check_skills(tmp_path)) == [
+        "allowed-tools must be a string, got list"
+    ]
+
+
+def test_duplicate_names_across_directories(tmp_path: Path) -> None:
+    write_skill(tmp_path, "one", frontmatter="---\nname: shared\ndescription: x\n---\n")
+    write_skill(tmp_path, "two", frontmatter="---\nname: shared\ndescription: x\n---\n")
+
+    found = messages(checker.check_skills(tmp_path))
+    assert found.count("name 'shared' must match directory name 'one'") == 1
+    assert found.count("name 'shared' must match directory name 'two'") == 1
+    duplicate = "duplicate skill name 'shared': .agents/skills/one/SKILL.md, .agents/skills/two/SKILL.md"
+    assert found.count(duplicate) == 2
+
+
+def test_missing_references_are_reported_once_each(tmp_path: Path) -> None:
+    body = (
+        "Read `docs/missing.md` twice: `docs/missing.md`.\n"
+        "Link [gone](references/gone.md) and [root](tests/nope.py).\n"
+        "Anchored `.agents/skills/demo/SKILL.md#section` resolves.\n"
+    )
+    write_skill(tmp_path, "demo", body)
+
+    assert messages(checker.check_skills(tmp_path)) == [
+        "missing local reference: docs/missing.md",
+        "missing local reference: references/gone.md",
+        "missing local reference: tests/nope.py",
+    ]
+
+
+def test_placeholders_urls_and_anchors_are_skipped(tmp_path: Path) -> None:
+    body = (
+        "Placeholders: `docs/<topic>/x.md`, `.agents/logbooks/*.md`, "
+        "`scripts/YYYY-MM-DD.py`, `docs/{a,b}.md`, `src/...`.\n"
+        "Links: [site](https://example.com/docs/x), [mail](mailto:a@b.c), [anchor](#here).\n"
+        "Retired top-level dirs are stale: `plots/output/fig.svg`.\n"
+    )
+    write_skill(tmp_path, "demo", body)
+
+    assert messages(checker.check_skills(tmp_path)) == [
+        "missing local reference: plots/output/fig.svg",
+    ]
+
+
+def test_drift_traps_fire_on_prose(tmp_path: Path) -> None:
+    body = (
+        "Old code sat in src/marin_dna/pipelines/evals.\n"
+        "Use agent-research, then gh-upload-asset the figure, "
+        "then maintain-research-question.\n"
+    )
+    write_skill(tmp_path, "demo", body)
+
+    found = messages(checker.check_skills(tmp_path))
+    assert len(found) == 4
+    assert found[0].startswith("src/marin_dna/pipelines/ no longer exists")
+    assert "agent-research" in found[1]
+    assert "gh-upload-asset" in found[2]
+    assert "maintain-research-question" in found[3]
+
+
+def test_vendored_unchanged_skills_skip_reference_checks_only(tmp_path: Path) -> None:
+    write_skill(tmp_path, "vendored", "Upstream path `docs/reports/index.md`.")
+    write_skill(tmp_path, "local", "Local path `docs/reports/index.md`.")
+    write_skill(
+        tmp_path,
+        "vendored-broken",
+        "Path `docs/nope.md`.",
+        frontmatter="---\nname: wrong\ndescription: x\n---\n",
+    )
+    manifest_dir = tmp_path / ".agents/skills/maintain-vendored-skills/references"
+    manifest_dir.mkdir(parents=True)
+    write_skill(tmp_path, "maintain-vendored-skills")
+    (manifest_dir / "manifest.json").write_text(
+        json.dumps(
+            {"unchanged": ["vendored", "vendored-broken"], "adapted": [], "local": []}
+        )
+    )
+
+    errors = checker.check_skills(tmp_path)
+    assert [(path.parent.name, message) for path, message in errors] == [
+        ("local", "missing local reference: docs/reports/index.md"),
+        ("vendored-broken", "name 'wrong' must match directory name 'vendored-broken'"),
+    ]
+
+
+def test_changed_files_narrow_the_report_only_when_they_have_errors(
+    tmp_path: Path,
+) -> None:
+    broken = write_skill(tmp_path, "broken", "See `docs/nope.md`.")
+    clean = write_skill(tmp_path, "clean")
+    also_broken = write_skill(tmp_path, "also-broken", "See `docs/nope2.md`.")
+
+    assert [p.parent.name for p, _ in checker.check_skills(tmp_path, [broken])] == [
+        "broken"
+    ]
+    assert [p.parent.name for p, _ in checker.check_skills(tmp_path, [clean])] == [
+        "also-broken",
+        "broken",
+    ]
+    assert [
+        p.parent.name for p, _ in checker.check_skills(tmp_path, [clean, also_broken])
+    ] == ["also-broken"]
+
+
+def test_cli_reports_errors_relative_to_root(tmp_path: Path) -> None:
+    write_skill(tmp_path, "demo", "See `docs/nope.md`.")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--root", str(tmp_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert result.stdout.splitlines() == [
+        "Skill metadata check failed (1 error(s)):",
+        "  - .agents/skills/demo/SKILL.md: missing local reference: docs/nope.md",
+    ]
+
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs/nope.md").write_text("now present\n")
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--root", str(tmp_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_root_without_skills_fails_loudly(tmp_path: Path) -> None:
+    with pytest.raises(AssertionError, match="no skills found"):
+        checker.check_skills(tmp_path)
+
+
+def test_repository_skills_pass() -> None:
+    assert checker.check_skills(REPO_ROOT) == []

--- a/tests/test_check_skill_metadata.py
+++ b/tests/test_check_skill_metadata.py
@@ -276,12 +276,34 @@ def test_placeholders_urls_anchors_and_code_span_links_are_skipped(
 
 
 def test_root_file_references_are_validated(tmp_path: Path) -> None:
-    write_skill(tmp_path, "demo", "Follow `AGENTS.md`; see `SKILL.md` and `README.md`.")
+    write_skill(
+        tmp_path,
+        "demo",
+        "Follow `AGENTS.md`; see `SKILL.md`, `README.md`, and `.python-version`.",
+    )
     write_file(tmp_path, "AGENTS.md")
 
     assert messages(checker.check_skills(tmp_path)) == [
-        "missing local reference: README.md"
+        "missing local reference: README.md",
+        "missing local reference: .python-version",
     ]
+
+
+def test_indented_fences_are_scanned(tmp_path: Path) -> None:
+    body = (
+        "1. Run:\n\n"
+        "   ```bash\n"
+        "   python3 .agents/skills/demo/scripts/tool.py --repo-root .\n"
+        "   ```\n"
+    )
+    write_skill(tmp_path, "demo", body)
+
+    assert messages(checker.check_skills(tmp_path)) == [
+        "missing local reference: .agents/skills/demo/scripts/tool.py"
+    ]
+
+    write_file(tmp_path, ".agents/skills/demo/scripts/tool.py")
+    assert checker.check_skills(tmp_path) == []
 
 
 def test_references_must_stay_inside_the_repository(tmp_path: Path) -> None:

--- a/tests/test_check_skill_metadata.py
+++ b/tests/test_check_skill_metadata.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType
-
-import pytest
 
 REPO_ROOT = Path(__file__).parents[1]
 SCRIPT_PATH = REPO_ROOT / "infra/check_skill_metadata.py"
@@ -37,8 +36,15 @@ def write_skill(
     header = (
         frontmatter if frontmatter is not None else VALID_FRONTMATTER.format(name=name)
     )
-    skill_file.write_text(header + f"\n# {name}\n\n{body}")
+    skill_file.write_text(header + f"\n# {name}\n\n{body}", encoding="utf-8")
     return skill_file
+
+
+def write_file(root: Path, relative: str, text: str = "x\n") -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
 
 
 def messages(errors: list[tuple[Path, str]]) -> list[str]:
@@ -46,11 +52,16 @@ def messages(errors: list[tuple[Path, str]]) -> list[str]:
 
 
 def test_valid_skill_has_no_errors(tmp_path: Path) -> None:
-    write_skill(tmp_path, "demo", "Uses `docs/guide.md` and [ref](references/a.md).")
-    (tmp_path / "docs").mkdir()
-    (tmp_path / "docs/guide.md").write_text("guide\n")
-    (tmp_path / ".agents/skills/demo/references").mkdir()
-    (tmp_path / ".agents/skills/demo/references/a.md").write_text("a\n")
+    write_skill(
+        tmp_path,
+        "demo",
+        "Uses `docs/guide.md:12`, [ref](references/a.md#top), and\n"
+        '[root](/docs/guide.md "Guide").\n\n'
+        "```bash\nuv run .agents/skills/demo/scripts/run.py --in docs/guide.md\n```\n",
+    )
+    write_file(tmp_path, "docs/guide.md")
+    write_file(tmp_path, ".agents/skills/demo/references/a.md")
+    write_file(tmp_path, ".agents/skills/demo/scripts/run.py")
 
     assert checker.check_skills(tmp_path) == []
 
@@ -63,6 +74,27 @@ def test_missing_frontmatter_delimiters(tmp_path: Path) -> None:
         "missing frontmatter delimiters",
         "missing frontmatter delimiters",
     ]
+
+
+def test_body_swallowed_by_a_later_rule_is_rejected(tmp_path: Path) -> None:
+    text = (
+        "---\nname: demo\ndescription: x\n\n# demo\n\n"
+        "Use when: the task needs it.\n\n---\n\nMore prose\n"
+    )
+    (tmp_path / ".agents/skills/demo").mkdir(parents=True)
+    (tmp_path / ".agents/skills/demo/SKILL.md").write_text(text, encoding="utf-8")
+
+    assert messages(checker.check_skills(tmp_path)) == [
+        "frontmatter key 'Use when' is not an identifier; is the closing --- missing?"
+    ]
+
+
+def test_byte_order_mark_is_tolerated(tmp_path: Path) -> None:
+    write_skill(
+        tmp_path, "demo", frontmatter="﻿" + VALID_FRONTMATTER.format(name="demo")
+    )
+
+    assert checker.check_skills(tmp_path) == []
 
 
 def test_frontmatter_must_be_mapping(tmp_path: Path) -> None:
@@ -125,31 +157,28 @@ def test_schedule_fields_must_appear_together(tmp_path: Path) -> None:
 
 
 def test_schedule_fields_are_validated(tmp_path: Path) -> None:
-    write_skill(
-        tmp_path,
-        "bad",
-        frontmatter=(
-            "---\nname: bad\ndescription: x\n"
-            'schedule_cron: "0 10 2 * * *"\nschedule_tz: Mars/Olympus_Mons\n---\n'
-        ),
-    )
-    write_skill(
-        tmp_path,
-        "typed",
-        frontmatter="---\nname: typed\ndescription: x\nschedule_cron: 5\nschedule_tz: [a]\n---\n",
-    )
-    write_skill(
-        tmp_path,
-        "good",
-        frontmatter=(
-            "---\nname: good\ndescription: x\n"
-            'schedule_cron: "0 10 * * *"\nschedule_tz: America/New_York\n---\n'
-        ),
-    )
+    def scheduled(name: str, cron: str, tz: str) -> None:
+        write_skill(
+            tmp_path,
+            name,
+            frontmatter=(
+                f"---\nname: {name}\ndescription: x\n"
+                f"schedule_cron: {cron}\nschedule_tz: {tz}\n---\n"
+            ),
+        )
+
+    scheduled("six-fields", '"0 10 2 * * *"', "America/New_York")
+    scheduled("letters", '"a b c d e"', "America/New_York")
+    scheduled("macro", '"@daily"', "America/New_York")
+    scheduled("bad-zone", '"0 10 * * *"', "Mars/Olympus_Mons")
+    scheduled("typed", "5", "[a]")
+    scheduled("good", '"*/15 0-6,22 1,15 jan-jun mon-fri"', "America/New_York")
 
     assert messages(checker.check_skills(tmp_path)) == [
-        "schedule_cron must be a 5-field cron expression, got '0 10 2 * * *'",
         "schedule_tz must be an IANA time zone, got 'Mars/Olympus_Mons'",
+        "schedule_cron must be a 5-field cron expression, got 'a b c d e'",
+        "schedule_cron must be a 5-field cron expression, got '@daily'",
+        "schedule_cron must be a 5-field cron expression, got '0 10 2 * * *'",
         "schedule_cron must be a string, got int",
         "schedule_tz must be a string, got list",
     ]
@@ -179,53 +208,110 @@ def test_duplicate_names_across_directories(tmp_path: Path) -> None:
     found = messages(checker.check_skills(tmp_path))
     assert found.count("name 'shared' must match directory name 'one'") == 1
     assert found.count("name 'shared' must match directory name 'two'") == 1
-    duplicate = "duplicate skill name 'shared': .agents/skills/one/SKILL.md, .agents/skills/two/SKILL.md"
+    duplicate = (
+        "duplicate skill name 'shared': "
+        ".agents/skills/one/SKILL.md, .agents/skills/two/SKILL.md"
+    )
     assert found.count(duplicate) == 2
+
+
+def test_skill_directory_without_skill_md(tmp_path: Path) -> None:
+    write_skill(tmp_path, "demo")
+    (tmp_path / ".agents/skills/stray").mkdir()
+    (tmp_path / ".agents/skills/stray/skill.md").write_text(
+        "lowercase\n", encoding="utf-8"
+    )
+    (tmp_path / ".agents/skills/__pycache__").mkdir()
+
+    assert [(p.name, m) for p, m in checker.check_skills(tmp_path)] == [
+        ("stray", "skill directory has no SKILL.md"),
+    ]
 
 
 def test_missing_references_are_reported_once_each(tmp_path: Path) -> None:
     body = (
-        "Read `docs/missing.md` twice: `docs/missing.md`.\n"
+        "Read `docs/missing.md` twice: `docs/missing.md:7`.\n"
         "Link [gone](references/gone.md) and [root](tests/nope.py).\n"
         "Anchored `.agents/skills/demo/SKILL.md#section` resolves.\n"
+        "```bash\npython3 .agents/skills/demo/scripts/absent.py --flag\n```\n"
     )
     write_skill(tmp_path, "demo", body)
 
     assert messages(checker.check_skills(tmp_path)) == [
+        "missing local reference: .agents/skills/demo/scripts/absent.py",
         "missing local reference: docs/missing.md",
         "missing local reference: references/gone.md",
         "missing local reference: tests/nope.py",
     ]
 
 
-def test_placeholders_urls_and_anchors_are_skipped(tmp_path: Path) -> None:
+def test_placeholders_urls_anchors_and_code_span_links_are_skipped(
+    tmp_path: Path,
+) -> None:
     body = (
         "Placeholders: `docs/<topic>/x.md`, `.agents/logbooks/*.md`, "
-        "`scripts/YYYY-MM-DD.py`, `docs/{a,b}.md`, `src/...`.\n"
-        "Links: [site](https://example.com/docs/x), [mail](mailto:a@b.c), [anchor](#here).\n"
-        "Retired top-level dirs are stale: `plots/output/fig.svg`.\n"
+        "`docs/YYYY-MM-DD.md`, `docs/{a}.md`, `src/...`, `tests/$NAME.py`.\n"
+        "Links: [site](https://example.com/docs/x), [mail](mailto:a@b.c), "
+        "[anchor](#here), and syntax `[text](url)` in a code span.\n"
+        "Glued paths: `s3://bucket/docs/x.md` and `a/docs/y.md`.\n"
+        "Real: `docs/present.md`.\n"
     )
     write_skill(tmp_path, "demo", body)
+    write_file(tmp_path, "docs/present.md")
+
+    assert checker.check_skills(tmp_path) == []
+
+
+def test_references_must_stay_inside_the_repository(tmp_path: Path) -> None:
+    traversal = os.path.relpath("/etc/hosts", tmp_path / ".agents/skills/demo")
+    write_skill(tmp_path, "demo", f"See [a](/etc/hosts) and [b]({traversal}).")
 
     assert messages(checker.check_skills(tmp_path)) == [
-        "missing local reference: plots/output/fig.svg",
+        "missing local reference: /etc/hosts",
+        f"reference escapes the repository: {traversal}",
     ]
+
+
+def test_reference_case_must_match_the_file_system(tmp_path: Path) -> None:
+    write_skill(tmp_path, "demo", "See `docs/README.md` and `docs/readme.md`.")
+    write_file(tmp_path, "docs/readme.md")
+
+    (message,) = messages(checker.check_skills(tmp_path))
+    # Case-insensitive file systems resolve the wrong-case path; others do not.
+    assert message in {
+        "reference case differs from the file system: docs/README.md",
+        "missing local reference: docs/README.md",
+    }
 
 
 def test_drift_traps_fire_on_prose(tmp_path: Path) -> None:
     body = (
-        "Old code sat in src/marin_dna/pipelines/evals.\n"
+        "Old code sat in src/marin_dna/pipelines/evals and plots/output.\n"
         "Use agent-research, then gh-upload-asset the figure, "
         "then maintain-research-question.\n"
+        "Fine: `docs/research/experiments/` and the Experiments section.\n"
     )
     write_skill(tmp_path, "demo", body)
+    write_file(tmp_path, "docs/research/experiments/.keep")
 
     found = messages(checker.check_skills(tmp_path))
-    assert len(found) == 4
+    assert len(found) == 5
     assert found[0].startswith("src/marin_dna/pipelines/ no longer exists")
-    assert "agent-research" in found[1]
-    assert "gh-upload-asset" in found[2]
-    assert "maintain-research-question" in found[3]
+    assert found[1].startswith("top-level experiments/ and plots/ were removed")
+    assert "agent-research" in found[2]
+    assert "gh-upload-asset" in found[3]
+    assert "maintain-research-question" in found[4]
+
+
+def write_manifest(root: Path, unchanged: list[object]) -> Path:
+    write_skill(root, "maintain-vendored-skills")
+    manifest = root / ".agents/skills/maintain-vendored-skills/references/manifest.json"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(
+        json.dumps({"unchanged": unchanged, "adapted": [], "local": []}),
+        encoding="utf-8",
+    )
+    return manifest
 
 
 def test_vendored_unchanged_skills_skip_reference_checks_only(tmp_path: Path) -> None:
@@ -237,14 +323,7 @@ def test_vendored_unchanged_skills_skip_reference_checks_only(tmp_path: Path) ->
         "Path `docs/nope.md`.",
         frontmatter="---\nname: wrong\ndescription: x\n---\n",
     )
-    manifest_dir = tmp_path / ".agents/skills/maintain-vendored-skills/references"
-    manifest_dir.mkdir(parents=True)
-    write_skill(tmp_path, "maintain-vendored-skills")
-    (manifest_dir / "manifest.json").write_text(
-        json.dumps(
-            {"unchanged": ["vendored", "vendored-broken"], "adapted": [], "local": []}
-        )
-    )
+    write_manifest(tmp_path, ["vendored", "vendored-broken"])
 
     errors = checker.check_skills(tmp_path)
     assert [(path.parent.name, message) for path, message in errors] == [
@@ -253,23 +332,14 @@ def test_vendored_unchanged_skills_skip_reference_checks_only(tmp_path: Path) ->
     ]
 
 
-def test_changed_files_narrow_the_report_only_when_they_have_errors(
-    tmp_path: Path,
-) -> None:
-    broken = write_skill(tmp_path, "broken", "See `docs/nope.md`.")
-    clean = write_skill(tmp_path, "clean")
-    also_broken = write_skill(tmp_path, "also-broken", "See `docs/nope2.md`.")
+def test_manifest_unchanged_entries_are_validated(tmp_path: Path) -> None:
+    write_skill(tmp_path, "vendored")
+    manifest = write_manifest(tmp_path, ["vendored", {"name": "vendored"}, "ghost"])
 
-    assert [p.parent.name for p, _ in checker.check_skills(tmp_path, [broken])] == [
-        "broken"
+    assert checker.check_skills(tmp_path) == [
+        (manifest, "unchanged entries must be names, got {'name': 'vendored'}"),
+        (manifest, "unchanged skill 'ghost' has no SKILL.md"),
     ]
-    assert [p.parent.name for p, _ in checker.check_skills(tmp_path, [clean])] == [
-        "also-broken",
-        "broken",
-    ]
-    assert [
-        p.parent.name for p, _ in checker.check_skills(tmp_path, [clean, also_broken])
-    ] == ["also-broken"]
 
 
 def test_cli_reports_errors_relative_to_root(tmp_path: Path) -> None:
@@ -287,8 +357,7 @@ def test_cli_reports_errors_relative_to_root(tmp_path: Path) -> None:
         "  - .agents/skills/demo/SKILL.md: missing local reference: docs/nope.md",
     ]
 
-    (tmp_path / "docs").mkdir()
-    (tmp_path / "docs/nope.md").write_text("now present\n")
+    write_file(tmp_path, "docs/nope.md")
     result = subprocess.run(
         [sys.executable, str(SCRIPT_PATH), "--root", str(tmp_path)],
         check=False,
@@ -299,9 +368,10 @@ def test_cli_reports_errors_relative_to_root(tmp_path: Path) -> None:
     assert result.stdout == ""
 
 
-def test_root_without_skills_fails_loudly(tmp_path: Path) -> None:
-    with pytest.raises(AssertionError, match="no skills found"):
-        checker.check_skills(tmp_path)
+def test_root_without_skills_is_an_error(tmp_path: Path) -> None:
+    (tmp_path / ".agents/skills").mkdir(parents=True)
+
+    assert messages(checker.check_skills(tmp_path)) == ["no skill directories found"]
 
 
 def test_repository_skills_pass() -> None:

--- a/tests/test_check_skill_metadata.py
+++ b/tests/test_check_skill_metadata.py
@@ -279,14 +279,28 @@ def test_root_file_references_are_validated(tmp_path: Path) -> None:
     write_skill(
         tmp_path,
         "demo",
-        "Follow `AGENTS.md`; see `SKILL.md`, `README.md`, and `.python-version`.",
+        "Follow `AGENTS.md`; see `SKILL.md`, `README.md`, `.python-version`, `.gitignore`.",
     )
     write_file(tmp_path, "AGENTS.md")
 
     assert messages(checker.check_skills(tmp_path)) == [
         "missing local reference: README.md",
         "missing local reference: .python-version",
+        "missing local reference: .gitignore",
     ]
+
+
+def test_skill_relative_paths_in_code_spans_are_validated(tmp_path: Path) -> None:
+    write_skill(tmp_path, "demo", "Load `references/` and run `scripts/tool.py`.")
+
+    assert messages(checker.check_skills(tmp_path)) == [
+        "missing local reference: references/",
+        "missing local reference: scripts/tool.py",
+    ]
+
+    write_file(tmp_path, ".agents/skills/demo/references/a.md")
+    write_file(tmp_path, ".agents/skills/demo/scripts/tool.py")
+    assert checker.check_skills(tmp_path) == []
 
 
 def test_indented_fences_are_scanned(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -198,6 +198,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pyyaml" },
 ]
 
 [package.metadata]
@@ -216,6 +217,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.6.1" },
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Keep the skills under `.agents/skills/` from rotting: adopt marin's skill-maintenance conventions in MarinDNA. Three pieces: a mechanical validator that lints every skill on each commit and in CI, hub-and-spoke content rules in `AGENTS.md` so a skill points at repository-wide policy instead of restating it, and two scheduled scrub skills that hunt for stale guidance.

## Validator

Every SKILL.md under `.agents/skills/` is validated by `infra/check_skill_metadata.py`, run from pre-commit on every commit (`always_run`, since a deletion or rename elsewhere can break a skill's links without touching `.agents/skills/`) and from the Quality workflow on every pull request and push to `main`. The check requires a YAML-mapping frontmatter whose `name` equals the directory and is unique, a single-line `description`, paired five-field `schedule_cron` and IANA `schedule_tz`, a string `allowed-tools`, and that every repository path in inline code, fenced code blocks, or a relative Markdown link resolves from the skill directory or the repository root — with exact case (macOS agrees with Linux CI) and without escaping the repository. Drift traps reject paths and skill names this repository already retired: `src/marin_dna/pipelines/`, top-level `experiments/` and `plots/`, `agent-research`, `gh-upload-asset`, and `maintain-research-question`. Skills a vendor manifest lists as `unchanged` are exempt from the path checks because `maintain-vendored-skills` verifies them byte-for-byte against upstream; `background-research` still cites Marin-only paths and stays untouched.

## Hub-and-spoke content

`AGENTS.md` gains a Skills section naming itself, `writing-style`, and Repository Lifecycle as the only homes for repository-wide, prose, and delivery rules, and defining the description line as the routing contract. `develop-snakemake-pipelines`, `maintain-vendored-skills`, and `draft-weekly-research-update` point at those hubs instead of restating them. The eight marin-vendored skills keep the descriptions from the pinned vendor commit (836eab3, before marin#8494); inheriting the narrowed routing phrasing is a `maintain-vendored-skills` refresh, left for a separate PR.

## Scheduled scrubs

`scrub-reflection-self-improvement` (daily 10:00 America/New_York) and `scrub-docs-code-parity` (daily 00:00) are adapted from marin at the pinned vendor commit and registered in the vendor manifest. They search `AGENTS.md`, `.agents/skills/`, `docs/`, and workflow READMEs for stale guidance and publish through the delivery steps in `AGENTS.md`. The cron fields document the intended cadence; scheduling itself stays outside the repository, as for the monthly vendor review.

## Dependencies and lockfiles

`pyyaml` joins the root dev group for the validator. Because every Snakemake project depends on the root package by editable path, their four lockfiles are relocked — one `requires-dev` metadata line each, no resolved package changes.

## Review hardening

An independent review pass hardened the validator (frontmatter closing-delimiter detection, cron/zoneinfo validation, UTF-8 reads, strict manifest entries, exact-case in-repo path resolution), added `infra/` and `.agents/` to the Test workflow's core change detection so validator and skill-script changes run the root suite, and put `infra/` under mypy.

## Verification

Verified locally: `uv run --locked pre-commit run --all-files` passes with the new hook, `uv run --locked pytest -m "not slow"` is 172 passed / 1 skipped, and breaking a skill link makes the hook fail with the offending path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122KnUoehYoVoSEDhmr9haw
