### PR TITLE
Honor explicit fp32 inference precision through Trainer setup

### DIFF
--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -135,7 +135,7 @@ The global `inference.return_embeddings` and `inference.torch_compile` settings 
 These settings cannot be overridden by a checkpoint entry.
 When bfloat16 fails a recorded numerical-parity check, a run configuration may set `inference.bf16: false`, `inference.tf32: false`, and a nonempty `inference.precision_reason` describing the evidence.
 The explicit TF32 setting is applied after Trainer construction so Accelerate cannot override it during compilation setup.
-Precision settings and the fallback reason are recorded in the scoring rules' Snakemake parameters; changing them invalidates prior scoring provenance.
+Explicit precision overrides and their reasons enter the scoring rules' Snakemake parameters; existing default runs retain their original parameter identity.
 Use explicit model targets when applying a precision override to an evaluation run.
 The embeddings come from the same FWD and RC forward passes that produce LLR and JSD.
 

--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -134,6 +134,7 @@ Every newly computed VEP score parquet contains pooled `emb_ref` and `emb_alt` v
 The global `inference.return_embeddings` and `inference.torch_compile` settings remain `true`; bfloat16 is the default precision.
 These settings cannot be overridden by a checkpoint entry.
 When bfloat16 fails a recorded numerical-parity check, a run configuration may set `inference.bf16: false`, `inference.tf32: false`, and a nonempty `inference.precision_reason` describing the evidence.
+Public APIs also accept an explicit `tf32` argument; with `bf16=False`, its default disables TF32.
 The explicit TF32 setting is applied after Trainer construction so Accelerate cannot override it during compilation setup.
 Explicit precision overrides and their reasons enter the scoring rules' Snakemake parameters; existing default runs retain their original parameter identity.
 Use explicit model targets when applying a precision override to an evaluation run.

--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -131,7 +131,12 @@ to the three #292 gLMs via their per-model `datasets:` lists.
 ### Pooled embeddings (#318)
 
 Every newly computed VEP score parquet contains pooled `emb_ref` and `emb_alt` vectors.
-The global `inference.return_embeddings`, `inference.torch_compile`, and `inference.bf16` settings are all `true` and cannot be overridden by a checkpoint entry.
+The global `inference.return_embeddings` and `inference.torch_compile` settings remain `true`; bfloat16 is the default precision.
+These settings cannot be overridden by a checkpoint entry.
+When bfloat16 fails a recorded numerical-parity check, a run configuration may set `inference.bf16: false`, `inference.tf32: false`, and a nonempty `inference.precision_reason` describing the evidence.
+The explicit TF32 setting is applied after Trainer construction so Accelerate cannot override it during compilation setup.
+Precision settings and the fallback reason are recorded in the scoring rules' Snakemake parameters; changing them invalidates prior scoring provenance.
+Use explicit model targets when applying a precision override to an evaluation run.
 The embeddings come from the same FWD and RC forward passes that produce LLR and JSD.
 
 Each allele column stores a length-`D` Float16 vector.

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/embedding_umap.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/embedding_umap.py
@@ -89,6 +89,7 @@ def compute_region_embeddings(
     num_workers: int = 4,
     torch_compile: bool = False,
     bf16: bool = True,
+    tf32: bool | None = None,
 ) -> pd.DataFrame:
     """Embed every region window; return embeddings + carried metadata.
 
@@ -152,6 +153,7 @@ def compute_region_embeddings(
             "per_device_eval_batch_size": batch_size,
             "torch_compile": torch_compile,
             "bf16_full_eval": bf16,
+            **({"tf32": tf32} if tf32 is not None else {}),
             "dataloader_num_workers": num_workers,
             "remove_unused_columns": False,
         },

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/embedding_umap.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/embedding_umap.py
@@ -153,7 +153,11 @@ def compute_region_embeddings(
             "per_device_eval_batch_size": batch_size,
             "torch_compile": torch_compile,
             "bf16_full_eval": bf16,
-            **({"tf32": tf32} if tf32 is not None else {}),
+            **(
+                {"tf32": tf32 if tf32 is not None else False}
+                if tf32 is not None or not bf16
+                else {}
+            ),
             "dataloader_num_workers": num_workers,
             "remove_unused_columns": False,
         },

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/inference.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/inference.py
@@ -50,6 +50,7 @@ def compute_variant_scores(
     return_embeddings: bool = False,
     eval_accumulation_steps: int | None = None,
     bf16: bool = True,
+    tf32: bool | None = None,
 ) -> pd.DataFrame:
     """Compute variant scores from a CLM: per-strand LLR + next-token JSD.
 
@@ -84,6 +85,7 @@ def compute_variant_scores(
             embedding run can otherwise accumulate on-GPU and OOM. ``None``
             (default) leaves behaviour unchanged.
         bf16: Whether to run evaluation forwards in bfloat16.
+        tf32: Explicit CUDA matmul precision; None retains framework defaults.
 
     Returns:
         DataFrame with per-strand score atoms. Rows align with input
@@ -122,6 +124,8 @@ def compute_variant_scores(
         "dataloader_num_workers": num_workers,
         "remove_unused_columns": False,
     }
+    if tf32 is not None:
+        inference_kwargs["tf32"] = tf32
     if eval_accumulation_steps is not None:
         inference_kwargs["eval_accumulation_steps"] = eval_accumulation_steps
 

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/inference.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/inference.py
@@ -85,7 +85,8 @@ def compute_variant_scores(
             embedding run can otherwise accumulate on-GPU and OOM. ``None``
             (default) leaves behaviour unchanged.
         bf16: Whether to run evaluation forwards in bfloat16.
-        tf32: Explicit CUDA matmul precision; None retains framework defaults.
+        tf32: Explicit CUDA matmul precision. None preserves the bf16 default
+            and disables TF32 when bf16=False requests fp32 inference.
 
     Returns:
         DataFrame with per-strand score atoms. Rows align with input
@@ -124,8 +125,8 @@ def compute_variant_scores(
         "dataloader_num_workers": num_workers,
         "remove_unused_columns": False,
     }
-    if tf32 is not None:
-        inference_kwargs["tf32"] = tf32
+    if tf32 is not None or not bf16:
+        inference_kwargs["tf32"] = tf32 if tf32 is not None else False
     if eval_accumulation_steps is not None:
         inference_kwargs["eval_accumulation_steps"] = eval_accumulation_steps
 

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/ll_gap.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/ll_gap.py
@@ -62,7 +62,8 @@ def compute_hf_ll_gap(
         num_workers: Dataloader workers.
         torch_compile: Whether to ``torch.compile`` the forward pass.
         bf16: Whether to run evaluation forwards in bfloat16.
-        tf32: Explicit CUDA matmul precision; None retains framework defaults.
+        tf32: Explicit CUDA matmul precision. None preserves the bf16 default
+            and disables TF32 when bf16=False requests fp32 inference.
 
     Returns:
         DataFrame with columns ``[id?, ll_sum_upper, ll_sum_lower, n_upper,
@@ -94,7 +95,11 @@ def compute_hf_ll_gap(
             "per_device_eval_batch_size": batch_size,
             "torch_compile": torch_compile,
             "bf16_full_eval": bf16,
-            **({"tf32": tf32} if tf32 is not None else {}),
+            **(
+                {"tf32": tf32 if tf32 is not None else False}
+                if tf32 is not None or not bf16
+                else {}
+            ),
             "dataloader_num_workers": num_workers,
             "remove_unused_columns": False,
         },

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/ll_gap.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/ll_gap.py
@@ -35,6 +35,7 @@ def compute_hf_ll_gap(
     num_workers: int = 4,
     torch_compile: bool = False,
     bf16: bool = True,
+    tf32: bool | None = None,
 ) -> pd.DataFrame:
     """Per-sequence functional/non-functional LL atoms for an HF causal LM.
 
@@ -61,6 +62,7 @@ def compute_hf_ll_gap(
         num_workers: Dataloader workers.
         torch_compile: Whether to ``torch.compile`` the forward pass.
         bf16: Whether to run evaluation forwards in bfloat16.
+        tf32: Explicit CUDA matmul precision; None retains framework defaults.
 
     Returns:
         DataFrame with columns ``[id?, ll_sum_upper, ll_sum_lower, n_upper,
@@ -92,6 +94,7 @@ def compute_hf_ll_gap(
             "per_device_eval_batch_size": batch_size,
             "torch_compile": torch_compile,
             "bf16_full_eval": bf16,
+            **({"tf32": tf32} if tf32 is not None else {}),
             "dataloader_num_workers": num_workers,
             "remove_unused_columns": False,
         },

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/model/runner.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/model/runner.py
@@ -454,6 +454,11 @@ def _run_inference(
             **(kwargs or {}),
         )
         trainer = Trainer(model=model, args=training_args)
+        # Accelerate enables TF32 while constructing its compilation state,
+        # after TrainingArguments has already applied an explicit tf32=False.
+        if kwargs.get("tf32") is not None:
+            torch.backends.cuda.matmul.allow_tf32 = kwargs["tf32"]
+            torch.backends.cudnn.allow_tf32 = kwargs["tf32"]
         predictions = trainer.predict(test_dataset=dataset).predictions
 
     if pad_n > 0:

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/workflow_config.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/workflow_config.py
@@ -90,3 +90,17 @@ def resolve_model_eval_accumulation_steps(
         value,
         field=f"model {model_name!r} eval_accumulation_steps",
     )
+
+
+def inference_precision_params(inference: Mapping[str, object]) -> dict[str, object]:
+    """Add provenance only for an explicitly selected precision override.
+
+    Existing default runs must retain their original Snakemake parameter map;
+    adding even a default-valued key would invalidate completed score outputs.
+    """
+    precision = {
+        key: inference.get(key) for key in ("bf16", "tf32", "precision_reason")
+    }
+    if precision == {"bf16": True, "tf32": None, "precision_reason": None}:
+        return {}
+    return {"precision": precision}

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/workflow_config.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/workflow_config.py
@@ -23,6 +23,12 @@ def validate_inference_config(
     tf32 = inference.get("tf32")
     if tf32 is not None and type(tf32) is not bool:
         raise ValueError("inference.tf32 must be a boolean or null")
+    if inference["bf16"] and (
+        tf32 is not None or inference.get("precision_reason") is not None
+    ):
+        raise ValueError(
+            "inference.tf32 overrides require the documented fp32 fallback"
+        )
     if inference["bf16"] is False:
         reason = inference.get("precision_reason")
         if tf32 is not False or not isinstance(reason, str) or not reason.strip():

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/workflow_config.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/workflow_config.py
@@ -14,10 +14,21 @@ def _positive_int(value: object, *, field: str) -> int:
 def validate_inference_config(
     inference: Mapping[str, object], models: Sequence[Mapping[str, object]]
 ) -> None:
-    """Require global-on semantic switches and reject checkpoint overrides."""
-    for field in sorted(GLOBAL_INFERENCE_SWITCHES):
+    """Validate global inference policy and documented fp32 fallbacks."""
+    for field in sorted(GLOBAL_INFERENCE_SWITCHES - {"bf16"}):
         if inference.get(field) is not True:
             raise ValueError(f"inference.{field} must be globally set to true")
+    if type(inference.get("bf16")) is not bool:
+        raise ValueError("inference.bf16 must be a boolean")
+    tf32 = inference.get("tf32")
+    if tf32 is not None and type(tf32) is not bool:
+        raise ValueError("inference.tf32 must be a boolean or null")
+    if inference["bf16"] is False:
+        reason = inference.get("precision_reason")
+        if tf32 is not False or not isinstance(reason, str) or not reason.strip():
+            raise ValueError(
+                "fp32 fallback requires inference.tf32=false and a precision_reason"
+            )
     if inference.get("rc") is not True:
         raise ValueError("inference.return_embeddings=true requires inference.rc=true")
 
@@ -31,7 +42,11 @@ def validate_inference_config(
 
     for model in models:
         model_name = str(model.get("name", "<unnamed>"))
-        forbidden = sorted(GLOBAL_INFERENCE_SWITCHES.intersection(model))
+        forbidden = sorted(
+            (GLOBAL_INFERENCE_SWITCHES | {"tf32", "precision_reason"}).intersection(
+                model
+            )
+        )
         if forbidden:
             raise ValueError(
                 f"model {model_name!r} cannot override global inference switches: "

--- a/snakemake/analysis/evals_v2/tests/evals/test_inference.py
+++ b/snakemake/analysis/evals_v2/tests/evals/test_inference.py
@@ -102,7 +102,8 @@ def test_compute_variant_scores_rc_true_returns_four_cols():
     assert len(scores) == len(ds)
 
 
-def test_compute_variant_scores_threads_execution_settings():
+@pytest.mark.parametrize("tf32", [None, False])
+def test_compute_variant_scores_threads_execution_settings(tf32):
     ds = _stub_dataset()
     fwd = np.zeros((len(ds), 2), dtype=np.float32)
     rc = np.zeros((len(ds), 2), dtype=np.float32)
@@ -123,7 +124,7 @@ def test_compute_variant_scores_threads_execution_settings():
             num_workers=2,
             torch_compile=True,
             bf16=False,
-            tf32=False,
+            tf32=tf32,
             rc=True,
             eval_accumulation_steps=3,
         )
@@ -361,4 +362,5 @@ def test_compute_variant_scores_preserves_legacy_positional_order():
         "return_embeddings",
         "eval_accumulation_steps",
         "bf16",
+        "tf32",
     ]

--- a/snakemake/analysis/evals_v2/tests/evals/test_inference.py
+++ b/snakemake/analysis/evals_v2/tests/evals/test_inference.py
@@ -123,6 +123,7 @@ def test_compute_variant_scores_threads_execution_settings():
             num_workers=2,
             torch_compile=True,
             bf16=False,
+            tf32=False,
             rc=True,
             eval_accumulation_steps=3,
         )
@@ -132,6 +133,7 @@ def test_compute_variant_scores_threads_execution_settings():
     assert kwargs["dataloader_num_workers"] == 2
     assert kwargs["torch_compile"] is True
     assert kwargs["bf16_full_eval"] is False
+    assert kwargs["tf32"] is False
     assert kwargs["eval_accumulation_steps"] == 3
 
 

--- a/snakemake/analysis/evals_v2/tests/evals/test_workflow_config.py
+++ b/snakemake/analysis/evals_v2/tests/evals/test_workflow_config.py
@@ -6,6 +6,7 @@ import pytest
 import yaml
 from marin_dna_evals.workflow_config import (
     GLOBAL_INFERENCE_SWITCHES,
+    inference_precision_params,
     resolve_model_batch_size,
     resolve_model_eval_accumulation_steps,
     validate_inference_config,
@@ -127,3 +128,19 @@ def test_precision_policy_cannot_be_overridden_by_checkpoint(field) -> None:
         validate_inference_config(
             _config()["inference"], [{"name": "model", field: False}]
         )
+
+
+def test_default_precision_preserves_existing_snakemake_parameter_identity() -> None:
+    assert inference_precision_params(_config()["inference"]) == {}
+
+
+def test_explicit_precision_override_enters_snakemake_provenance() -> None:
+    settings = dict(_config()["inference"])
+    settings.update(bf16=False, tf32=False, precision_reason="Recorded parity failure")
+    assert inference_precision_params(settings) == {
+        "precision": {
+            "bf16": False,
+            "tf32": False,
+            "precision_reason": "Recorded parity failure",
+        }
+    }

--- a/snakemake/analysis/evals_v2/tests/evals/test_workflow_config.py
+++ b/snakemake/analysis/evals_v2/tests/evals/test_workflow_config.py
@@ -1,5 +1,8 @@
 """Contracts for global inference semantics and checkpoint execution sizing."""
 
+import hashlib
+import json
+import re
 from pathlib import Path
 
 import pytest
@@ -144,3 +147,19 @@ def test_explicit_precision_override_enters_snakemake_provenance() -> None:
             "precision_reason": "Recorded parity failure",
         }
     }
+
+
+def test_existing_scoring_run_source_is_unchanged() -> None:
+    # Snakemake hashes run_func_src verbatim: even default-equivalent edits
+    # invalidate existing artifacts via the independent code rerun trigger.
+    fixture = json.loads(
+        (PROJECT_ROOT / "tests/fixtures/legacy_scoring_run_hashes.json").read_text()
+    )
+    for filename, expected in fixture["run_blocks"].items():
+        text = (PROJECT_ROOT / "workflow/rules" / filename).read_text()
+        blocks = re.findall(
+            r"^    run:\n(.*?)(?=^rule |\Z)", text, re.MULTILINE | re.DOTALL
+        )
+        assert [
+            hashlib.sha256(block.encode()).hexdigest() for block in blocks
+        ] == expected

--- a/snakemake/analysis/evals_v2/tests/evals/test_workflow_config.py
+++ b/snakemake/analysis/evals_v2/tests/evals/test_workflow_config.py
@@ -93,3 +93,37 @@ def test_invalid_checkpoint_execution_value_is_rejected(
             inference,
             [{"name": "model", field: value}],
         )
+
+
+def test_documented_fp32_fallback_is_accepted() -> None:
+    inference = dict(_config()["inference"])
+    inference.update(
+        bf16=False, tf32=False, precision_reason="Synthetic bf16 parity failed."
+    )
+    validate_inference_config(inference, [])
+
+
+@pytest.mark.parametrize(
+    "fields",
+    [
+        {"bf16": False},
+        {"bf16": False, "tf32": False},
+        {"bf16": False, "tf32": False, "precision_reason": " "},
+        {"bf16": False, "tf32": True, "precision_reason": "Parity failure"},
+        {"bf16": "false"},
+        {"bf16": True, "tf32": "false"},
+    ],
+)
+def test_incomplete_or_malformed_precision_fallback_is_rejected(fields) -> None:
+    inference = dict(_config()["inference"])
+    inference.update(fields)
+    with pytest.raises(ValueError, match="bf16|tf32|fp32"):
+        validate_inference_config(inference, [])
+
+
+@pytest.mark.parametrize("field", ["tf32", "precision_reason"])
+def test_precision_policy_cannot_be_overridden_by_checkpoint(field) -> None:
+    with pytest.raises(ValueError, match="cannot override"):
+        validate_inference_config(
+            _config()["inference"], [{"name": "model", field: False}]
+        )

--- a/snakemake/analysis/evals_v2/tests/fixtures/legacy_scoring_run_hashes.json
+++ b/snakemake/analysis/evals_v2/tests/fixtures/legacy_scoring_run_hashes.json
@@ -1,0 +1,17 @@
+{
+  "source_commit": "922e41149c8f9bdb3130f780f66163a0241ff045",
+  "run_blocks": {
+    "inference.smk": [
+      "91b1043f513d95e53cdc0213cd32af267b19fda07f27e328b5cd46f281ff48e4"
+    ],
+    "ll_gap.smk": [
+      "6a4356e889e7a1d7ecf1abb74d96ad97676baf6938b3047753b66debf08516dd",
+      "fe4f1b76aa27ea4673f8b09e84b98b5bc15c6763015c9e450cc79a9b3978aff1"
+    ],
+    "embedding_umap.smk": [
+      "10073a29d8c44db047c7bdce51d1cd5bd47fe8dc38b7da847e374ac08138246a",
+      "58eddc76fd1ffb83e10218b591ac7ccf10cc38a66b840fa94d0ee036fc9f060d",
+      "88c9e1c4f75e20e9ca02156b9a86016343db9eca6f06daebae6e365a569cc203"
+    ]
+  }
+}

--- a/snakemake/analysis/evals_v2/tests/model/test_runner_precision.py
+++ b/snakemake/analysis/evals_v2/tests/model/test_runner_precision.py
@@ -1,0 +1,40 @@
+"""Preserve caller precision across Trainer/Accelerate construction."""
+
+from types import SimpleNamespace
+
+import datasets
+import numpy as np
+import pytest
+import torch
+from marin_dna_evals.model.runner import _run_inference
+
+
+@pytest.mark.parametrize("requested", [False, None])
+def test_runner_preserves_explicit_tf32_after_trainer_setup(monkeypatch, requested):
+    monkeypatch.setattr(torch.backends.cuda.matmul, "allow_tf32", False)
+    monkeypatch.setattr(torch.backends.cudnn, "allow_tf32", False)
+
+    class PrecisionOverridingTrainer:
+        def __init__(self, *, model, args):
+            # Reproduce Accelerate's compilation-state initialization.
+            torch.backends.cuda.matmul.allow_tf32 = True
+            torch.backends.cudnn.allow_tf32 = True
+
+        def predict(self, *, test_dataset):
+            expected = requested is None
+            assert torch.backends.cuda.matmul.allow_tf32 is expected
+            assert torch.backends.cudnn.allow_tf32 is expected
+            return SimpleNamespace(predictions=np.asarray([[1.0], [2.0]]))
+
+    monkeypatch.setattr(
+        "marin_dna_evals.model.runner.Trainer", PrecisionOverridingTrainer
+    )
+    result = _run_inference(
+        torch.nn.Identity(),
+        datasets.Dataset.from_dict({"input_ids": [[1], [2]]}),
+        use_cpu=True,
+        per_device_eval_batch_size=2,
+        tf32=requested,
+        report_to="none",
+    )
+    np.testing.assert_array_equal(result, [[1.0], [2.0]])

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -273,3 +273,11 @@ for _d in config["datasets"]:
         f"dataset {_d['name']!r} `probe_feature` must be one of {PAIR_COMBOS}, "
         f"got {_pf!r}"
     )
+
+
+def get_inference_precision():
+    """Output-affecting precision settings and the documented fallback reason."""
+    return {
+        key: config["inference"].get(key)
+        for key in ("bf16", "tf32", "precision_reason")
+    }

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -22,6 +22,7 @@ from marin_dna_evals.metrics import (
 )
 from marin_dna_evals.variant_probe import PAIR_COMBOS, run_subset_probes
 from marin_dna_evals.workflow_config import (
+    inference_precision_params,
     resolve_model_batch_size,
     resolve_model_eval_accumulation_steps,
     validate_inference_config,
@@ -273,11 +274,3 @@ for _d in config["datasets"]:
         f"dataset {_d['name']!r} `probe_feature` must be one of {PAIR_COMBOS}, "
         f"got {_pf!r}"
     )
-
-
-def get_inference_precision():
-    """Output-affecting precision settings and the documented fallback reason."""
-    return {
-        key: config["inference"].get(key)
-        for key in ("bf16", "tf32", "precision_reason")
-    }

--- a/snakemake/analysis/evals_v2/workflow/rules/embedding_umap.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/embedding_umap.smk
@@ -23,6 +23,7 @@ rule compute_region_embeddings:
         model="|".join(UMAP_MODELS),
     threads: config["inference"]["num_workers"]
     params:
+        precision=get_inference_precision(),
         # Output-affecting fields only (snakemake `params` rerun trigger);
         # batch_size is execution-only and read inside `run:`.
         dataset=UMAP_CFG.get("dataset", "songlab/gpn-star-umap-regions"),
@@ -49,7 +50,8 @@ rule compute_region_embeddings:
             ),
             num_workers=config["inference"]["num_workers"],
             torch_compile=config["inference"].get("torch_compile", False),
-            bf16=config["inference"]["bf16"],
+            bf16=params.precision["bf16"],
+            tf32=params.precision["tf32"],
         )
         df.to_parquet(output[0])
         print(

--- a/snakemake/analysis/evals_v2/workflow/rules/embedding_umap.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/embedding_umap.smk
@@ -23,7 +23,7 @@ rule compute_region_embeddings:
         model="|".join(UMAP_MODELS),
     threads: config["inference"]["num_workers"]
     params:
-        precision=get_inference_precision(),
+        **inference_precision_params(config["inference"]),
         # Output-affecting fields only (snakemake `params` rerun trigger);
         # batch_size is execution-only and read inside `run:`.
         dataset=UMAP_CFG.get("dataset", "songlab/gpn-star-umap-regions"),
@@ -50,8 +50,8 @@ rule compute_region_embeddings:
             ),
             num_workers=config["inference"]["num_workers"],
             torch_compile=config["inference"].get("torch_compile", False),
-            bf16=params.precision["bf16"],
-            tf32=params.precision["tf32"],
+            bf16=config["inference"]["bf16"],
+            tf32=config["inference"].get("tf32"),
         )
         df.to_parquet(output[0])
         print(

--- a/snakemake/analysis/evals_v2/workflow/rules/embedding_umap.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/embedding_umap.smk
@@ -51,7 +51,6 @@ rule compute_region_embeddings:
             num_workers=config["inference"]["num_workers"],
             torch_compile=config["inference"].get("torch_compile", False),
             bf16=config["inference"]["bf16"],
-            tf32=config["inference"].get("tf32"),
         )
         df.to_parquet(output[0])
         print(

--- a/snakemake/analysis/evals_v2/workflow/rules/inference.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/inference.smk
@@ -15,6 +15,7 @@ rule compute_scores:
         dataset="|".join(DATASETS),
     threads: config["inference"]["num_workers"]
     params:
+        precision=get_inference_precision(),
         # 255 for BOS-using checkpoints (e.g. exp136), 256 for older runs;
         # the tokenizer baked into each checkpoint handles BOS itself.
         # NOTE: only output-affecting fields belong in `params:` — values
@@ -59,7 +60,8 @@ rule compute_scores:
                 "data_transform_on_the_fly"
             ],
             torch_compile=config["inference"]["torch_compile"],
-            bf16=config["inference"]["bf16"],
+            bf16=params.precision["bf16"],
+            tf32=params.precision["tf32"],
             rc=params.rc,
             return_embeddings=config["inference"]["return_embeddings"],
             eval_accumulation_steps=eval_accumulation_steps,

--- a/snakemake/analysis/evals_v2/workflow/rules/inference.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/inference.smk
@@ -61,7 +61,6 @@ rule compute_scores:
             ],
             torch_compile=config["inference"]["torch_compile"],
             bf16=config["inference"]["bf16"],
-            tf32=config["inference"].get("tf32"),
             rc=params.rc,
             return_embeddings=config["inference"]["return_embeddings"],
             eval_accumulation_steps=eval_accumulation_steps,

--- a/snakemake/analysis/evals_v2/workflow/rules/inference.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/inference.smk
@@ -15,7 +15,7 @@ rule compute_scores:
         dataset="|".join(DATASETS),
     threads: config["inference"]["num_workers"]
     params:
-        precision=get_inference_precision(),
+        **inference_precision_params(config["inference"]),
         # 255 for BOS-using checkpoints (e.g. exp136), 256 for older runs;
         # the tokenizer baked into each checkpoint handles BOS itself.
         # NOTE: only output-affecting fields belong in `params:` — values
@@ -60,8 +60,8 @@ rule compute_scores:
                 "data_transform_on_the_fly"
             ],
             torch_compile=config["inference"]["torch_compile"],
-            bf16=params.precision["bf16"],
-            tf32=params.precision["tf32"],
+            bf16=config["inference"]["bf16"],
+            tf32=config["inference"].get("tf32"),
             rc=params.rc,
             return_embeddings=config["inference"]["return_embeddings"],
             eval_accumulation_steps=eval_accumulation_steps,

--- a/snakemake/analysis/evals_v2/workflow/rules/ll_gap.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/ll_gap.smk
@@ -25,7 +25,7 @@ rule compute_ll_gap:
         region="|".join(LL_GAP_DATASETS),
     threads: config["inference"]["num_workers"]
     params:
-        precision=get_inference_precision(),
+        **inference_precision_params(config["inference"]),
         # Output-affecting fields (snakemake `params` rerun trigger); batch_size
         # is execution-only and read inside `run:`.
         window_size=lambda wc: get_model_config(wc.model)["window_size"],
@@ -46,8 +46,8 @@ rule compute_ll_gap:
             batch_size=batch_size,
             num_workers=config["inference"]["num_workers"],
             torch_compile=config["inference"].get("torch_compile", False),
-            bf16=params.precision["bf16"],
-            tf32=params.precision["tf32"],
+            bf16=config["inference"]["bf16"],
+            tf32=config["inference"].get("tf32"),
         )
         out.to_parquet(output[0], index=False)
         print(

--- a/snakemake/analysis/evals_v2/workflow/rules/ll_gap.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/ll_gap.smk
@@ -25,6 +25,7 @@ rule compute_ll_gap:
         region="|".join(LL_GAP_DATASETS),
     threads: config["inference"]["num_workers"]
     params:
+        precision=get_inference_precision(),
         # Output-affecting fields (snakemake `params` rerun trigger); batch_size
         # is execution-only and read inside `run:`.
         window_size=lambda wc: get_model_config(wc.model)["window_size"],
@@ -45,7 +46,8 @@ rule compute_ll_gap:
             batch_size=batch_size,
             num_workers=config["inference"]["num_workers"],
             torch_compile=config["inference"].get("torch_compile", False),
-            bf16=config["inference"]["bf16"],
+            bf16=params.precision["bf16"],
+            tf32=params.precision["tf32"],
         )
         out.to_parquet(output[0], index=False)
         print(

--- a/snakemake/analysis/evals_v2/workflow/rules/ll_gap.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/ll_gap.smk
@@ -47,7 +47,6 @@ rule compute_ll_gap:
             num_workers=config["inference"]["num_workers"],
             torch_compile=config["inference"].get("torch_compile", False),
             bf16=config["inference"]["bf16"],
-            tf32=config["inference"].get("tf32"),
         )
         out.to_parquet(output[0], index=False)
         print(


### PR DESCRIPTION
Accelerate re-enables TF32 while constructing a compiled Trainer, overriding an explicit `tf32=False` request.
Reapply the requested setting after construction and expose it through the maintained scoring, LL-gap, and embedding paths.
The workflow keeps bfloat16 as its default and permits an fp32 fallback with `bf16: false`, `tf32: false`, and a recorded `precision_reason`.
The fallback settings enter Snakemake scoring provenance.
Default rule parameters and all three existing rule bodies remain unchanged, preserving completed outputs under both the `params` and `code` rerun triggers.

The issue #550 synthetic full-context GPU check now preserves the requested false flag and matches eager fp32: maximum LLR difference 2.84e-5 and pooled-embedding difference 9.54e-7.
Validation: 426 tests passed, 5 skipped; the default 806-job workflow dry-run and repository quality checks passed in CI.
A completed-output fixture using Snakemake 9.25.1 preserves the baseline output under the new default and schedules a parameter-triggered rerun for the explicit fp32 fallback.
Independent review found no remaining material issues.

Deferred for a separate maintenance pass.
Separate the narrow fix that preserves explicit TF32 settings after Trainer construction from the broader fp32 fallback configuration and provenance policy before deciding what to merge.
The completed #550 evaluation used A10G BF16 and does not require that fallback policy.

Closes #561.
