### PR TITLE
Add RAG documents and combined development harness

### DIFF
--- a/snakemake/vertebrate_projection_dataset/README.md
+++ b/snakemake/vertebrate_projection_dataset/README.md
@@ -206,3 +206,7 @@ Both targets require a dry-run before execution.
 Set `rag_publication_source` to an existing producer identity (`root`, `pipeline_commit`, `config_sha256`, `pipeline_version`, `tier`) to publish previously built documents without rerunning projection.
 The source producer receipt must match that identity.
 The workflow owns publication files and mappings under the new publishing producer namespace.
+
+Publication manifests and cards distinguish source-producer provenance from the publisher namespace containing the exact public-row mappings and release hashes.
+Artifact URIs use the active Snakemake storage prefix, or absolute local paths when storage is disabled.
+Training consumers calculate epoch exposure from their own duration, batch size, and mixture weights.

--- a/snakemake/vertebrate_projection_dataset/README.md
+++ b/snakemake/vertebrate_projection_dataset/README.md
@@ -161,3 +161,48 @@ Set `require_zrs: true` only for a biological smoke catalog containing the expec
 The synthetic fixture has no biological positive-control interpretation.
 Manual review should inspect both strands, mapped center placement, sequence case, and assembly/dictionary agreement, and compare sampled mappings to saved source-alignment projections.
 Report sampled agreement with its sampling design; do not claim genome-wide equivalence from a smoke test.
+
+## RAG documents from five source regions
+
+The additive `rag_all_documents` target builds one order-selected RAG corpus and a combined development evaluation harness.
+Supply a `rag` configuration block with `catalogs`, `benchmarks`, `validation_rows`, `seed`, and `publication_shards`.
+Each catalog pins its URI, SHA-256, source columns, region value, chromosome naming convention, and expected row count.
+Each benchmark pins its official development revision, download URL, checksum, chromosome naming convention, and expected row count.
+The [synthetic integration test](tests/test_rag_workflow.py) shows a complete configuration.
+Experimental biological selections remain on the permanent [issue 550 branch](https://github.com/Open-Athena/marin-dna/tree/6b1593c274a886d20f5c0ddf3712916d446f5fed/snakemake/vertebrate_projection_dataset/config/rag_issue550).
+Human is included once per document.
+The existing default targets retain their previous behavior.
+
+From this project on an authorized remote worker, inspect the plan before execution:
+
+```bash
+uv run --locked pytest
+uv run --locked snakemake rag_all_documents --configfile rag.yaml --cores 4 --resources mem_mb=56000 -n
+```
+
+The request catalog deduplicates exact 255-bp hg38 intervals across regions and development cohorts.
+An independent membership table retains every source row, including unused chr18 anchors.
+All chr18 anchors are excluded from training; each region samples up to 400 validation documents from chr18 with seed 42.
+Outside chr18, original region memberships remain intact.
+The current input audit found no sequence cache with the same validated `liftOver -multiple` contract, so this configuration reuses chain and genome inputs and projects the exact request union once per species.
+Historical HAL, MultiZ, or single-best chain sequence outputs are not interchangeable caches.
+
+Outputs live under the normal producer/config namespace in `rag/`.
+`anchors/source_memberships.parquet` maps source rows to exact requests and split membership; per-species accepted/rejected tables retain alignment and extraction provenance.
+`datasets/<region>/<split>.parquet` retains row coordinates, species order, orientation, unpadded/padding counts, and the document sequence.
+`evaluation/combined_development.parquet` preserves canonical row identities and metadata for Mendelian traits, complex traits, and SGE, restricted to odd autosomes and chrX.
+An explicit outcome for every requested species distinguishes biological missingness from an incomplete producer.
+
+Each training locus contributes forward and reverse-complement rows.
+Species are permuted once per row, and `[SEQ]` separates available 255-bp segments; reverse complementation acts within segments.
+Genuine Ns are retained and unavailable species are omitted.
+Evaluation fixes human last and preserves the same non-human order across REF/ALT and both orientations.
+The training project adds one BOS and right-pads to 10,240 positions with zero loss weight on padding targets.
+The internal tables are provenance-rich; public dataset publication must expose only a `sequence` column in `train` and `validation`.
+
+`rag_all_publication_files` writes sequence-only Parquet shards, dataset cards, public-row mappings, and a release manifest with file sizes and SHA-256 checksums.
+`rag_publish` uploads the validated release atomically and checks anonymous access, file inventory, checksums, and a representative downloaded split.
+Both targets require a dry-run before execution.
+Set `rag_publication_source` to an existing producer identity (`root`, `pipeline_commit`, `config_sha256`, `pipeline_version`, `tier`) to publish previously built documents without rerunning projection.
+The source producer receipt must match that identity.
+The workflow owns publication files and mappings under the new publishing producer namespace.

--- a/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/rag/__init__.py
+++ b/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/rag/__init__.py
@@ -1,0 +1,1 @@
+"""Additive chain-derived RAG document construction."""

--- a/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/rag/documents.py
+++ b/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/rag/documents.py
@@ -1,0 +1,219 @@
+"""Locus identity, document geometry, and locus-isolated validation splits.
+
+Coordinates are 0-based and half-open. These functions consume unsplit,
+human-oriented windows, never the legacy per-species training splits.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+WINDOW_BP = 255
+CENTER_INDEX = 127
+MAX_SPECIES = 40
+MODEL_TOKENS = 10_240
+SEPARATOR = "[SEQ]"
+HUMAN = "hg38"
+REGIONS = ("cds", "tss_utr5", "utr3", "ncrna", "enhancer")
+_COMPLEMENT = str.maketrans("ACGTNacgtn", "TGCANtgcan")
+
+
+def stable_digest(*parts: str | int) -> str:
+    """Hash an unambiguous identity without Python's process-randomized hash."""
+    return hashlib.sha256(
+        json.dumps(parts, ensure_ascii=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+@dataclass(frozen=True, order=True)
+class Locus:
+    """One exact hg38 query window, independent of catalog or benchmark."""
+
+    chrom: str
+    start: int
+    end: int
+
+    def __post_init__(self) -> None:
+        if not self.chrom.startswith("chr") or any(c.isspace() for c in self.chrom):
+            raise ValueError("locus requires an explicit UCSC chromosome name")
+        if type(self.start) is not int or type(self.end) is not int:
+            raise ValueError("locus coordinates must be integers")
+        if self.start < 0 or self.end - self.start != WINDOW_BP:
+            raise ValueError("locus must be a nonnegative 255-bp half-open window")
+
+    @property
+    def query_name(self) -> str:
+        """Coordinate identity shared by training and exact VEP requests."""
+        return "rag_" + stable_digest("hg38", self.chrom, self.start, self.end)
+
+    def validate_bounds(self, chrom_sizes: Mapping[str, int]) -> None:
+        if self.chrom not in chrom_sizes or self.end > chrom_sizes[self.chrom]:
+            raise ValueError(f"locus outside pinned genome: {self}")
+
+
+def reverse_complement(sequence: str) -> str:
+    """Reverse-complement DNA while retaining genuine N bases and case."""
+    if set(sequence) - set("ACGTNacgtn"):
+        raise ValueError("DNA contains characters outside A/C/G/T/N")
+    return sequence.translate(_COMPLEMENT)[::-1]
+
+
+def validate_sequence(sequence: str) -> None:
+    if len(sequence) != WINDOW_BP or set(sequence) - set("ACGTNacgtn"):
+        raise ValueError("each available species must have exactly 255 A/C/G/T/N bases")
+
+
+@dataclass(frozen=True)
+class Document:
+    sequence: str
+    species_order: tuple[str, ...]
+    orientation: str
+
+    @property
+    def unpadded_tokens(self) -> int:
+        return 256 * len(self.species_order)
+
+    @property
+    def padding_tokens(self) -> int:
+        return MODEL_TOKENS - self.unpadded_tokens
+
+
+def assemble_document(
+    windows: Mapping[str, str],
+    *,
+    locus: Locus,
+    seed: int = 42,
+    orientation: str = "forward",
+    evaluation: bool = False,
+) -> Document:
+    """Order each published row reproducibly using no alleles or labels.
+
+    The hash ranking is a reproducible random permutation independent of input
+    iteration order. Training orientation copies receive their own fixed order.
+    Evaluation orientations share one order and put human last. Missing species
+    must be omitted from ``windows``; an observed all-N window remains available.
+    """
+    if orientation not in {"forward", "rc"}:
+        raise ValueError("orientation must be forward or rc")
+    if HUMAN not in windows or not 1 <= len(windows) <= MAX_SPECIES:
+        raise ValueError("documents require human and at most 40 species")
+    for species, sequence in windows.items():
+        if not isinstance(species, str) or not species:
+            raise ValueError("species identities must be nonempty strings")
+        validate_sequence(sequence)
+    domain = "evaluation" if evaluation else f"training-{orientation}"
+    order = sorted(
+        (species for species in windows if not (evaluation and species == HUMAN)),
+        key=lambda species: (
+            stable_digest(seed, domain, locus.query_name, species),
+            species,
+        ),
+    )
+    if evaluation:
+        order.append(HUMAN)
+    segments = [windows[species] for species in order]
+    if orientation == "rc":
+        segments = [reverse_complement(segment) for segment in segments]
+    return Document(SEPARATOR.join(segments), tuple(order), orientation)
+
+
+def allele_documents(
+    windows: Mapping[str, str],
+    *,
+    locus: Locus,
+    ref: str,
+    alt: str,
+    seed: int = 42,
+) -> dict[str, Document]:
+    """Build paired SNV inputs with the same retrieval, order, and padding."""
+    if (
+        ref not in "ACGT"
+        or alt not in "ACGT"
+        or len(ref) != 1
+        or len(alt) != 1
+        or ref == alt
+    ):
+        raise ValueError("RAG VEP requires distinct single-base uppercase REF and ALT")
+    if HUMAN not in windows:
+        raise ValueError("human reference window is required")
+    human = windows[HUMAN]
+    validate_sequence(human)
+    if human[CENTER_INDEX].upper() != ref:
+        raise ValueError(f"REF mismatch at {locus.chrom}:{locus.start + CENTER_INDEX}")
+    # Normalize both designated alleles to the same case before tokenization.
+    outputs = {}
+    for allele_name, allele in (("ref", ref), ("alt", alt)):
+        changed = {
+            **windows,
+            HUMAN: human[:CENTER_INDEX] + allele + human[CENTER_INDEX + 1 :],
+        }
+        for orientation in ("forward", "rc"):
+            outputs[f"{allele_name}_{orientation}"] = assemble_document(
+                changed,
+                locus=locus,
+                seed=seed,
+                orientation=orientation,
+                evaluation=True,
+            )
+    return outputs
+
+
+@dataclass(frozen=True)
+class SplitPlan:
+    """Original-orientation memberships; RC is applied only after this split."""
+
+    train: dict[str, tuple[Locus, ...]]
+    validation: dict[str, tuple[Locus, ...]]
+    excluded: dict[str, tuple[Locus, ...]]
+    exact_cross_region_duplicates: int
+
+
+def select_validation(
+    catalogs: Mapping[str, Iterable[Locus]],
+    *,
+    validation_rows: int = 400,
+    seed: int = 42,
+) -> SplitPlan:
+    """Hold out all chr18 loci and sample fixed original-orientation validation rows.
+
+    Source-region memberships are preserved. Every chr18 window is excluded
+    from training, whether or not it is among that region's sampled validation
+    rows. Use all available chr18 loci when fewer than the requested budget
+    exist, including an explicitly empty validation set. This also separates all orientation copies and
+    cross-region overlaps without a coordinate-overlap exclusion pass.
+    """
+    if validation_rows < 1 or not catalogs:
+        raise ValueError("validation budget and catalogs must be nonempty")
+    validation: dict[str, tuple[Locus, ...]] = {}
+    train: dict[str, tuple[Locus, ...]] = {}
+    excluded: dict[str, tuple[Locus, ...]] = {}
+    seen: set[Locus] = set()
+    duplicates = 0
+    for region, records in sorted(catalogs.items()):
+        rows = tuple(records)
+        unique = set(rows)
+        if len(rows) != len(unique):
+            raise ValueError(f"duplicate locus within {region} source catalog")
+        duplicates += len(unique & seen)
+        seen.update(unique)
+        candidates = [locus for locus in rows if locus.chrom == "chr18"]
+        validation[region] = tuple(
+            sorted(
+                candidates,
+                key=lambda locus: (
+                    stable_digest(seed, "validation", region, locus.query_name),
+                    locus,
+                ),
+            )[:validation_rows]
+        )
+        selected = set(validation[region])
+        train[region] = tuple(sorted(locus for locus in rows if locus.chrom != "chr18"))
+        excluded[region] = tuple(
+            sorted(locus for locus in candidates if locus not in selected)
+        )
+        if not train[region]:
+            raise ValueError(f"chr18 holdout leaves no training rows in {region}")
+    return SplitPlan(train, validation, excluded, duplicates)

--- a/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/rag/harness.py
+++ b/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/rag/harness.py
@@ -1,0 +1,175 @@
+"""Combined development harness with exact canonical row identities."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+
+from marin_dna_vertebrate_projection.rag.documents import (
+    Locus,
+    allele_documents,
+    stable_digest,
+)
+from marin_dna_vertebrate_projection.rag.tables import (
+    WindowStore,
+    read_rows,
+    sha256_file,
+    write_rows,
+)
+
+BENCHMARKS = {"mendelian_traits", "complex_traits", "sge"}
+DEVELOPMENT_CHROMS = {f"chr{number}" for number in range(1, 23, 2)} | {"chrX"}
+
+
+def read_benchmark(path: str | Path, spec: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Read a pinned official train split, converting its 1-based SNV boundary.
+
+    The declared chromosome convention is checked rather than guessed. Original
+    row positions and complete canonical metadata survive harness construction.
+    No held-out rows may enter this development harness.
+    """
+    name = spec["name"]
+    if name not in BENCHMARKS or spec["split"] != "train":
+        raise ValueError(
+            "only the three registered development benchmarks are authorized"
+        )
+    if sha256_file(path) != spec["sha256"]:
+        raise ValueError("canonical benchmark SHA-256 mismatch")
+    naming = spec["chrom_names"]
+    if naming not in {"ucsc", "ensembl"}:
+        raise ValueError("benchmark chromosome naming must be explicit")
+    records = []
+    for index, metadata in enumerate(read_rows(path)):
+        chrom = str(metadata["chrom"])
+        if naming == "ensembl":
+            if chrom.startswith("chr"):
+                raise ValueError(
+                    "bare benchmark chromosome adapter received a UCSC name"
+                )
+            chrom = "chr" + chrom
+        if chrom not in DEVELOPMENT_CHROMS:
+            raise ValueError("held-out chromosome in the declared development input")
+        pos = metadata["pos"]
+        if type(pos) is not int or pos < 1:
+            raise ValueError(
+                "canonical VEP position must be a 1-based positive integer"
+            )
+        ref, alt = metadata["ref"], metadata["alt"]
+        if (
+            ref not in {"A", "C", "G", "T"}
+            or alt not in {"A", "C", "G", "T"}
+            or ref == alt
+        ):
+            raise ValueError("canonical RAG cohort must contain distinct REF/ALT SNVs")
+        locus = Locus(chrom, pos - 1 - 127, pos - 1 + 128)
+        records.append(
+            {
+                "benchmark": name,
+                "source_row_index": index,
+                "source_row_id": stable_digest(name, spec["revision"], "train", index),
+                "locus": locus,
+                "ref": ref,
+                "alt": alt,
+                "metadata": metadata,
+            }
+        )
+    if len(records) != spec["expected_rows"]:
+        raise ValueError("canonical source cohort row count changed")
+    return records
+
+
+HARNESS_SCHEMA = pa.schema(
+    [
+        ("benchmark", pa.string()),
+        ("source_row_index", pa.int64()),
+        ("source_row_id", pa.string()),
+        ("query_name", pa.string()),
+        ("source_chrom", pa.string()),
+        ("source_start", pa.int64()),
+        ("source_end", pa.int64()),
+        ("split", pa.string()),
+        ("ref", pa.string()),
+        ("alt", pa.string()),
+        ("sequence", pa.string()),
+        ("species_order", pa.list_(pa.string())),
+        ("group_id", pa.string()),
+        ("accession_id", pa.string()),
+        ("metadata_json", pa.string()),
+    ]
+)
+
+
+def write_harness(
+    benchmarks: Mapping[str, list[dict[str, Any]]],
+    store: WindowStore,
+    *,
+    species: set[str],
+    output: str | Path,
+    seed: int = 42,
+) -> dict[str, int]:
+    """Store one reference document per canonical row; alleles/strands derive from it."""
+    if set(benchmarks) != BENCHMARKS:
+        raise ValueError(
+            "combined harness requires exactly the three benchmark cohorts"
+        )
+    counts = {name: len(records) for name, records in benchmarks.items()}
+
+    def rows() -> Iterator[dict[str, Any]]:
+        for name, records in sorted(benchmarks.items()):
+            identities = set()
+            for record in records:
+                if record["benchmark"] != name or record["source_row_id"] in identities:
+                    raise ValueError(
+                        "duplicate or incorrectly namespaced source identity"
+                    )
+                identities.add(record["source_row_id"])
+                locus = record["locus"]
+                windows, _ = store.get(locus, species)
+                # This asserts REF and equal retrieval/permutation for all inputs.
+                document = allele_documents(
+                    windows,
+                    locus=locus,
+                    ref=record["ref"],
+                    alt=record["alt"],
+                    seed=seed,
+                )["ref_forward"]
+                metadata = record["metadata"]
+                yield {
+                    "benchmark": name,
+                    "source_row_index": record["source_row_index"],
+                    "source_row_id": record["source_row_id"],
+                    "query_name": locus.query_name,
+                    "source_chrom": locus.chrom,
+                    "source_start": locus.start,
+                    "source_end": locus.end,
+                    "split": "train",
+                    "ref": record["ref"],
+                    "alt": record["alt"],
+                    "sequence": document.sequence,
+                    "species_order": list(document.species_order),
+                    "group_id": stable_digest(
+                        name, "match_group", str(metadata["match_group"])
+                    )
+                    if "match_group" in metadata
+                    else None,
+                    "accession_id": stable_digest(
+                        name, "accession", str(metadata["mavedb_urn"])
+                    )
+                    if "mavedb_urn" in metadata
+                    else None,
+                    "metadata_json": json.dumps(
+                        metadata, sort_keys=True, allow_nan=False
+                    ),
+                }
+
+    written = write_rows(output, rows(), HARNESS_SCHEMA)
+    if written != sum(counts.values()):
+        raise ValueError("joint harness lost canonical benchmark rows")
+    Path(output).with_suffix(".counts.json").write_text(
+        json.dumps(counts, indent=2) + "\n"
+    )
+    return counts

--- a/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/rag/pipeline.py
+++ b/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/rag/pipeline.py
@@ -1,0 +1,253 @@
+"""File boundaries for the additive RAG workflow.
+
+Coordinates are deduplicated across all source cohorts before projection.
+Source memberships, including unused chr18 rows, remain separate durable data.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from collections.abc import Mapping
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+import pyarrow as pa
+
+from marin_dna_vertebrate_projection.projection.chains import read_sizes
+from marin_dna_vertebrate_projection.rag.documents import (
+    HUMAN,
+    REGIONS,
+    Locus,
+    select_validation,
+)
+from marin_dna_vertebrate_projection.rag.harness import read_benchmark, write_harness
+from marin_dna_vertebrate_projection.rag.requests import ProjectionIdentity
+from marin_dna_vertebrate_projection.rag.tables import (
+    WindowStore,
+    read_catalog,
+    read_rows,
+    sha256_file,
+    write_rows,
+    write_training_datasets,
+)
+
+CATALOG_SCHEMA = pa.schema(
+    [
+        ("query_name", pa.string()),
+        ("source_chrom", pa.string()),
+        ("source_start", pa.int64()),
+        ("source_end", pa.int64()),
+        ("region_label", pa.string()),
+    ]
+)
+MEMBERSHIP_SCHEMA = pa.schema(
+    [
+        ("namespace", pa.string()),
+        ("source_row_id", pa.string()),
+        ("query_name", pa.string()),
+        ("source_chrom", pa.string()),
+        ("source_start", pa.int64()),
+        ("source_end", pa.int64()),
+        ("split", pa.string()),
+    ]
+)
+
+
+def download_benchmark(spec: Mapping[str, Any], output: str | Path) -> None:
+    """Fetch only the immutable, explicitly registered development file."""
+    if spec["split"] != "train" or not spec["url"].endswith(
+        f"/{spec['revision']}/train.parquet"
+    ):
+        raise ValueError("benchmark URL must pin the official development split")
+    target = Path(output)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary = target.with_suffix(".partial")
+    urllib.request.urlretrieve(spec["url"], temporary)
+    if sha256_file(temporary) != spec["sha256"]:
+        raise ValueError("downloaded benchmark SHA-256 mismatch")
+    temporary.replace(target)
+
+
+def load_sources(
+    catalog_paths: Mapping[str, str],
+    benchmark_paths: Mapping[str, str],
+    rag: Mapping[str, Any],
+) -> tuple[dict[str, dict[Locus, str]], dict[str, list[dict[str, Any]]]]:
+    if set(catalog_paths) != set(REGIONS) or set(catalog_paths) != set(rag["catalogs"]):
+        raise ValueError("RAG training requires the five declared source regions")
+    catalogs = {
+        name: read_catalog(path, rag["catalogs"][name])
+        for name, path in catalog_paths.items()
+    }
+    benchmarks = {
+        name: read_benchmark(path, rag["benchmarks"][name])
+        for name, path in benchmark_paths.items()
+    }
+    return catalogs, benchmarks
+
+
+def compile_requests(
+    catalog_paths: Mapping[str, str],
+    benchmark_paths: Mapping[str, str],
+    rag: Mapping[str, Any],
+    chains: Mapping[str, Mapping[str, str]],
+    genomes: Mapping[str, Mapping[str, str]],
+    sizes_path: str,
+    catalog_output: str,
+    memberships_output: str,
+    audit_output: str,
+) -> None:
+    catalogs, benchmarks = load_sources(catalog_paths, benchmark_paths, rag)
+    split = select_validation(
+        catalogs, validation_rows=rag["validation_rows"], seed=rag["seed"]
+    )
+    memberships = []
+    loci: set[Locus] = set()
+    sizes = read_sizes(sizes_path)
+    for region, source_ids in sorted(catalogs.items()):
+        for label, selected in (
+            ("train", split.train[region]),
+            ("validation", split.validation[region]),
+            ("excluded_chr18", split.excluded[region]),
+        ):
+            for locus in selected:
+                locus.validate_bounds(sizes)
+                if label != "excluded_chr18":
+                    loci.add(locus)
+                memberships.append(
+                    {
+                        "namespace": region,
+                        "source_row_id": source_ids[locus],
+                        "query_name": locus.query_name,
+                        "source_chrom": locus.chrom,
+                        "source_start": locus.start,
+                        "source_end": locus.end,
+                        "split": label,
+                    }
+                )
+    for benchmark, records in sorted(benchmarks.items()):
+        for record in records:
+            locus = record["locus"]
+            locus.validate_bounds(sizes)
+            loci.add(locus)
+            memberships.append(
+                {
+                    "namespace": benchmark,
+                    "source_row_id": record["source_row_id"],
+                    "query_name": locus.query_name,
+                    "source_chrom": locus.chrom,
+                    "source_start": locus.start,
+                    "source_end": locus.end,
+                    "split": "development",
+                }
+            )
+    write_rows(memberships_output, memberships, MEMBERSHIP_SCHEMA)
+    write_rows(
+        catalog_output,
+        (
+            {
+                "query_name": locus.query_name,
+                "source_chrom": locus.chrom,
+                "source_start": locus.start,
+                "source_end": locus.end,
+                "region_label": "rag_union",
+            }
+            for locus in sorted(loci)
+        ),
+        CATALOG_SCHEMA,
+    )
+    identities = {
+        name: ProjectionIdentity(
+            species=name,
+            assembly=row["assembly"],
+            chain_sha256=row["chain_sha256"],
+            source_sizes_sha256=row["source_sizes_sha256"],
+            target_sizes_sha256=row["target_sizes_sha256"],
+            genome_sha256=genomes[name]["sha256"],
+        ).fingerprint
+        for name, row in chains.items()
+    }
+    Path(audit_output).write_text(
+        json.dumps(
+            {
+                "unique_requests": len(loci),
+                "source_memberships": len(memberships),
+                "benchmark_rows": {
+                    name: len(rows) for name, rows in benchmarks.items()
+                },
+                "projection_fingerprints": identities,
+                "reused_queries": 0,
+                "reuse_decision": "No archived sequence cache has the identical -multiple chain contract and complete validated provenance; reuse pinned genomes/chains and project the exact union once.",
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+
+def assemble_outputs(
+    catalog_paths: Mapping[str, str],
+    benchmark_paths: Mapping[str, str],
+    rag: Mapping[str, Any],
+    union_path: str,
+    human_path: str,
+    sequence_paths: Mapping[str, str],
+    rejection_paths: Mapping[str, str],
+    sequence_rejection_paths: Mapping[str, str],
+    directory: str,
+    harness_output: str,
+) -> None:
+    catalogs, benchmarks = load_sources(catalog_paths, benchmark_paths, rag)
+    expected = {
+        Locus(row["source_chrom"], row["source_start"], row["source_end"])
+        for row in read_rows(union_path)
+    }
+    if not set(sequence_paths) == set(rejection_paths) == set(sequence_rejection_paths):
+        raise ValueError("species outcome files must match exactly")
+    Path(directory).mkdir(parents=True, exist_ok=True)
+    with TemporaryDirectory(prefix=".rag-windows-", dir=directory) as temporary:
+        store = WindowStore(Path(temporary) / "windows.sqlite")
+        try:
+            count = store.ingest(
+                human_path, species=HUMAN, accepted=True, expected=expected
+            )
+            if count != len(expected):
+                raise ValueError("incomplete human sequence accounting")
+            for name, path in sorted(sequence_paths.items()):
+                count = store.ingest(
+                    path, species=name, accepted=True, expected=expected
+                )
+                count += store.ingest(
+                    rejection_paths[name],
+                    species=name,
+                    accepted=False,
+                    expected=expected,
+                )
+                count += store.ingest(
+                    sequence_rejection_paths[name],
+                    species=name,
+                    accepted=False,
+                    expected=expected,
+                )
+                if count != len(expected):
+                    raise ValueError(f"incomplete accepted/rejected accounting: {name}")
+            species = {HUMAN, *sequence_paths}
+            write_training_datasets(
+                catalogs,
+                store,
+                species=species,
+                directory=directory,
+                validation_rows=rag["validation_rows"],
+                seed=rag["seed"],
+            )
+            write_harness(
+                benchmarks,
+                store,
+                species=species,
+                output=harness_output,
+                seed=rag["seed"],
+            )
+        finally:
+            store.close()

--- a/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/rag/publication.py
+++ b/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/rag/publication.py
@@ -1,0 +1,270 @@
+"""Sequence-only Hub shards with producer-owned row mappings and release hashes."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from marin_dna_vertebrate_projection.rag.documents import stable_digest
+from marin_dna_vertebrate_projection.rag.tables import (
+    TRAIN_SCHEMA,
+    read_rows,
+    sha256_file,
+)
+
+PUBLIC_SCHEMA = pa.schema([("sequence", pa.string())])
+MAP_SCHEMA = pa.schema(
+    [
+        *[field for field in TRAIN_SCHEMA if field.name != "sequence"],
+        ("split", pa.string()),
+        ("public_shard", pa.string()),
+        ("public_row_index", pa.int64()),
+    ]
+)
+
+
+def prepare_release(
+    inputs: Mapping[str, str],
+    directory: str,
+    mapping_output: str,
+    manifest_output: str,
+    *,
+    region: str,
+    repo_id: str,
+    producer: Mapping[str, str],
+    train_shards: int = 16,
+) -> dict[str, Any]:
+    if set(inputs) != {"train", "validation"} or train_shards < 1:
+        raise ValueError("publication requires exactly train and validation")
+    root = Path(directory)
+    root.mkdir(parents=True, exist_ok=True)
+    Path(mapping_output).parent.mkdir(parents=True, exist_ok=True)
+    manifest: dict[str, Any] = {
+        "repo_id": repo_id,
+        "region": region,
+        "producer": dict(producer),
+        "source_files": {},
+        "splits": {},
+        "files": {},
+    }
+    with pq.ParquetWriter(
+        mapping_output, MAP_SCHEMA, compression="zstd"
+    ) as mapping_writer:
+        for split, path in sorted(inputs.items()):
+            shards = train_shards if split == "train" else 1
+            paths = [
+                root / f"{split}/{index:05d}-of-{shards:05d}.parquet"
+                for index in range(shards)
+            ]
+            for shard in paths:
+                shard.parent.mkdir(parents=True, exist_ok=True)
+            writers = [
+                pq.ParquetWriter(shard, PUBLIC_SCHEMA, compression="zstd")
+                for shard in paths
+            ]
+            buffers: list[list[dict[str, str]]] = [[] for _ in paths]
+            counts = [0] * shards
+            mappings = []
+            unpadded = 0
+            identities = set()
+            try:
+                for row in read_rows(path):
+                    identity = stable_digest(
+                        region, row["source_row_id"], row["orientation"]
+                    )
+                    if identity in identities:
+                        raise ValueError("duplicate public source row identity")
+                    identities.add(identity)
+                    if (split == "train") == (row["source_chrom"] == "chr18"):
+                        raise ValueError("public row violates chr18 split")
+                    if split == "validation" and row["orientation"] != "forward":
+                        raise ValueError(
+                            "validation publication contains reverse-complement augmentation"
+                        )
+                    index = int(identity[:16], 16) % shards
+                    buffers[index].append({"sequence": row["sequence"]})
+                    mappings.append(
+                        {
+                            **{
+                                key: value
+                                for key, value in row.items()
+                                if key != "sequence"
+                            },
+                            "split": split,
+                            "public_shard": str(paths[index].relative_to(root)),
+                            "public_row_index": counts[index],
+                        }
+                    )
+                    counts[index] += 1
+                    unpadded += row["unpadded_tokens"]
+                    if len(buffers[index]) == 256:
+                        writers[index].write_table(
+                            pa.Table.from_pylist(buffers[index], schema=PUBLIC_SCHEMA)
+                        )
+                        buffers[index] = []
+                    if len(mappings) == 4096:
+                        mapping_writer.write_table(
+                            pa.Table.from_pylist(mappings, schema=MAP_SCHEMA)
+                        )
+                        mappings = []
+                for index, buffer in enumerate(buffers):
+                    if buffer:
+                        writers[index].write_table(
+                            pa.Table.from_pylist(buffer, schema=PUBLIC_SCHEMA)
+                        )
+                if mappings:
+                    mapping_writer.write_table(
+                        pa.Table.from_pylist(mappings, schema=MAP_SCHEMA)
+                    )
+            finally:
+                for writer in writers:
+                    writer.close()
+            manifest["source_files"][split] = {"sha256": sha256_file(path)}
+            manifest["splits"][split] = {
+                "rows": sum(counts),
+                "unpadded_tokens": unpadded,
+                "allocated_tokens": sum(counts) * 10240,
+                "shard_rows": counts,
+            }
+            for index, shard in enumerate(paths):
+                parquet = pq.ParquetFile(shard)
+                if (
+                    parquet.schema_arrow != PUBLIC_SCHEMA
+                    or parquet.metadata.num_rows != counts[index]
+                ):
+                    raise ValueError("public shard schema or count mismatch")
+    card = f"""---
+license: openmdw-1.1
+tags: [biology, genomics, dna]
+configs:
+- config_name: default
+  data_files:
+  - split: train
+    path: train/*.parquet
+  - split: validation
+    path: validation/*.parquet
+---
+
+# {repo_id}
+
+Human-anchored RAG documents for the `{region}` region in [MarinDNA experiment 550](https://github.com/Open-Athena/marin-dna/issues/550).
+The [producing workflow](https://github.com/Open-Athena/marin-dna/tree/{producer["pipeline_commit"]}/snakemake/vertebrate_projection_dataset) owns source identities, projected coordinates, sequence provenance, public shard row mappings, and release checksums.
+Its immutable artifact root is `{producer["root"]}`.
+
+Both splits contain only a string `sequence` column.
+Training has {manifest["splits"]["train"]["rows"]:,} rows; validation has {manifest["splits"]["validation"]["rows"]:,} rows sampled from the complete chr18 training holdout.
+Every retained training locus contributes forward and reverse-complement rows.
+Each document joins available 255-bp species windows with atomic `[SEQ]` separators in a fixed per-row permutation.
+Human is included once; up to 18 non-human mammalian and 21 other vertebrate order representatives supply context.
+Missing projections are omitted, genuine Ns and source letter case are retained, and reverse complementation acts within each segment.
+Coordinates in producer artifacts use hg38 and 0-based, half-open intervals.
+
+The training consumer adds one BOS token and right padding to 10,240 positions, with padding targets excluded from loss.
+The strings here contain neither BOS nor padding.
+Public shard assignment is deterministic; `public_row_index` in the producer's row mapping identifies each exact published document.
+
+MarinDNA releases the processed dataset under OpenMDW 1.1.
+The underlying public genome assemblies and alignments retain their original source terms and attribution, recorded in the pinned source manifests.
+This release adds document assembly and does not relicense the underlying source assets.
+"""
+    (root / "README.md").write_text(card)
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            manifest["files"][str(path.relative_to(root))] = {
+                "bytes": path.stat().st_size,
+                "sha256": sha256_file(path),
+            }
+    manifest["row_mapping"] = {"sha256": sha256_file(mapping_output)}
+    Path(manifest_output).parent.mkdir(parents=True, exist_ok=True)
+    Path(manifest_output).write_text(json.dumps(manifest, indent=2) + "\n")
+    return manifest
+
+
+def publish_release(directory: str, manifest_path: str, receipt_path: str) -> None:
+    """Commit the validated release atomically and verify anonymous Hub access."""
+    from huggingface_hub import HfApi, hf_hub_download
+
+    manifest = json.loads(Path(manifest_path).read_text())
+    root = Path(directory)
+    observed = {
+        str(path.relative_to(root)) for path in root.rglob("*") if path.is_file()
+    }
+    if observed != set(manifest["files"]):
+        raise ValueError("publication folder differs from its release manifest")
+    for name, expected in manifest["files"].items():
+        path = root / name
+        if (
+            path.stat().st_size != expected["bytes"]
+            or sha256_file(path) != expected["sha256"]
+        ):
+            raise ValueError("publication file changed after release validation")
+    api = HfApi()
+    repo = manifest["repo_id"]
+    api.create_repo(repo, repo_type="dataset", private=False, exist_ok=True)
+    if api.repo_info(repo, repo_type="dataset").private:
+        raise ValueError("MarinDNA publication cannot use a private repository")
+    commit = api.upload_folder(
+        repo_id=repo,
+        repo_type="dataset",
+        folder_path=root,
+        commit_message="Publish reproducible RAG train and chr18 validation release",
+        delete_patterns=["train/*", "validation/*", "README.md"],
+    )
+    anonymous = HfApi(token=False)
+    info = anonymous.repo_info(
+        repo, repo_type="dataset", revision=commit.oid, files_metadata=True
+    )
+    if info.private or info.gated:
+        raise ValueError("published dataset is not anonymously accessible")
+    files = {
+        item.rfilename: item
+        for item in info.siblings
+        if item.rfilename != ".gitattributes"
+    }
+    if set(files) != set(manifest["files"]):
+        raise ValueError("published file inventory differs from release")
+    for name, expected in manifest["files"].items():
+        item = files[name]
+        if item.size != expected["bytes"]:
+            raise ValueError("published file size mismatch")
+        if item.lfs is not None:
+            if item.lfs.sha256 != expected["sha256"]:
+                raise ValueError("published LFS checksum mismatch")
+        else:
+            downloaded = hf_hub_download(
+                repo, name, repo_type="dataset", revision=commit.oid, token=False
+            )
+            if sha256_file(downloaded) != expected["sha256"]:
+                raise ValueError("published file checksum mismatch")
+    validation_path = hf_hub_download(
+        repo,
+        "validation/00000-of-00001.parquet",
+        repo_type="dataset",
+        revision=commit.oid,
+        token=False,
+    )
+    if (
+        sha256_file(validation_path)
+        != manifest["files"]["validation/00000-of-00001.parquet"]["sha256"]
+    ):
+        raise ValueError("anonymous validation download checksum mismatch")
+    if pq.ParquetFile(validation_path).schema_arrow != PUBLIC_SCHEMA:
+        raise ValueError("anonymous dataset download has the wrong schema")
+    Path(receipt_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(receipt_path).write_text(
+        json.dumps(
+            {
+                "repo_id": repo,
+                "revision": commit.oid,
+                "release_manifest_sha256": sha256_file(manifest_path),
+                "anonymous_verified": True,
+            },
+            indent=2,
+        )
+        + "\n"
+    )

--- a/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/rag/publication.py
+++ b/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/rag/publication.py
@@ -37,6 +37,7 @@ def prepare_release(
     region: str,
     repo_id: str,
     producer: Mapping[str, str],
+    publisher: Mapping[str, str],
     train_shards: int = 16,
 ) -> dict[str, Any]:
     if set(inputs) != {"train", "validation"} or train_shards < 1:
@@ -48,6 +49,7 @@ def prepare_release(
         "repo_id": repo_id,
         "region": region,
         "producer": dict(producer),
+        "publisher": dict(publisher),
         "source_files": {},
         "splits": {},
         "files": {},
@@ -152,21 +154,21 @@ configs:
 
 # {repo_id}
 
-Human-anchored RAG documents for the `{region}` region in [MarinDNA experiment 550](https://github.com/Open-Athena/marin-dna/issues/550).
-The [producing workflow](https://github.com/Open-Athena/marin-dna/tree/{producer["pipeline_commit"]}/snakemake/vertebrate_projection_dataset) owns source identities, projected coordinates, sequence provenance, public shard row mappings, and release checksums.
-Its immutable artifact root is `{producer["root"]}`.
+Human-anchored RAG documents for the `{region}` region.
+The [producing workflow](https://github.com/Open-Athena/marin-dna/tree/{producer["pipeline_commit"]}/snakemake/vertebrate_projection_dataset) owns source identities, projected coordinates, and sequence provenance at `{producer["root"]}`.
+The [publishing workflow](https://github.com/Open-Athena/marin-dna/tree/{publisher["pipeline_commit"]}/snakemake/vertebrate_projection_dataset) owns public shard row mappings and release checksums at `{publisher["root"]}/publication_provenance/{region}`.
 
 Both splits contain only a string `sequence` column.
 Training has {manifest["splits"]["train"]["rows"]:,} rows; validation has {manifest["splits"]["validation"]["rows"]:,} rows sampled from the complete chr18 training holdout.
 Every retained training locus contributes forward and reverse-complement rows.
 Each document joins available 255-bp species windows with atomic `[SEQ]` separators in a fixed per-row permutation.
-Human is included once; up to 18 non-human mammalian and 21 other vertebrate order representatives supply context.
+Human is included once; selected non-human representatives supply context, with at most 40 species in a document.
 Missing projections are omitted, genuine Ns and source letter case are retained, and reverse complementation acts within each segment.
 Coordinates in producer artifacts use hg38 and 0-based, half-open intervals.
 
 The training consumer adds one BOS token and right padding to 10,240 positions, with padding targets excluded from loss.
 The strings here contain neither BOS nor padding.
-Public shard assignment is deterministic; `public_row_index` in the producer's row mapping identifies each exact published document.
+Public shard assignment is deterministic; `public_row_index` in the publisher's row mapping identifies each exact published document.
 
 MarinDNA releases the processed dataset under OpenMDW 1.1.
 The underlying public genome assemblies and alignments retain their original source terms and attribution, recorded in the pinned source manifests.

--- a/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/rag/requests.py
+++ b/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/rag/requests.py
@@ -1,0 +1,116 @@
+"""Exact request identities and fail-closed reuse of unsplit chain outputs."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+from marin_dna_vertebrate_projection.rag.documents import Locus, stable_digest
+
+
+@dataclass(frozen=True)
+class ProjectionIdentity:
+    """Immutable inputs that determine projection and extracted sequence bytes.
+
+    Archive digests identify genome revisions. The complete contract identifies
+    mapping multiplicity, center placement, sequence case, and orientation.
+    Historical single-best, HAL, or MultiZ results are different identities.
+    """
+
+    species: str
+    assembly: str
+    chain_sha256: str
+    source_sizes_sha256: str
+    target_sizes_sha256: str
+    genome_sha256: str
+    contract: str = "ucsc-liftover-minmatch0.95-multiple-center1-window255-human-orientation-case-v1"
+
+    def __post_init__(self) -> None:
+        if not self.species or not self.assembly or not self.contract:
+            raise ValueError("projection species, assembly, and contract are required")
+        for digest in (
+            self.chain_sha256,
+            self.source_sizes_sha256,
+            self.target_sizes_sha256,
+            self.genome_sha256,
+        ):
+            if not re.fullmatch("[0-9a-f]{64}", digest):
+                raise ValueError(
+                    "projection identity requires complete SHA-256 digests"
+                )
+
+    @property
+    def fingerprint(self) -> str:
+        return stable_digest(
+            self.species,
+            self.assembly,
+            self.chain_sha256,
+            self.source_sizes_sha256,
+            self.target_sizes_sha256,
+            self.genome_sha256,
+            self.contract,
+        )
+
+
+@dataclass(frozen=True)
+class SourceRecord:
+    """A catalog or benchmark row and its exact projection request."""
+
+    namespace: str
+    source_row_id: str
+    locus: Locus
+
+    def __post_init__(self) -> None:
+        if not self.namespace or not self.source_row_id:
+            raise ValueError("source identity requires namespace and row ID")
+
+    @property
+    def row_id(self) -> str:
+        return stable_digest(self.namespace, self.source_row_id)
+
+
+@dataclass(frozen=True)
+class RequestPlan:
+    requests: tuple[Locus, ...]
+    source_rows: tuple[SourceRecord, ...]
+    missing: dict[str, tuple[Locus, ...]]
+    reused: dict[str, tuple[Locus, ...]]
+
+
+def plan_requests(
+    source_rows: Iterable[SourceRecord],
+    identities: Mapping[str, ProjectionIdentity],
+    *,
+    chrom_sizes: Mapping[str, int],
+    cached: Mapping[str, Mapping[Locus, str]] | None = None,
+) -> RequestPlan:
+    """Deduplicate requests across all catalogs and benchmarks before species batches.
+
+    ``cached`` records completed accepted OR rejected queries, keyed by exact
+    coordinates and accompanied by their producing projection fingerprint.
+    Only verified matching fingerprints can suppress a chain query. Cache
+    provenance/file checksums must be validated by the file adapter first.
+    """
+    rows = tuple(source_rows)
+    if len({row.row_id for row in rows}) != len(rows):
+        raise ValueError("duplicate namespaced source row identity")
+    if not rows or not identities:
+        raise ValueError("projection plan requires source rows and target identities")
+    if any(species != identity.species for species, identity in identities.items()):
+        raise ValueError("target identity does not match species key")
+    loci = tuple(sorted({row.locus for row in rows}))
+    for locus in loci:
+        locus.validate_bounds(chrom_sizes)
+    cache = cached or {}
+    if set(cache) - set(identities):
+        raise ValueError("cache includes an unregistered target species")
+    missing, reused = {}, {}
+    for species, identity in sorted(identities.items()):
+        species_cache = cache.get(species, {})
+        reused[species] = tuple(
+            locus for locus in loci if species_cache.get(locus) == identity.fingerprint
+        )
+        reused_set = set(reused[species])
+        missing[species] = tuple(locus for locus in loci if locus not in reused_set)
+    return RequestPlan(loci, rows, missing, reused)

--- a/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/rag/tables.py
+++ b/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/rag/tables.py
@@ -1,0 +1,310 @@
+"""Bounded-batch Parquet adapters for RAG requests and auditable documents."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import re
+import sqlite3
+from collections.abc import Iterable, Iterator, Mapping
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from marin_dna_vertebrate_projection.rag.documents import (
+    HUMAN,
+    Locus,
+    assemble_document,
+    select_validation,
+    validate_sequence,
+)
+
+
+def sha256_file(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_rows(
+    path: str | Path, columns: list[str] | None = None
+) -> Iterator[dict[str, Any]]:
+    """Read at most one Parquet batch at a time; TSV inputs support fixtures."""
+    path = Path(path)
+    if path.suffix == ".parquet":
+        for batch in pq.ParquetFile(path).iter_batches(
+            batch_size=4096, columns=columns
+        ):
+            yield from batch.to_pylist()
+    else:
+        with path.open() as handle:
+            for row in csv.DictReader(handle, delimiter="\t"):
+                yield (
+                    row
+                    if columns is None
+                    else {column: row[column] for column in columns}
+                )
+
+
+def write_rows(
+    path: str | Path, rows: Iterable[dict[str, Any]], schema: pa.Schema
+) -> int:
+    """Write deterministic Parquet batches, including schema-valid empty outputs."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    count = 0
+    batch = []
+    with pq.ParquetWriter(path, schema, compression="zstd") as writer:
+        for row in rows:
+            batch.append(row)
+            if len(batch) == 4096:
+                writer.write_table(pa.Table.from_pylist(batch, schema=schema))
+                count += len(batch)
+                batch = []
+        if batch:
+            writer.write_table(pa.Table.from_pylist(batch, schema=schema))
+            count += len(batch)
+    return count
+
+
+def coordinate_int(value: Any) -> int:
+    if type(value) is int:
+        return value
+    if isinstance(value, str) and re.fullmatch(r"[0-9]+", value):
+        return int(value)
+    raise ValueError("genomic coordinates require exact integers")
+
+
+def read_catalog(path: str | Path, spec: Mapping[str, Any]) -> dict[Locus, str]:
+    """Select exact source memberships with an explicit coordinate-name adapter.
+
+    Specs map ``id``, ``chrom``, ``start``, ``end``, and ``region`` to source
+    columns and supply ``region_value``. ``chrom_names`` explicitly declares
+    UCSC names or the source's bare/Ensembl names; numeric positions are already
+    0-based half-open in both accepted anchor sources.
+    """
+    if sha256_file(path) != spec["sha256"]:
+        raise ValueError("source anchor SHA-256 mismatch")
+    fields = spec["columns"]
+    naming = spec["chrom_names"]
+    if naming not in {"ucsc", "ensembl"}:
+        raise ValueError("anchor chromosome-name convention must be explicit")
+    result: dict[Locus, str] = {}
+    ids: set[str] = set()
+    for row in read_rows(path, list(fields.values())):
+        if row[fields["region"]] != spec["region_value"]:
+            continue
+        chrom = str(row[fields["chrom"]])
+        if naming == "ensembl":
+            if chrom.startswith("chr"):
+                raise ValueError("bare chromosome adapter received a UCSC name")
+            chrom = "chr" + chrom
+        locus = Locus(
+            chrom,
+            coordinate_int(row[fields["start"]]),
+            coordinate_int(row[fields["end"]]),
+        )
+        source_id = str(row[fields["id"]])
+        if locus in result or source_id in ids or not source_id:
+            raise ValueError("duplicate or empty source anchor identity")
+        result[locus] = source_id
+        ids.add(source_id)
+    if len(result) != spec["expected_rows"]:
+        raise ValueError(
+            f"source catalog count mismatch: {len(result)} != {spec['expected_rows']}"
+        )
+    return result
+
+
+class WindowStore:
+    """Disk-backed sequence/provenance lookup; no all-species sequence group-by.
+
+    One accepted sequence or explicit rejection must exist for every requested
+    locus/species pair. Missing files and incomplete producers are errors, not
+    biological missingness. The primary key detects overlapping cache inputs.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self.connection = sqlite3.connect(path)
+        self.connection.execute("PRAGMA cache_size=-32768")
+        self.connection.execute("PRAGMA temp_store=FILE")
+        self.connection.execute(
+            "CREATE TABLE windows(query_name TEXT, species TEXT, sequence TEXT, provenance TEXT NOT NULL, "
+            "PRIMARY KEY(query_name,species)) WITHOUT ROWID"
+        )
+
+    def close(self) -> None:
+        self.connection.close()
+
+    def ingest(
+        self,
+        path: str | Path,
+        *,
+        species: str,
+        accepted: bool,
+        expected: set[Locus],
+    ) -> int:
+        count = 0
+        with self.connection:
+            for row in read_rows(path):
+                locus = Locus(
+                    row["source_chrom"], row["source_start"], row["source_end"]
+                )
+                if locus not in expected:
+                    raise ValueError(
+                        "sequence producer contains an unrequested source locus"
+                    )
+                sequence = row.get("sequence") if accepted else None
+                if accepted:
+                    validate_sequence(sequence)
+                    if row.get("alignment_name") != species:
+                        raise ValueError(
+                            "sequence species differs from its registered input"
+                        )
+                    if row["t_end"] - row["t_start"] != 255 or row["t_strand"] not in {
+                        "+",
+                        "-",
+                    }:
+                        raise ValueError("invalid projected sequence geometry")
+                    if not 0 <= row["t_start"] < row["t_end"] <= row["t_src_size"]:
+                        raise ValueError("projected sequence exceeds target bounds")
+                    if species != HUMAN and (
+                        row["pre_resize_t_end"] - row["pre_resize_t_start"] != 1
+                        or row["pre_resize_t_start"] != row["t_start"] + 127
+                    ):
+                        raise ValueError("mapped center is not at sequence index 127")
+                elif not row.get("rejection_reason"):
+                    raise ValueError(
+                        "unavailable species requires an explicit rejection reason"
+                    )
+                metadata = {
+                    key: value for key, value in row.items() if key != "sequence"
+                }
+                try:
+                    self.connection.execute(
+                        "INSERT INTO windows VALUES (?,?,?,?)",
+                        (
+                            locus.query_name,
+                            species,
+                            sequence,
+                            json.dumps(metadata, sort_keys=True),
+                        ),
+                    )
+                except sqlite3.IntegrityError as error:
+                    raise ValueError(
+                        "duplicate locus/species outcome in sequence inputs"
+                    ) from error
+                count += 1
+        return count
+
+    def get(
+        self, locus: Locus, species: set[str]
+    ) -> tuple[dict[str, str], dict[str, Any]]:
+        rows = self.connection.execute(
+            "SELECT species,sequence,provenance FROM windows WHERE query_name=? ORDER BY species",
+            (locus.query_name,),
+        ).fetchall()
+        if {row[0] for row in rows} != species:
+            raise ValueError("incomplete species outcome accounting for a source locus")
+        available = {
+            name: sequence for name, sequence, _ in rows if sequence is not None
+        }
+        if HUMAN not in available:
+            raise ValueError("human reference sequence is unavailable")
+        return available, {name: json.loads(provenance) for name, _, provenance in rows}
+
+
+TRAIN_SCHEMA = pa.schema(
+    [
+        ("sequence", pa.string()),
+        ("query_name", pa.string()),
+        ("source_row_id", pa.string()),
+        ("source_chrom", pa.string()),
+        ("source_start", pa.int64()),
+        ("source_end", pa.int64()),
+        ("orientation", pa.string()),
+        ("species_order", pa.list_(pa.string())),
+        ("unpadded_tokens", pa.int64()),
+        ("padding_tokens", pa.int64()),
+    ]
+)
+
+
+def _training_documents(
+    loci: Iterable[Locus],
+    orientations: tuple[str, ...],
+    store: WindowStore,
+    species: set[str],
+    source_ids: Mapping[Locus, str],
+    seed: int,
+) -> Iterator[dict[str, Any]]:
+    for locus in loci:
+        windows, _ = store.get(locus, species)
+        for orientation in orientations:
+            document = assemble_document(
+                windows, locus=locus, seed=seed, orientation=orientation
+            )
+            yield {
+                "sequence": document.sequence,
+                "query_name": locus.query_name,
+                "source_row_id": source_ids[locus],
+                "source_chrom": locus.chrom,
+                "source_start": locus.start,
+                "source_end": locus.end,
+                "orientation": orientation,
+                "species_order": list(document.species_order),
+                "unpadded_tokens": document.unpadded_tokens,
+                "padding_tokens": document.padding_tokens,
+            }
+
+
+def write_training_datasets(
+    catalogs: Mapping[str, Mapping[Locus, str]],
+    store: WindowStore,
+    *,
+    species: set[str],
+    directory: str | Path,
+    validation_rows: int = 400,
+    seed: int = 42,
+) -> dict[str, Any]:
+    """Write internal documents after the chr18 split; publication strips columns."""
+    directory = Path(directory)
+    plan = select_validation(catalogs, validation_rows=validation_rows, seed=seed)
+    summary: dict[str, Any] = {
+        "validation_chromosome": "chr18",
+        "validation_seed": seed,
+        "exact_cross_region_duplicate_memberships": plan.exact_cross_region_duplicates,
+        "cross_region_duplicates": "retain original region membership outside chr18",
+        "regions": {},
+    }
+    for region, source_ids in sorted(catalogs.items()):
+        region_summary = {
+            "source_anchors": len(source_ids),
+            "unused_chr18_anchors": len(plan.excluded[region]),
+        }
+        for split, loci, orientations in (
+            ("train", plan.train[region], ("forward", "rc")),
+            ("validation", plan.validation[region], ("forward",)),
+        ):
+            count = write_rows(
+                directory / region / f"{split}.parquet",
+                _training_documents(
+                    loci, orientations, store, species, source_ids, seed
+                ),
+                TRAIN_SCHEMA,
+            )
+            if count != len(loci) * len(orientations):
+                raise ValueError("document count differs from split plan")
+            region_summary[f"{split}_rows"] = count
+            region_summary[f"{split}_allocated_tokens"] = count * 10240
+        region_summary["expected_training_epochs"] = (
+            4_000_000 / region_summary["train_rows"]
+        )
+        summary["regions"][region] = region_summary
+    (directory / "split_summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+    return summary

--- a/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/rag/tables.py
+++ b/snakemake/vertebrate_projection_dataset/src/marin_dna_vertebrate_projection/rag/tables.py
@@ -302,9 +302,6 @@ def write_training_datasets(
                 raise ValueError("document count differs from split plan")
             region_summary[f"{split}_rows"] = count
             region_summary[f"{split}_allocated_tokens"] = count * 10240
-        region_summary["expected_training_epochs"] = (
-            4_000_000 / region_summary["train_rows"]
-        )
         summary["regions"][region] = region_summary
     (directory / "split_summary.json").write_text(json.dumps(summary, indent=2) + "\n")
     return summary

--- a/snakemake/vertebrate_projection_dataset/tests/test_rag_documents.py
+++ b/snakemake/vertebrate_projection_dataset/tests/test_rag_documents.py
@@ -1,0 +1,159 @@
+"""Biological and split contracts for the new RAG recipe."""
+
+import pytest
+
+from marin_dna_vertebrate_projection.rag.documents import (
+    HUMAN,
+    SEPARATOR,
+    Locus,
+    allele_documents,
+    assemble_document,
+    reverse_complement,
+    select_validation,
+)
+
+
+def test_missing_species_are_omitted_and_genuine_n_is_preserved():
+    locus = Locus("chr1", 0, 255)
+    human_only = assemble_document({HUMAN: "a" * 255}, locus=locus)
+    assert human_only.sequence == "a" * 255
+    assert human_only.unpadded_tokens == 256
+    assert human_only.padding_tokens == 9984
+    available_n = assemble_document({HUMAN: "a" * 255, "bird": "N" * 255}, locus=locus)
+    assert len(available_n.sequence.split(SEPARATOR)) == 2
+    assert "N" * 255 in available_n.sequence
+    assert available_n.unpadded_tokens == 512
+
+
+def test_geometry_at_complete_cohort_and_permutation_independent_of_input_order():
+    windows = {HUMAN: "A" * 255, **{f"species{i}": "C" * 255 for i in range(39)}}
+    locus = Locus("chrX", 1000, 1255)
+    result = assemble_document(windows, locus=locus)
+    reordered = assemble_document(dict(reversed(list(windows.items()))), locus=locus)
+    assert result == reordered
+    assert result.padding_tokens == 0
+    assert result.unpadded_tokens == 10_240
+    assert result.sequence.count(SEPARATOR) == 39
+    assert len(set(result.species_order)) == 40
+    assert HUMAN in result.species_order
+    orders = {
+        assemble_document(windows, locus=Locus("chr1", i, i + 255)).species_order
+        for i in range(8)
+    }
+    assert len(orders) == 8
+    assert any(order[-1] != HUMAN for order in orders)
+
+
+def test_rc_preserves_species_segments_and_syntax():
+    windows = {HUMAN: "AcgTN" * 51, "bird": "tGcAn" * 51}
+    locus = Locus("chr1", 200, 455)
+    forward = assemble_document(windows, locus=locus, evaluation=True)
+    rc = assemble_document(windows, locus=locus, evaluation=True, orientation="rc")
+    assert forward.species_order == rc.species_order == ("bird", HUMAN)
+    assert rc.sequence.split(SEPARATOR) == [
+        reverse_complement(s) for s in forward.sequence.split(SEPARATOR)
+    ]
+    assert reverse_complement(reverse_complement(windows[HUMAN])) == windows[HUMAN]
+
+
+def test_ref_alt_have_identical_context_order_and_padding_in_both_orientations():
+    windows = {HUMAN: "a" * 255, "bird": "C" * 255, "mammal": "g" * 255}
+    result = allele_documents(windows, locus=Locus("chr3", 10, 265), ref="A", alt="G")
+    assert len({d.species_order for d in result.values()}) == 1
+    assert len({d.padding_tokens for d in result.values()}) == 1
+    for orientation, expected in (("forward", ("A", "G")), ("rc", ("T", "C"))):
+        ref = result[f"ref_{orientation}"].sequence.split(SEPARATOR)
+        alt = result[f"alt_{orientation}"].sequence.split(SEPARATOR)
+        assert ref[:-1] == alt[:-1]
+        assert [(a, b) for a, b in zip(ref[-1], alt[-1], strict=True) if a != b] == [
+            expected
+        ]
+        assert (ref[-1][127], alt[-1][127]) == expected
+
+
+def test_ref_check_fails_before_emitting_documents():
+    with pytest.raises(ValueError, match="REF mismatch"):
+        allele_documents(
+            {HUMAN: "A" * 255}, locus=Locus("chr1", 0, 255), ref="C", alt="G"
+        )
+
+
+@pytest.mark.parametrize("ref,alt", [("", "A"), ("A", "A"), ("A", "AG"), ("N", "G")])
+def test_unsupported_variants_fail(ref, alt):
+    with pytest.raises(ValueError, match="single-base"):
+        allele_documents(
+            {HUMAN: "A" * 255}, locus=Locus("chr1", 0, 255), ref=ref, alt=alt
+        )
+
+
+def test_chr18_is_entirely_held_out_and_membership_is_preserved_elsewhere():
+    catalogs = {
+        "cds": [
+            Locus(chrom, i, i + 255)
+            for chrom in ("chr1", "chr18")
+            for i in range(0, 8000, 128)
+        ],
+        "ncrna": [
+            Locus(chrom, i, i + 255)
+            for chrom in ("chr1", "chr18")
+            for i in range(0, 8000, 200)
+        ],
+    }
+    result = select_validation(catalogs, validation_rows=4)
+    assert all(len(rows) == 4 for rows in result.validation.values())
+    assert result.exact_cross_region_duplicates > 0
+    assert all(result.excluded.values())
+    for region, region_rows in catalogs.items():
+        assert set(result.train[region]) | set(result.validation[region]) | set(
+            result.excluded[region]
+        ) == set(region_rows)
+        assert set(result.train[region]) == {
+            locus for locus in region_rows if locus.chrom != "chr18"
+        }
+        assert all(
+            locus.chrom == "chr18"
+            for locus in result.validation[region] + result.excluded[region]
+        )
+        assert not set(result.validation[region]) & set(result.excluded[region])
+    reverse_inputs = {
+        key: reversed(value) for key, value in reversed(list(catalogs.items()))
+    }
+    assert result == select_validation(reverse_inputs, validation_rows=4)
+
+
+def test_small_chr18_catalog_uses_all_available_without_sampling_other_chromosomes():
+    rows = [Locus("chr1", i, i + 255) for i in range(100)] + [Locus("chr18", 0, 255)]
+    result = select_validation({"cds": rows}, validation_rows=2)
+    assert result.validation["cds"] == (Locus("chr18", 0, 255),)
+    assert len(result.train["cds"]) == 100
+    empty = select_validation({"cds": rows[:-1]}, validation_rows=2)
+    assert empty.validation["cds"] == ()
+    assert len(empty.train["cds"]) == 100
+
+
+def test_every_chr18_window_stays_out_of_training_when_validation_uses_only_a_sample():
+    rows = [Locus("chr18", i, i + 255) for i in range(0, 2550, 255)] + [
+        Locus("chr1", 0, 255)
+    ]
+    result = select_validation({"cds": rows}, validation_rows=2)
+    assert result.train["cds"] == (Locus("chr1", 0, 255),)
+    assert len(result.excluded["cds"]) == 8
+
+
+def test_validation_duplicate_source_rows_fail():
+    locus = Locus("chr1", 0, 255)
+    with pytest.raises(ValueError, match="duplicate locus"):
+        select_validation({"cds": [locus, locus]}, validation_rows=1)
+
+
+def test_invalid_windows_and_out_of_bounds_fail():
+    with pytest.raises(ValueError, match="half-open"):
+        Locus("chr1", -1, 254)
+    with pytest.raises(ValueError, match="UCSC"):
+        Locus("1", 0, 255)
+    locus = Locus("chr1", 0, 255)
+    with pytest.raises(ValueError, match="outside pinned genome"):
+        locus.validate_bounds({"chr1": 254})
+    for windows in ({}, {"bird": "A" * 255}, {HUMAN: "A" * 254}, {HUMAN: "R" * 255}):
+        with pytest.raises(ValueError):
+            assemble_document(windows, locus=locus)

--- a/snakemake/vertebrate_projection_dataset/tests/test_rag_documents.py
+++ b/snakemake/vertebrate_projection_dataset/tests/test_rag_documents.py
@@ -1,7 +1,6 @@
 """Biological and split contracts for the new RAG recipe."""
 
 import pytest
-
 from marin_dna_vertebrate_projection.rag.documents import (
     HUMAN,
     SEPARATOR,

--- a/snakemake/vertebrate_projection_dataset/tests/test_rag_requests.py
+++ b/snakemake/vertebrate_projection_dataset/tests/test_rag_requests.py
@@ -1,0 +1,71 @@
+from dataclasses import replace
+
+import pytest
+
+from marin_dna_vertebrate_projection.rag.documents import Locus
+from marin_dna_vertebrate_projection.rag.requests import (
+    ProjectionIdentity,
+    SourceRecord,
+    plan_requests,
+)
+
+
+def identity():
+    return ProjectionIdentity("bird", "bird-v1", "a" * 64, "b" * 64, "c" * 64, "d" * 64)
+
+
+def test_exact_requests_deduplicate_across_catalogs_and_benchmarks():
+    shared = Locus("chr1", 0, 255)
+    nearby = Locus("chr1", 1, 256)
+    rows = [
+        SourceRecord("training:cds", "1", shared),
+        SourceRecord("mendelian", "1", shared),
+        SourceRecord("sge", "1", nearby),
+    ]
+    plan = plan_requests(rows, {"bird": identity()}, chrom_sizes={"chr1": 300})
+    assert len(plan.source_rows) == 3
+    assert len({row.row_id for row in rows}) == 3
+    assert plan.requests == (shared, nearby)
+    assert plan.missing["bird"] == plan.requests
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("chain_sha256", "e" * 64),
+        ("genome_sha256", "f" * 64),
+        ("assembly", "bird-v2"),
+        ("contract", "single-best-liftover"),
+        ("source_sizes_sha256", "e" * 64),
+        ("target_sizes_sha256", "f" * 64),
+    ],
+)
+def test_cache_reuse_requires_every_identity_component(field, value):
+    locus = Locus("chr1", 0, 255)
+    original = identity()
+    different = replace(original, **{field: value})
+    rows = [SourceRecord("training:cds", "1", locus)]
+    exact = plan_requests(
+        rows,
+        {"bird": original},
+        chrom_sizes={"chr1": 300},
+        cached={"bird": {locus: original.fingerprint}},
+    )
+    assert exact.reused["bird"] == (locus,)
+    assert exact.missing["bird"] == ()
+    changed = plan_requests(
+        rows,
+        {"bird": different},
+        chrom_sizes={"chr1": 300},
+        cached={"bird": {locus: original.fingerprint}},
+    )
+    assert changed.reused["bird"] == ()
+    assert changed.missing["bird"] == (locus,)
+
+
+def test_out_of_bounds_and_duplicate_source_rows_fail():
+    row = SourceRecord("sge", "1", Locus("chr1", 0, 255))
+    with pytest.raises(ValueError, match="outside pinned genome"):
+        plan_requests([row], {"bird": identity()}, chrom_sizes={"chr1": 254})
+    with pytest.raises(ValueError, match="duplicate namespaced"):
+        plan_requests([row, row], {"bird": identity()}, chrom_sizes={"chr1": 300})

--- a/snakemake/vertebrate_projection_dataset/tests/test_rag_requests.py
+++ b/snakemake/vertebrate_projection_dataset/tests/test_rag_requests.py
@@ -1,7 +1,6 @@
 from dataclasses import replace
 
 import pytest
-
 from marin_dna_vertebrate_projection.rag.documents import Locus
 from marin_dna_vertebrate_projection.rag.requests import (
     ProjectionIdentity,

--- a/snakemake/vertebrate_projection_dataset/tests/test_rag_tables.py
+++ b/snakemake/vertebrate_projection_dataset/tests/test_rag_tables.py
@@ -1,0 +1,153 @@
+import json
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from marin_dna_vertebrate_projection.rag.documents import Locus
+from marin_dna_vertebrate_projection.rag.tables import (
+    WindowStore,
+    read_catalog,
+    sha256_file,
+    write_training_datasets,
+)
+
+
+def sequence_row(locus, species="hg38", sequence="A" * 255):
+    return {
+        "query_name": locus.query_name,
+        "source_chrom": locus.chrom,
+        "source_start": locus.start,
+        "source_end": locus.end,
+        "alignment_name": species,
+        "t_start": 1000,
+        "t_end": 1255,
+        "t_strand": "+",
+        "t_src_size": 2000,
+        "pre_resize_t_start": 1127,
+        "pre_resize_t_end": 1128,
+        "sequence": sequence,
+    }
+
+
+def test_unsplit_sequence_assembly_preserves_human_only_validation_and_rc_training(
+    tmp_path,
+):
+    train = Locus("chr1", 0, 255)
+    validation = Locus("chr18", 0, 255)
+    unused_chr18 = Locus("chr18", 500, 755)
+    loci = {train, validation, unused_chr18}
+    human = tmp_path / "human.parquet"
+    pq.write_table(
+        pa.Table.from_pylist([sequence_row(locus) for locus in sorted(loci)]), human
+    )
+    bird = tmp_path / "bird.parquet"
+    pq.write_table(pa.Table.from_pylist([sequence_row(train, "bird", "c" * 255)]), bird)
+    rejected = tmp_path / "rejected.parquet"
+    pq.write_table(
+        pa.Table.from_pylist(
+            [
+                {
+                    "source_chrom": locus.chrom,
+                    "source_start": locus.start,
+                    "source_end": locus.end,
+                    "rejection_reason": "no_mapping",
+                }
+                for locus in sorted(loci - {train})
+            ]
+        ),
+        rejected,
+    )
+    store = WindowStore(tmp_path / "windows.sqlite")
+    try:
+        assert store.ingest(human, species="hg38", accepted=True, expected=loci) == 3
+        assert store.ingest(bird, species="bird", accepted=True, expected=loci) == 1
+        assert (
+            store.ingest(rejected, species="bird", accepted=False, expected=loci) == 2
+        )
+        windows, provenance = store.get(validation, {"hg38", "bird"})
+        assert set(windows) == {"hg38"}
+        assert provenance["bird"]["rejection_reason"] == "no_mapping"
+        summary = write_training_datasets(
+            {
+                "cds": {
+                    locus: f"original-{index}"
+                    for index, locus in enumerate(sorted(loci))
+                }
+            },
+            store,
+            species={"hg38", "bird"},
+            directory=tmp_path / "datasets",
+            validation_rows=1,
+        )
+        training = pq.read_table(tmp_path / "datasets/cds/train.parquet").to_pylist()
+        held_out = pq.read_table(
+            tmp_path / "datasets/cds/validation.parquet"
+        ).to_pylist()
+        assert len(training) == 2
+        assert {row["orientation"] for row in training} == {"forward", "rc"}
+        assert {row["source_chrom"] for row in training} == {"chr1"}
+        assert len(held_out) == 1
+        assert held_out[0]["sequence"] == "A" * 255
+        assert held_out[0]["species_order"] == ["hg38"]
+        assert summary["regions"]["cds"]["unused_chr18_anchors"] == 1
+        assert (
+            json.loads((tmp_path / "datasets/split_summary.json").read_text())
+            == summary
+        )
+    finally:
+        store.close()
+
+
+def test_incomplete_outcomes_and_duplicate_inputs_fail(tmp_path):
+    locus = Locus("chr1", 0, 255)
+    source = tmp_path / "human.parquet"
+    pq.write_table(pa.Table.from_pylist([sequence_row(locus)]), source)
+    store = WindowStore(tmp_path / "windows.sqlite")
+    try:
+        store.ingest(source, species="hg38", accepted=True, expected={locus})
+        with pytest.raises(ValueError, match="incomplete species"):
+            store.get(locus, {"hg38", "bird"})
+        with pytest.raises(ValueError, match="duplicate locus/species"):
+            store.ingest(source, species="hg38", accepted=True, expected={locus})
+    finally:
+        store.close()
+
+
+def test_invalid_projected_center_fails_before_document_construction(tmp_path):
+    locus = Locus("chr1", 0, 255)
+    row = sequence_row(locus, "bird")
+    row["pre_resize_t_start"] += 1
+    row["pre_resize_t_end"] += 1
+    source = tmp_path / "bird.parquet"
+    pq.write_table(pa.Table.from_pylist([row]), source)
+    store = WindowStore(tmp_path / "windows.sqlite")
+    try:
+        with pytest.raises(ValueError, match="center"):
+            store.ingest(source, species="bird", accepted=True, expected={locus})
+    finally:
+        store.close()
+
+
+def test_catalog_adapter_keeps_exact_membership_and_checks_pinned_bytes(tmp_path):
+    path = tmp_path / "source.tsv"
+    path.write_text(
+        "id\tchrom\tstart\tend\tarm\na\t18\t0\t255\tncrna\nb\t1\t500\t755\tenhancer\n"
+    )
+    spec = {
+        "columns": {
+            "id": "id",
+            "chrom": "chrom",
+            "start": "start",
+            "end": "end",
+            "region": "arm",
+        },
+        "chrom_names": "ensembl",
+        "sha256": sha256_file(path),
+        "region_value": "ncrna",
+        "expected_rows": 1,
+    }
+    assert read_catalog(path, spec) == {Locus("chr18", 0, 255): "a"}
+    path.write_text(path.read_text().replace("255", "256"))
+    with pytest.raises(ValueError, match="SHA-256"):
+        read_catalog(path, spec)

--- a/snakemake/vertebrate_projection_dataset/tests/test_rag_tables.py
+++ b/snakemake/vertebrate_projection_dataset/tests/test_rag_tables.py
@@ -3,7 +3,6 @@ import json
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
-
 from marin_dna_vertebrate_projection.rag.documents import Locus
 from marin_dna_vertebrate_projection.rag.tables import (
     WindowStore,

--- a/snakemake/vertebrate_projection_dataset/tests/test_rag_workflow.py
+++ b/snakemake/vertebrate_projection_dataset/tests/test_rag_workflow.py
@@ -1,0 +1,175 @@
+"""Exercise the complete additive DAG with tiny, synthetic Kent inputs."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+import yaml
+
+from marin_dna_vertebrate_projection.rag.documents import REGIONS
+from marin_dna_vertebrate_projection.rag.tables import read_rows, sha256_file
+
+PROJECT = Path(__file__).parents[1]
+
+
+def test_rag_combined_workflow(tmp_path: Path) -> None:
+    if any(
+        not shutil.which(name)
+        for name in ("liftOver", "faToTwoBit", "twoBitInfo", "twoBitToFa")
+    ):
+        pytest.skip("Kent tools required for the RAG integration test")
+    workdir = tmp_path / "pipeline"
+    shutil.copytree(
+        PROJECT,
+        workdir,
+        ignore=shutil.ignore_patterns(
+            ".venv",
+            ".snakemake",
+            "results",
+            "__pycache__",
+            ".pytest_cache",
+            "*.egg-info",
+        ),
+    )
+    anchors = workdir / "rag-fixture.tsv"
+    anchors.write_text(
+        "id\tchrom\tstart\tend\tregion\nplus\tchr1\t100\t355\tall\nminus\tchr1\t300\t555\tall\nunmapped\tchr1\t600\t855\tall\n"
+    )
+    spec = {
+        "uri": str(anchors),
+        "sha256": sha256_file(anchors),
+        "columns": {
+            "id": "id",
+            "chrom": "chrom",
+            "start": "start",
+            "end": "end",
+            "region": "region",
+        },
+        "region_value": "all",
+        "chrom_names": "ucsc",
+        "expected_rows": 3,
+    }
+    benchmarks = {}
+    for name in ("mendelian_traits", "complex_traits", "sge"):
+        source = tmp_path / name / ("b" * 40) / "train.parquet"
+        source.parent.mkdir(parents=True)
+        pq.write_table(
+            pa.Table.from_pylist(
+                [
+                    {"chrom": "1", "pos": pos, "ref": "T", "alt": "A", "match_group": 1}
+                    for pos in (228, 428, 728)
+                ]
+            ),
+            source,
+        )
+        benchmarks[name] = {
+            "name": name,
+            "revision": "b" * 40,
+            "expected_rows": 3,
+            "split": "train",
+            "url": source.as_uri(),
+            "sha256": sha256_file(source),
+            "chrom_names": "ensembl",
+        }
+    overlay = workdir / "rag-overlay.yaml"
+    overlay.write_text(
+        yaml.safe_dump(
+            {
+                "rag": {
+                    "catalogs": {name: spec for name in REGIONS},
+                    "benchmarks": benchmarks,
+                    "validation_rows": 400,
+                    "seed": 42,
+                }
+            }
+        )
+    )
+    env = {
+        **os.environ,
+        "PIPELINE_COMMIT_SHA": "a" * 40,
+        "UV_PROJECT_ENVIRONMENT": str(Path(sys.executable).parent.parent),
+        "UV_NO_SYNC": "1",
+    }
+    common = [
+        str(Path(sys.executable).with_name("snakemake")),
+        "rag_all_documents",
+        "--workflow-profile",
+        "none",
+        "--default-storage-provider",
+        "none",
+        "--configfile",
+        str(overlay),
+        "--cores",
+        "1",
+    ]
+
+    def run(*arguments: str, target: str = "rag_all_documents") -> str:
+        command = common.copy()
+        command[1] = target
+        result = subprocess.run(
+            command + list(arguments),
+            cwd=workdir,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=180,
+            check=False,
+        )
+        output = result.stdout + result.stderr
+        assert result.returncode == 0, output
+        return output
+
+    plan = run("--dry-run")
+    assert "rag_union_catalog" in plan and "rag_chain_liftover" in plan
+    assert "localrule chain_liftover:" not in plan and "dataset_splits" not in plan
+    run()
+    audit_path = next((workdir / "results").rglob("rag/anchors/request_audit.json"))
+    root = audit_path.parent.parent
+    audit = json.loads(audit_path.read_text())
+    assert audit["unique_requests"] == 3
+    assert audit["source_memberships"] == 24
+    for region in REGIONS:
+        training = list(read_rows(root / f"datasets/{region}/train.parquet"))
+        assert len(training) == 6
+        assert {row["orientation"] for row in training} == {"forward", "rc"}
+        assert all(row["source_chrom"] != "chr18" for row in training)
+        assert not list(read_rows(root / f"datasets/{region}/validation.parquet"))
+    harness = list(read_rows(root / "evaluation/combined_development.parquet"))
+    assert len(harness) == 9
+    assert all(row["species_order"][-1] == "hg38" for row in harness)
+    assert len({row["source_row_id"] for row in harness}) == 9
+    assert len({row["group_id"] for row in harness}) == 3
+    publication_plan = run("--dry-run", target="rag_all_publication_files")
+    assert "rag_prepare_release" in publication_plan
+    assert "rag_chain_liftover" not in publication_plan
+    run(target="rag_all_publication_files")
+    for region in REGIONS:
+        release = json.loads(
+            (root / f"publication_provenance/{region}/release.json").read_text()
+        )
+        assert release["splits"]["train"]["rows"] == 6
+        mapping = list(
+            read_rows(root / f"publication_provenance/{region}/rows.parquet")
+        )
+        assert len(mapping) == 6
+        for row in mapping:
+            shard = list(
+                read_rows(root / f"publication/{region}" / row["public_shard"])
+            )
+            published = shard[row["public_row_index"]]
+            assert set(published) == {"sequence"}
+            original = next(
+                item
+                for item in read_rows(root / f"datasets/{region}/train.parquet")
+                if item["source_row_id"] == row["source_row_id"]
+                and item["orientation"] == row["orientation"]
+            )
+            assert published["sequence"] == original["sequence"]

--- a/snakemake/vertebrate_projection_dataset/tests/test_rag_workflow.py
+++ b/snakemake/vertebrate_projection_dataset/tests/test_rag_workflow.py
@@ -83,12 +83,16 @@ def test_rag_combined_workflow(tmp_path: Path) -> None:
     overlay.write_text(
         yaml.safe_dump(
             {
+                "anchors": "tests/fixtures/chains/anchors.tsv",
+                "anchors_sha256": sha256_file(
+                    workdir / "tests/fixtures/chains/anchors.tsv"
+                ),
                 "rag": {
                     "catalogs": {name: spec for name in REGIONS},
                     "benchmarks": benchmarks,
                     "validation_rows": 400,
                     "seed": 42,
-                }
+                },
             }
         )
     )
@@ -147,22 +151,45 @@ def test_rag_combined_workflow(tmp_path: Path) -> None:
     assert all(row["species_order"][-1] == "hg38" for row in harness)
     assert len({row["source_row_id"] for row in harness}) == 9
     assert len({row["group_id"] for row in harness}) == 3
+    # Publish an existing producer under a different code/config namespace.
+    publication_config = yaml.safe_load(overlay.read_text())
+    publication_config["rag_publication_source"] = {
+        **json.loads((root.parent / "metadata/producer.json").read_text()),
+        "root": str(root),
+    }
+    overlay.write_text(yaml.safe_dump(publication_config))
+    env["PIPELINE_COMMIT_SHA"] = "c" * 40
     publication_plan = run("--dry-run", target="rag_all_publication_files")
     assert "rag_prepare_release" in publication_plan
     assert "rag_chain_liftover" not in publication_plan
     run(target="rag_all_publication_files")
+    publication_root = next(
+        (workdir / "results").rglob("rag/publication_provenance")
+    ).parent
     for region in REGIONS:
         release = json.loads(
-            (root / f"publication_provenance/{region}/release.json").read_text()
+            (
+                publication_root / f"publication_provenance/{region}/release.json"
+            ).read_text()
         )
         assert release["splits"]["train"]["rows"] == 6
+        assert release["producer"]["pipeline_commit"] == "a" * 40
+        assert release["producer"]["root"] == str(root)
+        assert release["publisher"]["pipeline_commit"] == "c" * 40
+        assert release["publisher"]["root"] == str(publication_root)
+        card = (publication_root / f"publication/{region}/README.md").read_text()
+        assert str(root) in card and str(publication_root) in card
         mapping = list(
-            read_rows(root / f"publication_provenance/{region}/rows.parquet")
+            read_rows(
+                publication_root / f"publication_provenance/{region}/rows.parquet"
+            )
         )
         assert len(mapping) == 6
         for row in mapping:
             shard = list(
-                read_rows(root / f"publication/{region}" / row["public_shard"])
+                read_rows(
+                    publication_root / f"publication/{region}" / row["public_shard"]
+                )
             )
             published = shard[row["public_row_index"]]
             assert set(published) == {"sequence"}

--- a/snakemake/vertebrate_projection_dataset/tests/test_rag_workflow.py
+++ b/snakemake/vertebrate_projection_dataset/tests/test_rag_workflow.py
@@ -13,7 +13,6 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 import yaml
-
 from marin_dna_vertebrate_projection.rag.documents import REGIONS
 from marin_dna_vertebrate_projection.rag.tables import read_rows, sha256_file
 

--- a/snakemake/vertebrate_projection_dataset/workflow/Snakefile
+++ b/snakemake/vertebrate_projection_dataset/workflow/Snakefile
@@ -5,6 +5,8 @@ include: "rules/common.smk"
 include: "rules/anchors.smk"
 include: "rules/projection.smk"
 include: "rules/dataset.smk"
+include: "rules/rag.smk"
+include: "rules/rag_publication.smk"
 
 
 rule all:

--- a/snakemake/vertebrate_projection_dataset/workflow/rules/rag.smk
+++ b/snakemake/vertebrate_projection_dataset/workflow/rules/rag.smk
@@ -53,7 +53,7 @@ if config.get("rag"):
                 output.audit,
             )
 
-    use rule chain_requests as rag_chain_requests with:
+    rule rag_chain_requests:
         input:
             anchors=RAG_UNION,
             sizes=asset_input(SOURCE["source_sizes"]),
@@ -62,6 +62,21 @@ if config.get("rag"):
         output:
             requests=RAG_REQUESTS,
             bed=f"{RAG_RESULTS}/anchors/centers.bed",
+        resources:
+            mem_mb=int(config["table_mem_mb"]),
+        run:
+            # The union rule validates the separately pinned RAG source catalogs.
+            if file_sha256(input.sizes) != SOURCE["source_sizes_sha256"]:
+                raise ValueError("source chromosome dictionary SHA-256 mismatch")
+            if (
+                file_sha256(input.human_sizes)
+                != GENOMES["hg38"]["chrom_sizes_sha256"]
+            ):
+                raise ValueError("human genome dictionary SHA-256 mismatch")
+            validate_human_dictionary(input.sizes, input.human_sizes)
+            prepare_chain_requests(
+                input.anchors, input.sizes, output.requests, output.bed
+            )
 
     use rule chain_liftover as rag_chain_liftover with:
         input:

--- a/snakemake/vertebrate_projection_dataset/workflow/rules/rag.smk
+++ b/snakemake/vertebrate_projection_dataset/workflow/rules/rag.smk
@@ -1,0 +1,167 @@
+"""Additional RAG targets; legacy projection and publication rules are unchanged."""
+
+from marin_dna_vertebrate_projection.rag.pipeline import (
+    assemble_outputs,
+    compile_requests,
+    download_benchmark,
+)
+
+if config.get("rag"):
+    RAG = config["rag"]
+    RAG_RESULTS = f"{RESULTS}/rag"
+    RAG_REGIONS = sorted(RAG["catalogs"])
+    RAG_BENCHMARKS = sorted(RAG["benchmarks"])
+    RAG_UNION = f"{RAG_RESULTS}/anchors/catalog.parquet"
+    RAG_REQUESTS = f"{RAG_RESULTS}/anchors/requests.parquet"
+    RAG_CATALOGS = {
+        name: asset_input(spec["uri"]) for name, spec in RAG["catalogs"].items()
+    }
+    RAG_BENCHMARK_FILES = {
+        name: f"{RAG_RESULTS}/sources/{name}.parquet" for name in RAG_BENCHMARKS
+    }
+
+    rule rag_benchmark_source:
+        output:
+            f"{RAG_RESULTS}/sources/{{benchmark}}.parquet",
+        wildcard_constraints:
+            benchmark="|".join(RAG_BENCHMARKS),
+        run:
+            download_benchmark(RAG["benchmarks"][wildcards.benchmark], output[0])
+
+    rule rag_union_catalog:
+        input:
+            catalogs=RAG_CATALOGS.values(),
+            benchmarks=RAG_BENCHMARK_FILES.values(),
+            sizes=asset_input(GENOMES["hg38"]["chrom_sizes"]),
+            provenance=ASSET_PROVENANCE,
+        output:
+            catalog=RAG_UNION,
+            memberships=f"{RAG_RESULTS}/anchors/source_memberships.parquet",
+            audit=f"{RAG_RESULTS}/anchors/request_audit.json",
+        resources:
+            mem_mb=int(config["table_mem_mb"]),
+        run:
+            compile_requests(
+                dict(zip(RAG_CATALOGS, input.catalogs, strict=True)),
+                dict(zip(RAG_BENCHMARK_FILES, input.benchmarks, strict=True)),
+                RAG,
+                ASSETS,
+                GENOMES,
+                input.sizes,
+                output.catalog,
+                output.memberships,
+                output.audit,
+            )
+
+    use rule chain_requests as rag_chain_requests with:
+        input:
+            anchors=RAG_UNION,
+            sizes=asset_input(SOURCE["source_sizes"]),
+            human_sizes=asset_input(GENOMES["hg38"]["chrom_sizes"]),
+            provenance=ASSET_PROVENANCE,
+        output:
+            requests=RAG_REQUESTS,
+            bed=f"{RAG_RESULTS}/anchors/centers.bed",
+
+    use rule chain_liftover as rag_chain_liftover with:
+        input:
+            bed=f"{RAG_RESULTS}/anchors/centers.bed",
+            chain=lambda w: asset_input(ASSETS[w.species]["chain"]),
+            validated=f"{RESULTS}/chains/{{species}}/validated.json",
+        output:
+            mapped=f"{RAG_RESULTS}/chains/{{species}}/mapped.bed",
+            unmapped=f"{RAG_RESULTS}/chains/{{species}}/unmapped.bed",
+        log:
+            f"{RAG_RESULTS}/chains/{{species}}/liftover.log",
+        benchmark:
+            f"{RAG_RESULTS}/chains/{{species}}/liftover.benchmark.tsv"
+
+    use rule chain_contract as rag_chain_contract with:
+        input:
+            requests=RAG_REQUESTS,
+            mapped=f"{RAG_RESULTS}/chains/{{species}}/mapped.bed",
+            unmapped=f"{RAG_RESULTS}/chains/{{species}}/unmapped.bed",
+            sizes=lambda w: asset_input(ASSETS[w.species]["target_sizes"]),
+            species=SPECIES_SELECTED_INPUT,
+            validated=f"{RESULTS}/chains/{{species}}/validated.json",
+        output:
+            accepted=f"{RAG_RESULTS}/chains/{{species}}/accepted.parquet",
+            rejected=f"{RAG_RESULTS}/chains/{{species}}/rejected.parquet",
+            audit=f"{RAG_RESULTS}/chains/{{species}}/audit.json",
+
+    use rule human_reference_sequences as rag_human_sequences with:
+        input:
+            anchors=RAG_UNION,
+            requests=RAG_REQUESTS,
+            twobit=local(f"{RESULTS}/reference/hg38.2bit"),
+            sizes=f"{RESULTS}/reference/hg38.chrom.sizes",
+            compatibility=f"{RESULTS}/reference/hg38.compatibility.json",
+        output:
+            f"{RAG_RESULTS}/sequences/hg38.parquet",
+
+    use rule projected_genome_compatibility as rag_projected_compatibility with:
+        input:
+            accepted=f"{RAG_RESULTS}/chains/{{species}}/accepted.parquet",
+            sizes=f"{RESULTS}/reference/{{species}}.chrom.sizes",
+            validated=f"{RESULTS}/reference/{{species}}.compatibility.json",
+        output:
+            f"{RAG_RESULTS}/chains/{{species}}/sequence_compatibility.json",
+
+    use rule chain_sequences as rag_chain_sequences with:
+        input:
+            accepted=f"{RAG_RESULTS}/chains/{{species}}/accepted.parquet",
+            twobit=local(f"{RESULTS}/reference/{{species}}.2bit"),
+            compatibility=f"{RAG_RESULTS}/chains/{{species}}/sequence_compatibility.json",
+        output:
+            sequences=f"{RAG_RESULTS}/sequences/{{species}}.parquet",
+            rejected=f"{RAG_RESULTS}/chains/{{species}}/sequence_rejected.parquet",
+
+    rule rag_documents:
+        input:
+            catalogs=RAG_CATALOGS.values(),
+            benchmarks=RAG_BENCHMARK_FILES.values(),
+            union=RAG_UNION,
+            human=f"{RAG_RESULTS}/sequences/hg38.parquet",
+            sequences=expand(
+                f"{RAG_RESULTS}/sequences/{{species}}.parquet", species=ACTIVE_SPECIES
+            ),
+            rejections=expand(
+                f"{RAG_RESULTS}/chains/{{species}}/rejected.parquet",
+                species=ACTIVE_SPECIES,
+            ),
+            sequence_rejections=expand(
+                f"{RAG_RESULTS}/chains/{{species}}/sequence_rejected.parquet",
+                species=ACTIVE_SPECIES,
+            ),
+        output:
+            train=expand(
+                f"{RAG_RESULTS}/datasets/{{region}}/train.parquet", region=RAG_REGIONS
+            ),
+            validation=expand(
+                f"{RAG_RESULTS}/datasets/{{region}}/validation.parquet",
+                region=RAG_REGIONS,
+            ),
+            summary=f"{RAG_RESULTS}/datasets/split_summary.json",
+            harness=f"{RAG_RESULTS}/evaluation/combined_development.parquet",
+            harness_counts=f"{RAG_RESULTS}/evaluation/combined_development.counts.json",
+        resources:
+            mem_mb=16000,
+        run:
+            assemble_outputs(
+                dict(zip(RAG_CATALOGS, input.catalogs, strict=True)),
+                dict(zip(RAG_BENCHMARK_FILES, input.benchmarks, strict=True)),
+                RAG,
+                input.union,
+                input.human,
+                dict(zip(ACTIVE_SPECIES, input.sequences, strict=True)),
+                dict(zip(ACTIVE_SPECIES, input.rejections, strict=True)),
+                dict(zip(ACTIVE_SPECIES, input.sequence_rejections, strict=True)),
+                str(Path(output.summary).parent),
+                output.harness,
+            )
+
+    rule rag_all_documents:
+        input:
+            PRODUCER_MANIFEST,
+            f"{RAG_RESULTS}/datasets/split_summary.json",
+            f"{RAG_RESULTS}/evaluation/combined_development.parquet",

--- a/snakemake/vertebrate_projection_dataset/workflow/rules/rag_publication.smk
+++ b/snakemake/vertebrate_projection_dataset/workflow/rules/rag_publication.smk
@@ -24,6 +24,14 @@ if config.get("rag"):
     def rag_publication_input(path):
         return storage.s3(path) if path.startswith("s3://") else path
 
+    def rag_artifact_uri(path):
+        if "://" in path:
+            return path
+        settings = workflow.storage_settings
+        if settings.default_storage_provider:
+            return f"{settings.default_storage_prefix.rstrip('/')}/{path}"
+        return str(Path(path).resolve())
+
     rule rag_prepare_release:
         input:
             train=rag_publication_input(
@@ -65,7 +73,17 @@ if config.get("rag"):
                 output.manifest,
                 region=wildcards.region,
                 repo_id=f"{config['hf_owner']}/{config.get('rag_repo_prefix', 'rag-five-regions-v1')}-{wildcards.region}",
-                producer=RAG_PUBLICATION_SOURCE,
+                producer={
+                    **RAG_PUBLICATION_SOURCE,
+                    "root": rag_artifact_uri(RAG_SOURCE_ROOT),
+                },
+                publisher={
+                    "root": rag_artifact_uri(RAG_RESULTS),
+                    "pipeline_commit": PIPELINE_COMMIT,
+                    "config_sha256": PIPELINE_CONFIG_SHA256,
+                    "pipeline_version": PIPELINE_VERSION,
+                    "tier": TIER,
+                },
                 train_shards=RAG_PUBLISH_SHARDS,
             )
 

--- a/snakemake/vertebrate_projection_dataset/workflow/rules/rag_publication.smk
+++ b/snakemake/vertebrate_projection_dataset/workflow/rules/rag_publication.smk
@@ -1,0 +1,102 @@
+"""Publish RAG documents while retaining row provenance in the owning workflow."""
+
+from marin_dna_vertebrate_projection.provenance import validate_producer_manifest
+from marin_dna_vertebrate_projection.rag.publication import (
+    prepare_release,
+    publish_release,
+)
+
+if config.get("rag"):
+    RAG_PUBLICATION_SOURCE = config.get(
+        "rag_publication_source",
+        {
+            "root": RAG_RESULTS,
+            "pipeline_commit": PIPELINE_COMMIT,
+            "config_sha256": PIPELINE_CONFIG_SHA256,
+            "pipeline_version": PIPELINE_VERSION,
+            "tier": TIER,
+        },
+    )
+    RAG_SOURCE_ROOT = RAG_PUBLICATION_SOURCE["root"].rstrip("/")
+    RAG_PUBLISH_SHARDS = int(RAG.get("publication_shards", 16))
+    assert RAG_PUBLISH_SHARDS > 0
+
+    def rag_publication_input(path):
+        return storage.s3(path) if path.startswith("s3://") else path
+
+    rule rag_prepare_release:
+        input:
+            train=rag_publication_input(
+                f"{RAG_SOURCE_ROOT}/datasets/{{region}}/train.parquet"
+            ),
+            validation=rag_publication_input(
+                f"{RAG_SOURCE_ROOT}/datasets/{{region}}/validation.parquet"
+            ),
+            producer=rag_publication_input(
+                f"{RAG_SOURCE_ROOT.rsplit('/',1)[0]}/metadata/producer.json"
+            ),
+        output:
+            train=expand(
+                f"{RAG_RESULTS}/publication/{{region}}/train/{{shard:05d}}-of-{RAG_PUBLISH_SHARDS:05d}.parquet",
+                region="{region}",
+                shard=range(RAG_PUBLISH_SHARDS),
+            ),
+            validation=f"{RAG_RESULTS}/publication/{{region}}/validation/00000-of-00001.parquet",
+            card=f"{RAG_RESULTS}/publication/{{region}}/README.md",
+            mapping=f"{RAG_RESULTS}/publication_provenance/{{region}}/rows.parquet",
+            manifest=f"{RAG_RESULTS}/publication_provenance/{{region}}/release.json",
+        wildcard_constraints:
+            region="|".join(RAG_REGIONS),
+        resources:
+            mem_mb=4000,
+        run:
+            validate_producer_manifest(
+                input.producer,
+                **{
+                    key: value
+                    for key, value in RAG_PUBLICATION_SOURCE.items()
+                    if key != "root"
+                },
+            )
+            prepare_release(
+                {"train": input.train, "validation": input.validation},
+                str(Path(output.card).parent),
+                output.mapping,
+                output.manifest,
+                region=wildcards.region,
+                repo_id=f"{config['hf_owner']}/{config.get('rag_repo_prefix', 'rag-five-regions-v1')}-{wildcards.region}",
+                producer=RAG_PUBLICATION_SOURCE,
+                train_shards=RAG_PUBLISH_SHARDS,
+            )
+
+    rule rag_publish_release:
+        input:
+            train=expand(
+                f"{RAG_RESULTS}/publication/{{region}}/train/{{shard:05d}}-of-{RAG_PUBLISH_SHARDS:05d}.parquet",
+                region="{region}",
+                shard=range(RAG_PUBLISH_SHARDS),
+            ),
+            validation=f"{RAG_RESULTS}/publication/{{region}}/validation/00000-of-00001.parquet",
+            card=f"{RAG_RESULTS}/publication/{{region}}/README.md",
+            manifest=f"{RAG_RESULTS}/publication_provenance/{{region}}/release.json",
+        output:
+            f"{RAG_RESULTS}/publication_provenance/{{region}}/hub_receipt.json",
+        resources:
+            hf_uploads=1,
+            mem_mb=4000,
+        run:
+            publish_release(str(Path(input.card).parent), input.manifest, output[0])
+
+    rule rag_all_publication_files:
+        input:
+            expand(
+                f"{RAG_RESULTS}/publication_provenance/{{region}}/release.json",
+                region=RAG_REGIONS,
+            ),
+
+    rule rag_publish:
+        input:
+            expand(
+                f"{RAG_RESULTS}/publication_provenance/{{region}}/hub_receipt.json",
+                region=RAG_REGIONS,
+            ),


### PR DESCRIPTION
Closed without merging after the approved [post-experiment triage](https://github.com/Open-Athena/marin-dna/blob/7efe323cdad12cd6098c93667169858ebdcdffe3/.agents/artifacts/issue-550/remaining-work-triage.md).
The document producer is specific to the current RAG recipe; it will remain on the permanent experiment branch until the interface has stabilized.
The [reviewed source snapshot](https://github.com/Open-Athena/marin-dna/tree/0a5e31300fd94f179e6478e376604c7b18b08194) is preserved, and the integrated execution code and results remain on the permanent branch for #550.

Adds RAG documents and a combined development harness to the vertebrate projection workflow.
Exact genomic requests are shared across source catalogs while source memberships remain separate; chr18 is excluded from training, available species are assembled into fixed permutations, and the three development cohorts retain their canonical row identities.

Public release targets produce sequence-only Parquet shards and keep row mappings and checksum manifests in workflow-owned storage.
The added rules preserve existing default targets and reuse the existing chain and genome validators.
Biological selections and training code remain on the permanent #550 branch.

Validation: `uv run --locked pytest` passed all 283 tests on the authorized CPU worker, including the existing and added end-to-end workflows with Kent 482.
Ruff and Snakefmt checks passed; the biological dry-run selected 365 intended jobs with no HAL generation, MultiZ scanning, or upstream anchor construction.

Related issue: #551.
