### PR TITLE
Prefer EC2 A10G GPUs for future VEP runs

### DIFF
--- a/.agents/skills/evaluate-models/SKILL.md
+++ b/.agents/skills/evaluate-models/SKILL.md
@@ -7,6 +7,11 @@ description: Protect held-out labeled variant-effect prediction data and design,
 
 Apply these rules before computing aggregates or choosing tables and plots.
 
+## Choose VEP Compute
+
+Prefer NVIDIA A10G GPUs on Amazon EC2 for new VEP runs within the task's approved compute budget.
+Use another accelerator when capacity or workload requirements call for it, or when the user chooses it.
+
 ## Protect Held-Out VEP Data
 
 - Use odd-numbered autosomes and chromosome X for development, training, validation, model selection, probing, and tuning on labeled variant-effect prediction data.


### PR DESCRIPTION
Prefer NVIDIA A10G GPUs on Amazon EC2 when planning new VEP runs, following the user's standing hardware preference.
The guidance retains the task's approved budget and allows alternatives when capacity or workload requirements call for them.

The skill validator and whitespace check pass.

Deferred as standalone evaluation guidance; the recorded EC2 A10G preference can be adopted independently of the completed #550 experiment.
