### PR TITLE
Register enhancer order-control VEP checkpoint

### DIFF
--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -403,6 +403,9 @@ Two unavoidable AWS-side failure modes worth knowing about:
 
 ## Configuration (`config/config.yaml`)
 
+The issue #517 enhancer order control is registered as `exp517-phylop-uniform-enhancer-order-step-4999` for Mendelian and Complex Traits development evaluation.
+It uses the terminal step-4,999 export and a 255-base DNA window.
+
 | Key | Purpose |
 | --- | --- |
 | `input_hf_prefix` | HF prefix for `f"{prefix}_{dataset.name}"`. |

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -1316,6 +1316,12 @@ models:
     window_size: 256
     datasets: [mendelian_traits]
 
+  # Issue #517: strict phyloP Arm A enhancer, one source per vertebrate order.
+  - name: exp517-phylop-uniform-enhancer-order-step-4999
+    gcs_path: gs://marin-us-east5/MarinDNA/exp517_phylop_enhancer_order/checkpoints/dna-exp517-phylop-uniform-0p25b-enhancer-order-v1/2026.09.04/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits, complex_traits]
+
 inference:
   batch_size: 128       # Was 64 with output_hidden_states=True keeping all
                         # 19+2 layers' activations alive (~2.6 GB at L=256,


### PR DESCRIPTION
Register the terminal checkpoint of the issue #517 strict phyloP enhancer experiment with one sequence source per vertebrate order.
The entry uses a 255-base DNA window and adds only Mendelian and Complex Traits development evaluations.
The final export was verified against GCS checksums on September 8.
The research evaluation environment passed 416 tests with five skips using CPU selection for unit-test mocks, plus the separate pinned A10G GPU runtime check.
Its targeted dry-run contains two scoring jobs and two metric jobs, with no checkpoint-download job or unrelated evaluation.
The GPU-visible mock-test limitation is tracked in #544.

Part of #517.
