### PR TITLE
Load Transformers 5 special-token lists in evals_v2

### DIFF
--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -17,6 +17,8 @@ For each `model` × `dataset` in the config:
    Before tokenizer or model construction, `marin_dna_evals.hf_compat` reads the local `config.json` and validates its effective RoPE semantics.
    Transformers-5-only `rope_parameters` are translated in memory for the pinned Transformers 4 consumer.
    Consistent dual-schema exports are accepted, while conflicting, malformed, incomplete, or unrepresentable schemas fail before weights load.
+   Transformers 5 special-token lists are mapped to the Transformers 4 `additional_special_tokens` field in memory, preserving the serialized tokenizer and token IDs.
+   Conflicting old/new lists fail explicitly; native Transformers 4 named-token dictionaries retain their meaning.
 2. **Score** every variant with `compute_variant_scores`. The score
    bundle is per-strand LLR + JSD (`down_jsd_mean` in issue #175 — the
    per-position 4-nuc next-token JSD averaged over downstream positions).

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/hf_compat.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/hf_compat.py
@@ -411,16 +411,34 @@ def load_hf_checkpoint_tokenizer(
     """Load native Transformers 4 and Transformers 5 tokenizer exports."""
     checkpoint_path = Path(checkpoint_path)
     tokenizer_config_path = checkpoint_path / "tokenizer_config.json"
+    load_kwargs: dict[str, Any] = {}
     if tokenizer_config_path.is_file():
         tokenizer_config = _read_json_object(tokenizer_config_path)
+        extra_tokens = tokenizer_config.get("extra_special_tokens")
+        if isinstance(extra_tokens, list):
+            # Transformers 5 renamed the additional-special-token list. In
+            # Transformers 4 this name instead denotes named token attributes.
+            if (
+                "additional_special_tokens" in tokenizer_config
+                and tokenizer_config["additional_special_tokens"] != extra_tokens
+            ):
+                raise HfCheckpointCompatibilityError(
+                    f"{tokenizer_config_path}: conflicting special-token lists"
+                )
+            load_kwargs = {
+                "extra_special_tokens": {},
+                "additional_special_tokens": extra_tokens,
+            }
         if tokenizer_config.get("tokenizer_class") == "TokenizersBackend":
             tokenizer_json_path = checkpoint_path / "tokenizer.json"
             if not tokenizer_json_path.is_file():
                 raise HfCheckpointCompatibilityError(
                     f"TokenizersBackend export is missing tokenizer.json: {tokenizer_json_path}"
                 )
-            return PreTrainedTokenizerFast.from_pretrained(checkpoint_path)
-    return AutoTokenizer.from_pretrained(checkpoint_path)
+            return PreTrainedTokenizerFast.from_pretrained(
+                checkpoint_path, **load_kwargs
+            )
+    return AutoTokenizer.from_pretrained(checkpoint_path, **load_kwargs)
 
 
 def _load_hf_model_and_tokenizer(

--- a/snakemake/analysis/evals_v2/tests/evals/test_hf_compat.py
+++ b/snakemake/analysis/evals_v2/tests/evals/test_hf_compat.py
@@ -257,6 +257,108 @@ def test_load_tokenizer_requires_json_for_transformers5_backend(tmp_path: Path) 
         load_hf_checkpoint_tokenizer(tmp_path)
 
 
+@pytest.mark.parametrize("class_name", ["PreTrainedTokenizerFast", "TokenizersBackend"])
+@pytest.mark.parametrize("serialized_added_token", [False, True])
+def test_load_tokenizer_translates_transformers5_special_tokens(
+    tmp_path: Path, class_name: str, serialized_added_token: bool
+) -> None:
+    from tokenizers import (
+        Regex,
+        Tokenizer,
+        models,
+        normalizers,
+        pre_tokenizers,
+        processors,
+    )
+    from transformers import PreTrainedTokenizerFast
+
+    vocab = {
+        token: index
+        for index, token in enumerate(
+            ["[PAD]", "[UNK]", "[BOS]", "[SEQ]", "a", "c", "g", "t"]
+        )
+    }
+    backend = Tokenizer(models.WordLevel(vocab, unk_token="[UNK]"))
+    backend.normalizer = normalizers.Lowercase()
+    backend.pre_tokenizer = pre_tokenizers.Split(Regex(".{1}"), behavior="isolated")
+    backend.post_processor = processors.TemplateProcessing(
+        single="[BOS] $A", special_tokens=[("[BOS]", 2)]
+    )
+    original = PreTrainedTokenizerFast(
+        tokenizer_object=backend,
+        bos_token="[BOS]",
+        pad_token="[PAD]",
+        unk_token="[UNK]",
+        additional_special_tokens=["[SEQ]"],
+        model_max_length=10240,
+    )
+    original.save_pretrained(tmp_path)
+    config_path = tmp_path / "tokenizer_config.json"
+    config = json.loads(config_path.read_text())
+    config["tokenizer_class"] = class_name
+    config.pop("additional_special_tokens")
+    config["extra_special_tokens"] = (
+        [
+            {
+                "content": "[SEQ]",
+                "special": True,
+                "normalized": False,
+                "single_word": False,
+                "lstrip": False,
+                "rstrip": False,
+                "__type": "AddedToken",
+            }
+        ]
+        if serialized_added_token
+        else ["[SEQ]"]
+    )
+    config_path.write_text(json.dumps(config))
+    (tmp_path / "special_tokens_map.json").unlink()
+    before = {path.name: path.read_bytes() for path in tmp_path.iterdir()}
+
+    loaded = load_hf_checkpoint_tokenizer(tmp_path)
+
+    assert loaded.get_vocab() == original.get_vocab() == vocab
+    assert (
+        loaded.encode("AC[SEQ]GT") == original.encode("AC[SEQ]GT") == [2, 4, 5, 3, 6, 7]
+    )
+    assert loaded.all_special_ids == original.all_special_ids
+    assert loaded.additional_special_tokens == ["[SEQ]"]
+    assert loaded.decode([2, 4, 3, 5, 0], skip_special_tokens=True) == original.decode(
+        [2, 4, 3, 5, 0], skip_special_tokens=True
+    )
+    assert {path.name: path.read_bytes() for path in tmp_path.iterdir()} == before
+
+
+def test_load_tokenizer_preserves_transformers4_named_tokens(tmp_path: Path) -> None:
+    (tmp_path / "tokenizer_config.json").write_text(
+        json.dumps(
+            {
+                "tokenizer_class": "PreTrainedTokenizerFast",
+                "extra_special_tokens": {"image_token": "[IMAGE]"},
+            }
+        )
+    )
+    with patch("marin_dna_evals.hf_compat.AutoTokenizer.from_pretrained") as loader:
+        load_hf_checkpoint_tokenizer(tmp_path)
+    loader.assert_called_once_with(tmp_path)
+
+
+def test_load_tokenizer_rejects_conflicting_special_token_lists(tmp_path: Path) -> None:
+    (tmp_path / "tokenizer_config.json").write_text(
+        json.dumps(
+            {
+                "extra_special_tokens": ["[SEQ]"],
+                "additional_special_tokens": ["[OTHER]"],
+            }
+        )
+    )
+    with pytest.raises(
+        HfCheckpointCompatibilityError, match="conflicting special-token lists"
+    ):
+        load_hf_checkpoint_tokenizer(tmp_path)
+
+
 @pytest.mark.parametrize(
     ("function_name", "loader_name"),
     [


### PR DESCRIPTION
Marin exports with `extra_special_tokens: ["[SEQ]"]` fail before inference in the pinned Transformers 4 runtime.
Translate that Transformers 5 list to `additional_special_tokens` in memory, preserving native named-token dictionaries and rejecting conflicting lists.

The regression test reproduces the original failure and checks both tokenizer class names, serialized added tokens, token IDs, special-token behavior, and unchanged checkpoint bytes.
Validation: the full locked evaluation suite passes on the experiment integration checkout with CUDA disabled (424 passed, 5 skipped); the workflow dry-run passes, and independent review found no material issues.
An initial run with CUDA visible exposed five existing CPU-fixture device mismatches; the new tokenizer tests passed in both runs.
CI on this mainline-only diff is in progress.

Deferred as a standalone tokenizer compatibility fix; the issue and regression tests provide the context for a later maintenance pass.

Closes #558.
