### PR TITLE
Preserve approvals and check access before unattended work

### DIFF
--- a/.agents/skills/develop-snakemake-pipelines/SKILL.md
+++ b/.agents/skills/develop-snakemake-pipelines/SKILL.md
@@ -33,15 +33,20 @@ Use the targets intended for the task. Put pipeline-wide defaults such as cores,
 - Treat existing rules and the shared Python code paths they invoke as immutable when their artifacts share underlying data or storage on S3.
 - Add task-specific rules, modules, tests, configuration, targets, and output namespaces instead of editing an existing path. Copy code when that is the clearest way to keep the new execution path isolated.
 - Preserve existing rule names, inputs, outputs, parameters, and transitive behavior. Do not rely on producer-keyed paths alone to make an in-place change safe.
-- If the requested outcome cannot be implemented additively, stop and obtain explicit user approval before modifying a legacy rule or shared execution path.
+- If the requested outcome cannot be implemented additively, check existing task authorization for modifying the legacy rule or shared execution path.
+  Resolve any missing approval during initial preflight before making that change.
 
 ## Inspect Before Executing
 
 1. Run the owning project's tests.
 2. Dry-run before every real Snakemake invocation.
 3. Inspect the planned jobs, inputs, outputs, resources, and rerun reasons.
-4. Stop and ask before executing if the plan includes an unintended upstream, unrelated, expensive, or destructive job. Timestamp changes and default rerun triggers do not establish intent.
-5. Follow inherited compute-safety rules before local heavy work. Obtain explicit user approval before launching paid remote compute, including SkyPilot resources.
+4. Correct the plan before executing if it includes unintended jobs or work outside the approved scope or budget.
+   Ask only if resolving the mismatch requires new authority or a material user decision.
+   Timestamp changes and default rerun triggers do not establish intent.
+5. Follow inherited compute-safety rules before local heavy work and [Task Authorization](../../../AGENTS.md#task-authorization) for paid remote compute, including SkyPilot resources.
+   Reuse existing approval for launches and recovery within the cumulative budget.
+   For unattended execution, complete [execution-permissions preflight](../../../docs/operations/unattended-codex.md) before dependent resource launches.
 6. Monitor a new script, configuration, or compute combination during its first minutes. Check progress rate, expected devices, mounts, authentication, and early failures.
 
 ## Create A Pipeline

--- a/.agents/skills/marin-experiment/SKILL.md
+++ b/.agents/skills/marin-experiment/SKILL.md
@@ -39,7 +39,9 @@ Inspect the resolved dependency tree when accelerator extras, custom indexes, Tr
 ## Prepare The Launch
 
 - Read the current `iris --help` and the launch API used by the selected Marin release before constructing the command.
-- Obtain explicit user approval before launching paid remote resources.
+- Follow [AGENTS.md](../../../AGENTS.md#task-authorization) to establish launch authority during initial preflight.
+  Reuse existing explicit approval for paid resources, required credential use, and retries within the approved scope and cumulative budget.
+  Include coordinators, failed attempts, and replacement workers in the budget; ask only for missing authority or an expansion beyond its limits.
 - Pin or snapshot the experiment branch before submitting the job.
 - Propagate required dependency groups and environment variables to every remote step according to the current API. Parent coordinator settings may not propagate to workers.
 - Follow `wandb-reporting` for run and group naming. MarinDNA experiment runs must map back to `dna-exp<N>`.

--- a/.agents/skills/marin-experiment/SKILL.md
+++ b/.agents/skills/marin-experiment/SKILL.md
@@ -40,8 +40,10 @@ Inspect the resolved dependency tree when accelerator extras, custom indexes, Tr
 
 - Read the current `iris --help` and the launch API used by the selected Marin release before constructing the command.
 - Follow [AGENTS.md](../../../AGENTS.md#task-authorization) to establish launch authority during initial preflight.
-  Reuse existing explicit approval for paid resources, required credential use, and retries within the approved scope and cumulative budget.
+  Reuse existing explicit approval for paid resources, required credential use, retries, and runtime extensions within the approved scope and cumulative budget.
   Include coordinators, failed attempts, and replacement workers in the budget; ask only for missing authority or an expansion beyond its limits.
+- Complete [execution-permissions preflight](../../../docs/operations/unattended-codex.md) before an unattended launch.
+  Set worker deadlines to cover setup, execution, export, and upload within the remaining budget, and record a durable recovery path for interruptions.
 - Pin or snapshot the experiment branch before submitting the job.
 - Propagate required dependency groups and environment variables to every remote step according to the current API. Parent coordinator settings may not propagate to workers.
 - Follow `wandb-reporting` for run and group naming. MarinDNA experiment runs must map back to `dna-exp<N>`.
@@ -56,6 +58,8 @@ Watch the first minutes of a new script, dependency set, or compute configuratio
 3. Confirm the expected accelerator count and device type. Treat CPU fallback as a failure when an accelerator was requested.
 4. Confirm W&B reports an advancing step and sane throughput, loss, and memory use.
 5. Check mounts, credentials, and output paths before leaving the job unattended.
+6. Compare observed throughput with shutdown deadlines and the remaining cumulative budget.
+   Extend or replace workers under the existing authorization when needed, while enough time remains to preserve outputs and recover.
 
 Use event-driven status tools or coarse polling that respects shared-node safety. Do not rely on submission success as evidence that the coordinator or workers started.
 

--- a/.agents/skills/run-research/SKILL.md
+++ b/.agents/skills/run-research/SKILL.md
@@ -59,6 +59,8 @@ is clear.
 Follow the task-authorization procedure in [AGENTS.md](../../../AGENTS.md#task-authorization) before dependent execution.
 Record the approval source, date, scope, limits, and unresolved items in the logbook, and carry them into each handoff or resumed session.
 Check that record against the available user instructions before asking for permission again.
+For unattended work, complete [execution-permissions preflight](../../../docs/operations/unattended-codex.md) before dependent resource launches.
+On resumption, recheck the effective execution settings and active worker deadlines while retaining the existing task authorization.
 
 1. Create or switch to a long-lived research branch. Use a name requested by the user or follow the naming guidance in `AGENTS.md`.
 2. Create an experiment issue with `file-issue` unless scope or visibility needs

--- a/.agents/skills/run-research/SKILL.md
+++ b/.agents/skills/run-research/SKILL.md
@@ -56,6 +56,10 @@ is clear.
 
 ### 1. Prologue
 
+Follow the task-authorization procedure in [AGENTS.md](../../../AGENTS.md#task-authorization) before dependent execution.
+Record the approval source, date, scope, limits, and unresolved items in the logbook, and carry them into each handoff or resumed session.
+Check that record against the available user instructions before asking for permission again.
+
 1. Create or switch to a long-lived research branch. Use a name requested by the user or follow the naming guidance in `AGENTS.md`.
 2. Create an experiment issue with `file-issue` unless scope or visibility needs
    human confirmation. If the user provides one, use it.

--- a/.agents/skills/task-logbook/SKILL.md
+++ b/.agents/skills/task-logbook/SKILL.md
@@ -55,6 +55,12 @@ author:
 - Constraints:
 - Coordinating issue/PR:
 
+## Authorization And Execution Access
+- Approval source/date, scope, and limits (without private conversation text):
+- Cumulative budget, spent/committed amount, and remaining amount:
+- Effective permission profile/sandbox, approval policy/reviewer, and unresolved restrictions:
+- Active resource IDs, shutdown times, durable outputs, and recovery commands:
+
 ## Baseline
 - Date:
 - Code refs:
@@ -85,6 +91,10 @@ For research series, add a short experiment ID prefix such as `MOE-HC` and use
 IDs like `MOE-HC-001` in logbook entries, W&B run names, and issue comments.
 
 The author should ordinarily be the user who asked you to make the logbook. If there is no GitHub issue, omit it.
+
+For authorization and execution-access fields, use [Task Authorization](../../../AGENTS.md#task-authorization) and the [unattended handoff record](../../../docs/operations/unattended-codex.md#initial-preflight-and-resumption).
+Keep references to original private approval messages in private task context, and carry them through handoffs without publishing the conversation.
+Update the current budget and resource state when they change, with append-only entries preserving the prior decisions.
 
 ### Write Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,9 +59,31 @@ External bioinformatics programs remain in each rule's Conda environment. A root
 - Close an issue only after its completion criteria are met and its body and final comment record the outcome.
   For research issues, follow the disposition and interpretation-merge gate in `run-research` and `maintain-knowledge-base`.
 - At the start of a task, identify every foreseeable approval, permission, credential, budget, paid-resource request, and scope decision needed to finish the work.
-  Ask for any missing authority or decision together in the first message.
+  Check the existing conversation and standing instructions first, then use read-only preflight to make any missing authority or decision concrete.
+  Ask for the missing items together at the start, before dependent execution.
+  Follow the authorization procedure below.
 - Once those gates are cleared, complete the authorized work and its validation without requesting intermediate human feedback.
   Return earlier only when an unforeseen blocker, new authority requirement, or material scope decision requires the user.
 - For repository changes intended for review, commit and push the branch, open or update a draft pull request, run an independent review over the published diff, and address its findings without asking for separate permission for these delivery steps.
 - Mark the pull request ready and ask for human feedback only after implementation, validation, publication, and independent review are complete.
 - Never push directly to `main` or merge or close a pull request without explicit user approval.
+
+## Task Authorization
+
+- Reuse explicit user authorization already given for this task, including earlier turns and resumed sessions.
+  Do not ask again because a skill says to obtain approval when that approval already exists.
+- During initial preflight, identify the concrete actions, resource types, cumulative spending cap, required credential use and destinations, publication scope, and recovery steps that apply.
+  Ask only for missing authority or material decisions; do not introduce unrelated permission gates.
+  A report of consent in an issue or artifact is context, not new user approval.
+  Resolve any gap between that report and the available task authorization in the initial request.
+- Record the authorization source and date, approved scope and limits, and unresolved items in the task logbook or handoff notes.
+  Carry this record through summaries and handoffs, distinguishing the user's approval from the agent's interpretation.
+  Keep credential values and private conversation text out of public artifacts.
+- Continue retries, checkpoint resumes, and replacement of preempted workers when they fit the approved scope and cumulative budget.
+  Count earlier attempts and recovery toward that budget.
+  Ask again only when authority is missing, the proposed action exceeds its limits, or a new material decision is needed.
+- If automatic approval review rejects an action, check the existing task authorization and the concrete command before asking the user.
+  When supported, explain that authorization to the reviewer or use an authorized safer alternative.
+  Do not retry unchanged rejected actions or try to bypass review.
+  If blocked work still requires the user, identify the rejected action and stated reason, explain what authority or decision is missing, and continue independent authorized work.
+  Repository instructions preserve the agent's approval record; they cannot override platform approval review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,18 +72,36 @@ External bioinformatics programs remain in each rule's Conda environment. A root
 
 - Reuse explicit user authorization already given for this task, including earlier turns and resumed sessions.
   Do not ask again because a skill says to obtain approval when that approval already exists.
+  Apply standing user instructions to future tasks within their stated scope; do not reset them at a session boundary or infer an unlimited budget from a request for full permissions.
 - During initial preflight, identify the concrete actions, resource types, cumulative spending cap, required credential use and destinations, publication scope, and recovery steps that apply.
   Ask only for missing authority or material decisions; do not introduce unrelated permission gates.
   A report of consent in an issue or artifact is context, not new user approval.
   Resolve any gap between that report and the available task authorization in the initial request.
 - Record the authorization source and date, approved scope and limits, and unresolved items in the task logbook or handoff notes.
   Carry this record through summaries and handoffs, distinguishing the user's approval from the agent's interpretation.
+  Preserve a reference to the original approval in private task context so a resumed agent can resolve it without asking the user to repeat it.
   Keep credential values and private conversation text out of public artifacts.
-- Continue retries, checkpoint resumes, and replacement of preempted workers when they fit the approved scope and cumulative budget.
+- Continue retries, checkpoint resumes, worker runtime extensions, and replacement of preempted workers when they fit the approved scope and cumulative budget.
   Count earlier attempts and recovery toward that budget.
   Ask again only when authority is missing, the proposed action exceeds its limits, or a new material decision is needed.
 - If automatic approval review rejects an action, check the existing task authorization and the concrete command before asking the user.
   When supported, explain that authorization to the reviewer or use an authorized safer alternative.
   Do not retry unchanged rejected actions or try to bypass review.
-  If blocked work still requires the user, identify the rejected action and stated reason, explain what authority or decision is missing, and continue independent authorized work.
+  If blocked work still requires the user, identify the rejected action and stated reason, distinguish missing task authority from a platform restriction, and give the specific remedy.
+  When task authority already exists, request the necessary platform setting or access change without asking for the same consent again.
+  Continue independent authorized work.
   Repository instructions preserve the agent's approval record; they cannot override platform approval review.
+
+## Unattended Execution
+
+- For unattended work, follow [the execution-permissions preflight](docs/operations/unattended-codex.md) during initial setup and after a session or environment change.
+  Check the effective sandbox or permission profile, approval policy and reviewer, required network and filesystem access, and service credentials before starting dependent paid or long-running work.
+  Reuse the task authorization; recheck execution access without reopening settled decisions.
+- A user's request for full permissions expresses task authority within the stated scope; the client or host must also permit the required operations.
+  Automatic approval review can still reject them, and a successful one-off escalation does not establish continuing access.
+  Surface a known mismatch during initial preflight, using the supported owner-controlled setup in the runbook.
+  Do not change enforced policy or launch an unrestricted child agent to evade an active restriction.
+- Plan worker lifetimes, durable outputs, and recovery within the cumulative budget before launch.
+  Include setup, final assembly, export, and upload in runtime estimates, and revisit deadlines using observed throughput while recovery is still possible.
+  Carry resource IDs, shutdown times, spending to date, remaining budget, and resume instructions through handoffs.
+  If a platform restriction blocks recovery, preserve outputs and release idle paid resources where authorized; do not leave them waiting for repeated consent.

--- a/docs/operations/unattended-codex.md
+++ b/docs/operations/unattended-codex.md
@@ -1,0 +1,101 @@
+# Unattended Codex Work
+
+Preserve task approval across sessions and check execution access before starting work that must continue without the user present.
+The agent follows [Task Authorization](../../AGENTS.md#task-authorization); the user or host owner controls the session's execution permissions.
+These instructions apply to future tasks that load this repository's guidance.
+Merging them does not change an existing session's permission settings.
+
+## Initial Preflight And Resumption
+
+1. Recover the task's existing authorization from available user instructions and private task context.
+   Record its source and date, permitted actions and resource types, cumulative spending cap, credential purposes and destinations, publication scope, and recovery limits.
+   Carry forward spending from failed attempts and previous sessions.
+   Keep original-message references in private handoff context; public logbooks can record scope and limits without quoting private conversation text.
+2. Inspect the current session's effective permission profile or sandbox, approval policy, reviewer, and any managed restrictions.
+   Inspect only relevant configuration keys; do not dump configuration files or credential stores.
+   A config file expresses a requested setting; the running client's effective settings determine access.
+3. Check the access needed by the remaining workflow, including launch, monitoring, runtime extensions, recovery, artifact upload, and cleanup.
+   Use read-only service checks and reversible local probes where useful, following the repository's credential instructions.
+   Verify credential availability and destination access without printing secret values.
+   A successful read or one approved command does not establish permission for later writes or paid operations.
+4. Ask once at initial preflight for missing task authority, material decisions, or a concrete client/host setting change.
+   When authority already exists, explain the execution restriction and its remedy without asking the user to approve the task again.
+   Continue independent work while a dependent operation is blocked.
+   On resumption, repeat access checks for the current environment and reconcile the authorization record with available user instructions.
+
+Use this compact handoff record, omitting fields that do not apply:
+
+| Field | Record |
+|---|---|
+| Authorization | Source/date, standing instructions, approved scope, unresolved decisions; private reference to original approval |
+| Budget | Cumulative cap, spent/committed amount, remaining amount, resource types, recovery allowance |
+| Credentials and publication | Credential purpose, service/account, destination and artifact class; no credential values |
+| Execution access | Effective profile/sandbox, approval policy/reviewer, managed restrictions, probe results and unresolved restrictions |
+| Active resources | Provider IDs, job IDs, shutdown times, durable artifact locations, resume and cleanup commands |
+
+## Owner-Controlled Full Access
+
+Use this setup when the user has requested unrestricted local execution for authorized work.
+Full Access removes local sandbox restrictions; task scope, spending limits, service permissions, and separate connector controls still apply.
+Managed policy can restrict the available modes. [OpenAI permission profiles](https://learn.chatgpt.com/docs/permissions)
+
+### Desktop App Or IDE
+
+Select **Full access** using the permissions control below the composer.
+If the option is hidden, the documented desktop setup enables its visibility under **Settings > General > Permissions**.
+Enabling the option only adds it to the menu; select it for the task and verify the active mode.
+Check the mode again for a new or resumed task, because making an option visible does not change existing tasks. [OpenAI permission modes](https://learn.chatgpt.com/docs/permission-modes)
+
+### Persistent CLI Profile
+
+For a reusable, explicitly selected CLI configuration, the owner can save the following as `~/.codex/marin-unattended.config.toml` (or in the configured `CODEX_HOME` directory):
+
+```toml
+approval_policy = "never"
+default_permissions = ":danger-full-access"
+```
+
+Select that configuration when starting or resuming authorized work:
+
+```bash
+codex --profile marin-unattended --cd /path/to/marin-dna
+codex resume --profile marin-unattended --cd /path/to/marin-dna SESSION_ID
+```
+
+This named configuration persists across CLI sessions when selected with `--profile`.
+To make these settings the user-wide CLI default instead, the owner can place the same top-level keys in their existing `~/.codex/config.toml`, preserving unrelated settings.
+That default applies beyond this repository.
+Current CLI profiles use separate `<name>.config.toml` files; the older `[profiles.<name>]` format is unsupported in Codex 0.134.0 and later. [OpenAI configuration profiles](https://learn.chatgpt.com/docs/config-file/config-advanced#profiles)
+
+Do not mix `default_permissions` with legacy `sandbox_mode`, `[sandbox_workspace_write]`, or `--sandbox` settings.
+Remove conflicting legacy settings from the owner's configuration when adopting permission profiles.
+Project settings and CLI overrides can supersede user profiles, and managed requirements can forbid Full Access or `approval_policy = "never"`.
+Verify the effective settings after startup. [OpenAI configuration precedence](https://learn.chatgpt.com/docs/config-file/config-basic#configuration-precedence)
+
+The profile format and CLI start/resume flags were checked against Codex CLI 0.153.2 and official documentation on 2026-09-10.
+Check the installed client's help and current official documentation when those interfaces change.
+These are owner setup instructions; an agent in a restricted session must not use them to start an unrestricted child or rewrite enforced policy after a rejection.
+
+## Recognize Incomplete Setup
+
+| Observed setting or failure | Meaning and next action |
+|---|---|
+| Workspace restrictions with **Approve for me** / `auto_review` | Automatic review handles escalation requests and can reject them. Check whether required operations remain subject to review and identify the setup mismatch before promising unattended execution. |
+| `approval_policy = "never"` with a restrictive sandbox | Prompts are disabled while access remains restricted. The owner must select permissions that allow the required operations. |
+| Full Access is unavailable or effective settings remain restricted | Ask the client/host owner to resolve the specific managed restriction through supported settings. Preserve the existing task approval. |
+| A service reports missing credentials or insufficient rights | Diagnose that service's access using its normal client. Local Full Access cannot grant provider-side rights. |
+| An already authorized action is rejected | Check the command and approval source, supply that evidence when supported, or use an authorized alternative. Report any remaining platform blocker precisely; do not repeat unchanged rejected requests. |
+
+Automatic review changes who handles approvals while retaining the sandbox boundary.
+It provides no guarantee that a later operation will be approved. [OpenAI automatic review](https://learn.chatgpt.com/docs/sandboxing/auto-review)
+
+## Worker Deadlines And Recovery
+
+Before launch, estimate the complete path through setup, computation, final assembly, export, and durable upload.
+Set worker lifetimes and recovery headroom within the approved cumulative budget, including coordinator and failed-attempt costs.
+Arrange durable checkpoints or intermediate outputs before ephemeral storage can disappear.
+
+Compare observed throughput with time remaining until shutdown early enough to extend, checkpoint, or replace the worker under the existing authorization.
+Do not make a predictable timeout depend on the user returning to repeat that authorization.
+Keep budget and shutdown limits in force; request new authority only for an actual expansion beyond them.
+If execution restrictions block recovery, save accessible outputs and release idle paid resources where authorized, record the exact blocker and resume path, and continue unaffected work.


### PR DESCRIPTION
Preserve task approvals across retries, runtime extensions, and resumed sessions, and check effective execution permissions before unattended resource launches.
This catches cases where the user has authorized the work but the client still requires automatic or human review.

Document owner-controlled Full Access setup for desktop clients and persistent CLI profiles, including managed-policy limits and the difference between disabling prompts and granting access.
Carry approval sources, cumulative spending, worker deadlines, and recovery commands through handoffs, and align pipeline and training skills with the shared procedure.
Repository guidance does not change the running client's permission settings.

Repository quality checks, four skill validators, relative links, and the TOML example pass.
CI passes, including all five project test jobs and the dashboard build.
Independent review of the published diff found no issues; scenario walkthroughs covered resumed budgets, permission mismatches, denied uploads, and missing spending authority.
Permission changes and cloud operations were not exercised by those checks.

Deferred as standalone unattended-execution guidance; the runbook and documented scenarios provide the context for a later maintenance pass.

Fixes #555
