### PR TITLE
Register 10k, 20k, 50k, and final RAG checkpoints for VEP

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,8 +160,13 @@ jobs:
         shell: bash
         run: |
           log_path="$RUNNER_TEMP/snakemake-dry-run.log"
+          config_args=()
+          if [[ "${{ matrix.name }}" == "evals-v2" ]]; then
+            overlay=$(uv run --locked python -m marin_dna_evals.ci_dry_run config/config.yaml "$RUNNER_TEMP")
+            config_args=(--configfile "$overlay")
+          fi
           set +e
-          timeout 60s uv run --locked snakemake -n --quiet all --default-storage-provider none --cores 1 >"$log_path" 2>&1
+          timeout 60s uv run --locked snakemake -n --quiet all --default-storage-provider none --cores 1 "${config_args[@]}" >"$log_path" 2>&1
           status=$?
           set -e
           tail -n 80 "$log_path"

--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -444,6 +444,9 @@ These are tested at `tests/evals/test_grouped_vep_metrics.py`,
 Models with `inference_backend: rag_combined` consume a pinned combined context harness from `vertebrate_projection_dataset`.
 Register each model's exact checkpoint, `window_size: 255`, `document_tokens: 10240`, the three datasets (`mendelian_traits`, `complex_traits`, `sge`), and `rag_harness: {uri: ..., sha256: ...}` before evaluation.
 Submit the exact model–dataset registration as a small PR.
+The offline CI dry-run uses `python -m marin_dna_evals.ci_dry_run config/config.yaml <temporary-directory>` to generate a temporary model overlay with empty local harness stubs.
+It retains every registered model, checkpoint, cohort, and checksum while validating the DAG without S3 credentials.
+Use that overlay only with `snakemake -n`; production uses the registered harness URI and verifies its checksum before inference.
 The backend accepts only the canonical development split and checks every source row, revision-derived identity, coordinate, allele, label, and namespaced group against the registered canonical dataset revisions before loading the model.
 
 Requesting any one of the model's three score files schedules one combined job that writes all three canonical outputs in `results/scores/{model}/{dataset}.parquet`.

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -76,7 +76,7 @@ datasets:
 models:
   # Issue 550: final 100,000-update checkpoint; evaluation waits for its export.
   - name: dna-exp550-rag46m-five-regions-v1-step-100000
-    gcs_path: gs://marin-us-east1/MarinDNA/exp550_rag_five_regions/checkpoints/dna-exp550-rag46m-five-regions-v1/2026.09.10.7/hf/step-100000
+    gcs_path: gs://marin-us-east5/MarinDNA/exp550_rag_five_regions/checkpoints/dna-exp550-rag46m-five-regions-v1/2026.09.10.8/hf/step-100000
     inference_backend: rag_combined
     window_size: 255
     document_tokens: 10240

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -74,6 +74,19 @@ datasets:
 # `return_embeddings`, `torch_compile`, and `bf16` are global inference settings
 # and are rejected on model entries.
 models:
+  # Issue 550: first 10,000-update checkpoint, requested for development VEP.
+  - name: dna-exp550-rag46m-five-regions-v1-step-10000
+    gcs_path: gs://marin-eu-west4/MarinDNA/exp550_rag_five_regions/checkpoints/dna-exp550-rag46m-five-regions-v1/2026.09.10.9/hf/step-10000
+    inference_backend: rag_combined
+    window_size: 255
+    document_tokens: 10240
+    batch_size: 2
+    eval_accumulation_steps: 8
+    datasets: [mendelian_traits, complex_traits, sge]
+    rag_harness:
+      uri: s3://oa-bolinas/snakemake/vertebrate_projection_dataset/results/rag-five-regions-v1/6b1593c274a886d20f5c0ddf3712916d446f5fed/10ba63bc375ba912909b82cda68143df4677431124fc8e15f6ac42850ce0fca6/full/rag/evaluation/combined_development.parquet
+      sha256: 6631d35f9ae0afc754c623a2e3960682e8a834a28001906279745882f99cb73b
+
   # Issue 550: final 100,000-update checkpoint; evaluation waits for its export.
   - name: dna-exp550-rag46m-five-regions-v1-step-100000
     gcs_path: gs://marin-eu-west4/MarinDNA/exp550_rag_five_regions/checkpoints/dna-exp550-rag46m-five-regions-v1/2026.09.10.9/hf/step-100000
@@ -1399,6 +1412,8 @@ probe:
     # Explicit per-model `datasets` (not derived): probing a legacy cell still
     # requires its existing score parquet to contain emb_ref/emb_alt. Add cells
     # here after confirming that schema or explicitly re-scoring the target.
+    - name: dna-exp550-rag46m-five-regions-v1-step-10000
+      datasets: [mendelian_traits, complex_traits, sge]
     - name: dna-exp550-rag46m-five-regions-v1-step-100000
       datasets: [mendelian_traits, complex_traits, sge]
     - name: mix-v0.9-p1B-i24-exp135-m5.1-step-59158

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -80,7 +80,20 @@ models:
     inference_backend: rag_combined
     window_size: 255
     document_tokens: 10240
-    batch_size: 2
+    batch_size: 8
+    eval_accumulation_steps: 8
+    datasets: [mendelian_traits, complex_traits, sge]
+    rag_harness:
+      uri: s3://oa-bolinas/snakemake/vertebrate_projection_dataset/results/rag-five-regions-v1/6b1593c274a886d20f5c0ddf3712916d446f5fed/10ba63bc375ba912909b82cda68143df4677431124fc8e15f6ac42850ce0fca6/full/rag/evaluation/combined_development.parquet
+      sha256: 6631d35f9ae0afc754c623a2e3960682e8a834a28001906279745882f99cb73b
+
+  # Issue 550: 20,000-update checkpoint, requested for development VEP.
+  - name: dna-exp550-rag46m-five-regions-v1-step-20000
+    gcs_path: gs://marin-eu-west4/MarinDNA/exp550_rag_five_regions/checkpoints/dna-exp550-rag46m-five-regions-v1/2026.09.10.9/hf/step-20000
+    inference_backend: rag_combined
+    window_size: 255
+    document_tokens: 10240
+    batch_size: 8
     eval_accumulation_steps: 8
     datasets: [mendelian_traits, complex_traits, sge]
     rag_harness:
@@ -93,7 +106,7 @@ models:
     inference_backend: rag_combined
     window_size: 255
     document_tokens: 10240
-    batch_size: 2
+    batch_size: 8
     eval_accumulation_steps: 8
     datasets: [mendelian_traits, complex_traits, sge]
     rag_harness:
@@ -1413,6 +1426,8 @@ probe:
     # requires its existing score parquet to contain emb_ref/emb_alt. Add cells
     # here after confirming that schema or explicitly re-scoring the target.
     - name: dna-exp550-rag46m-five-regions-v1-step-10000
+      datasets: [mendelian_traits, complex_traits, sge]
+    - name: dna-exp550-rag46m-five-regions-v1-step-20000
       datasets: [mendelian_traits, complex_traits, sge]
     - name: dna-exp550-rag46m-five-regions-v1-step-100000
       datasets: [mendelian_traits, complex_traits, sge]

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -74,6 +74,19 @@ datasets:
 # `return_embeddings`, `torch_compile`, and `bf16` are global inference settings
 # and are rejected on model entries.
 models:
+  # Issue 550: final 100,000-update checkpoint; evaluation waits for its export.
+  - name: dna-exp550-rag46m-five-regions-v1-step-100000
+    gcs_path: gs://marin-us-east1/MarinDNA/exp550_rag_five_regions/checkpoints/dna-exp550-rag46m-five-regions-v1/2026.09.10.7/hf/step-100000
+    inference_backend: rag_combined
+    window_size: 255
+    document_tokens: 10240
+    batch_size: 2
+    eval_accumulation_steps: 8
+    datasets: [mendelian_traits, complex_traits, sge]
+    rag_harness:
+      uri: s3://oa-bolinas/snakemake/vertebrate_projection_dataset/results/rag-five-regions-v1/6b1593c274a886d20f5c0ddf3712916d446f5fed/10ba63bc375ba912909b82cda68143df4677431124fc8e15f6ac42850ce0fca6/full/rag/evaluation/combined_development.parquet
+      sha256: 6631d35f9ae0afc754c623a2e3960682e8a834a28001906279745882f99cb73b
+
   # Final-step entries for the exp55/58/59 evolutionary-timescale runs.
   # Scoped to mendelian_traits to match what's actually been computed on
   # S3 — these were rerun via per-target invocations after the AUPRC
@@ -1386,6 +1399,8 @@ probe:
     # Explicit per-model `datasets` (not derived): probing a legacy cell still
     # requires its existing score parquet to contain emb_ref/emb_alt. Add cells
     # here after confirming that schema or explicitly re-scoring the target.
+    - name: dna-exp550-rag46m-five-regions-v1-step-100000
+      datasets: [mendelian_traits, complex_traits, sge]
     - name: mix-v0.9-p1B-i24-exp135-m5.1-step-59158
       datasets: [mendelian_traits]
 

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -76,7 +76,7 @@ datasets:
 models:
   # Issue 550: final 100,000-update checkpoint; evaluation waits for its export.
   - name: dna-exp550-rag46m-five-regions-v1-step-100000
-    gcs_path: gs://marin-us-east5/MarinDNA/exp550_rag_five_regions/checkpoints/dna-exp550-rag46m-five-regions-v1/2026.09.10.8/hf/step-100000
+    gcs_path: gs://marin-eu-west4/MarinDNA/exp550_rag_five_regions/checkpoints/dna-exp550-rag46m-five-regions-v1/2026.09.10.9/hf/step-100000
     inference_backend: rag_combined
     window_size: 255
     document_tokens: 10240

--- a/snakemake/analysis/evals_v2/src/marin_dna_evals/ci_dry_run.py
+++ b/snakemake/analysis/evals_v2/src/marin_dna_evals/ci_dry_run.py
@@ -1,0 +1,40 @@
+"""Prepare local harness stubs for an offline CI DAG dry-run only."""
+
+import argparse
+from pathlib import Path
+from tempfile import mkdtemp
+
+import yaml
+
+
+def prepare_overlay(config_path: Path, output_directory: Path) -> Path:
+    """Preserve registered models while replacing RAG harness URIs with local stubs.
+
+    The stubs contain no data and cannot pass the production checksum validation.
+    Only use this overlay with Snakemake's dry-run option.
+    """
+    config = yaml.safe_load(config_path.read_text())
+    output_directory.mkdir(parents=True, exist_ok=True)
+    temporary = Path(mkdtemp(prefix="evals-v2-dry-run-", dir=output_directory))
+    models = config["models"]
+    for index, model in enumerate(models):
+        if model.get("inference_backend") != "rag_combined":
+            continue
+        harness = temporary / f"harness-{index}.parquet"
+        harness.touch()
+        model["rag_harness"]["uri"] = str(harness.resolve())
+    overlay = temporary / "config.yaml"
+    overlay.write_text(yaml.safe_dump({"models": models}, sort_keys=False))
+    return overlay
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("config", type=Path)
+    parser.add_argument("output_directory", type=Path)
+    args = parser.parse_args()
+    print(prepare_overlay(args.config, args.output_directory))
+
+
+if __name__ == "__main__":
+    main()

--- a/snakemake/analysis/evals_v2/tests/evals/test_rag_workflow.py
+++ b/snakemake/analysis/evals_v2/tests/evals/test_rag_workflow.py
@@ -1,15 +1,76 @@
 """Explicit model registration and one-job routing for the combined backend."""
 
 import copy
+import os
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 import yaml
+from marin_dna_evals.ci_dry_run import prepare_overlay
 from marin_dna_evals.workflow_config import validate_rag_models
 
 PROJECT = Path(__file__).parents[2]
+
+
+def test_registered_models_dry_run_offline_without_changing_contracts(tmp_path):
+    source = PROJECT / "config/config.yaml"
+    original_text = source.read_text()
+    original = yaml.safe_load(original_text)
+    overlay = prepare_overlay(source, tmp_path)
+    rewritten = yaml.safe_load(overlay.read_text())
+    assert set(rewritten) == {"models"}
+    assert source.read_text() == original_text
+    assert len(rewritten["models"]) == len(original["models"])
+    rag_models = []
+    for before, after in zip(original["models"], rewritten["models"], strict=True):
+        restored = copy.deepcopy(after)
+        if before.get("inference_backend") == "rag_combined":
+            rag_models.append(before)
+            stub = Path(after["rag_harness"]["uri"])
+            assert stub.is_file() and stub.stat().st_size == 0
+            restored["rag_harness"]["uri"] = before["rag_harness"]["uri"]
+        assert restored == before
+    assert rag_models, "exercise the registered combined RAG path"
+    environment = {
+        key: value for key, value in os.environ.items() if not key.startswith("AWS_")
+    }
+    environment.update(
+        AWS_EC2_METADATA_DISABLED="true",
+        AWS_CONFIG_FILE=str(tmp_path / "absent-aws-config"),
+        AWS_SHARED_CREDENTIALS_FILE=str(tmp_path / "absent-aws-credentials"),
+    )
+    result = subprocess.run(
+        [
+            str(Path(sys.executable).with_name("snakemake")),
+            "all",
+            "--snakefile",
+            str(PROJECT / "workflow/Snakefile"),
+            "--directory",
+            str(PROJECT),
+            "--workflow-profile",
+            "none",
+            "--default-storage-provider",
+            "none",
+            "--configfile",
+            str(overlay),
+            "--cores",
+            "1",
+            "--dry-run",
+        ],
+        env=environment,
+        text=True,
+        capture_output=True,
+        timeout=90,
+        check=False,
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert output.count("rule compute_rag_scores:") == len(rag_models)
+    for model in rag_models:
+        for dataset in model["datasets"]:
+            assert f"results/scores/{model['name']}/{dataset}.parquet" in output
 
 
 def model_config():


### PR DESCRIPTION
Closed without merging after the approved [post-experiment triage](https://github.com/Open-Athena/marin-dna/blob/7efe323cdad12cd6098c93667169858ebdcdffe3/.agents/artifacts/issue-550/remaining-work-triage.md).
These checkpoint registrations and their CI scaffolding belong to the completed experiment and do not need promotion into the default mainline workflow.
The [reviewed source snapshot](https://github.com/Open-Athena/marin-dna/tree/0253beb83294f3c060df30fa6bf3a21be80c1870) is preserved, and the integrated execution code and results remain on the permanent branch for #550.

Register the 10k, 20k, halfway 50k, and final 100k checkpoints from #550 for combined RAG scoring and frozen probes on the Mendelian, Complex Traits, and SGE development cohorts.
The entries pin the europe-west4 version-9 GCS exports, the existing combined harness and SHA-256, 255-base human windows, and 10,240-token documents.
Batch size 8 uses the measured fastest stable A10G BF16 configuration with shared-prefix caching and embeddings.

The 10k and 20k evaluations are complete and checksum-verified in canonical S3.
The final checkpoint completed development VEP and frozen probes on September 14 after 441 worker tests passed with five skips and an inspected ten-job production dry-run.
All 15 final outputs are checksum-verified in canonical S3; the [completion receipt](https://github.com/Open-Athena/marin-dna/blob/a949e8f79fd0e3453406c7ae27d3e2f15ef1ae7c/.agents/artifacts/issue-550/evaluation/step-100000-completed.json) pins the execution and output identities.
The halfway 50k checkpoint also completed development VEP and frozen probes on September 14; its [completion receipt](https://github.com/Open-Athena/marin-dna/blob/c5f1fb9fca6d143eb5800902a2af659f54d1af7e/.agents/artifacts/issue-550/evaluation/step-50000-completed.json) verifies all 15 outputs, and the worker is terminated.

Depends on #554 for the combined cached backend and #559 for tokenizer compatibility.
The credential-free CI dry-run substitutes temporary local harness paths while preserving the full model registry; production uses the normal S3 profile and checksum checks.

All CI checks pass on the expanded registration, including the locked evals_v2 tests and credential-free dry-run.
Independent review found no remaining issues.
The 50k worker passed 441 locked tests with five skips, a fresh synthetic batch-8 check at 5.705 variants per second, and an inspected ten-job default-S3 production dry-run before biological execution.
Part of #550.
