### PR TITLE
Record local k-mer homology retrieval and indexing limits

### DIFF
--- a/docs/research/experiments/568-kmer-conservation.md
+++ b/docs/research/experiments/568-kmer-conservation.md
@@ -1,0 +1,114 @@
+# Local k-mer retrieval of mammalian homologs
+
+> [!NOTE]
+> **TL;DR:** Complete local k-mer sets recover 97.1% of held-out mammalian homology pairs at ten candidate loci, but the tested MinHash/LSH settings do not improve the recall–runtime frontier over exact indexes; the study stops before conservation selection or training.
+
+## Findings
+
+The full-set similarity signal is useful for recovering known homologs in this bounded fixture.
+The development-selected W255/k9 representation recovered 204 of 210 held-out physical locus pairs at ten unique candidates per query: 97.1% recall, with a 95% grouped-bootstrap interval of 94.9–99.1%.
+This is evidence of local sequence similarity, not evidence that an entire retrieved window is evolutionarily constrained.
+
+Do not advance the tested MinHash/LSH recipe to a conservation selector.
+Every development LSH setting that passed the prespecified recall and injected-decoy thresholds was slower than an exact-index setting with equal or higher recall, and the frozen held-out comparisons retained that disadvantage.
+A small development runtime tradeoff for exhaustive MinHash scanning did not persist against the frozen exact controls on held-out loci; sketch construction also raised total measured preparation-plus-query cost.
+These are results for the sampled sketch sizes and implementations, not a general impossibility result for genomic sketching.
+
+Window geometry and acceptance criteria remain separate limitations.
+Local windows helped isolate short synthetic tracts, but denser tiling and a two-scale union did not improve aggregate held-out recall over the selected single scale.
+Requiring a global match across an independently tiled window discarded many retrieved homologs, and similar target copies made the designated partner ambiguous.
+
+## Evidence
+
+The benchmark regenerated #521's 128 human/mouse/armadillo homology controls from pinned projection inputs, added 128 anchors, and expanded every projected center to a 4,096 bp genomic context.
+The original assemblies were retained, and all 768 central 255 bp sequences matched their source projections up to reverse complement.
+The fixed target universe included 3,000 random genomic contexts, 768 contexts matched for GC, repeat fraction, and coarse sequence complexity, 192 repeat-rich challenges, and 768 injected shuffled decoys.
+
+Homologs and overlapping contexts were assigned together to 87 development and 65 held-out split groups before tuning.
+Queries and candidates were counted as physical loci connected by within-species genomic overlap; disjoint homologous intervals remained separate candidates.
+Recall counted every known source-locus/target-locus pair, with each query spending its candidate budget once.
+The primary budget was ten unique candidate loci per query, with one and 100 also reported.
+The held-out evaluation comprised 210 known pairs from 204 queries in 65 split groups.
+Confidence intervals resampled split groups 2,000 times with a fixed seed; the many secondary controls are descriptive comparisons, not a new held-out selection procedure.
+
+The development screen crossed five window lengths (64, 128, 255, 511, and 1,024 bp) with four canonical k-mer lengths (9, 13, 17, and 21) at half-window stride.
+Full, half, and quarter strides, repeat masking, whole-context scoring, and a budget-preserving scale union were follow-up controls.
+Each setting covered the same contexts, used independent species/contig tiling phases, and skipped k-mers spanning ambiguous bases.
+Complete-set Jaccard scores used an exact inverted index; MinHash scans and compatible banded LSH used the same input windows and candidate universe.
+Matched Linclust included its intrinsic alignment filtering, while a separate edit-distance diagnostic measured the loss from requiring a full-window match after exact retrieval.
+
+<p align="center">
+  <img src="figures/568/window-screen.svg" alt="Development recall across five window lengths: k9 performs best, with its highest observed recall at 255 bp; grouped confidence intervals overlap across neighboring widths." />
+</p>
+
+_Development known-pair recall at ten unique candidates; 274 pairs in 87 split groups, complete canonical k-mer sets, and half-window stride.
+Error bars are 95% percentile intervals from 2,000 split-group bootstrap resamples.
+The selected width is a study choice, not an established optimum._
+
+| Frozen held-out setting | Recall at C=10 (95% CI) | Query time (s) | Cold stages (s) | Index (MB) |
+|---|---:|---:|---:|---:|
+| Full sets, W255/k9 | 97.1% (94.9–99.1) | 11.67 | 25.0 | 221.4 |
+| MinHash scan, W255/k9, H512 | 95.7% (92.5–98.5) | 9.65 | 66.7 | 463.5 |
+| LSH, W255/k9, H512, r2 | 95.7% (92.4–98.5) | 11.32 | 71.8 | 811.1 |
+| Linclust, W255 | 42.4% (36.6–49.3) | 0.18 | — | — |
+| Full sets, W511/k9 | 97.1% (94.7–99.1) | 7.82 | 21.2 | 224.5 |
+| Full sets, W1024/k13 | 95.2% (91.8–98.0) | 1.27 | 15.1 | 346.9 |
+| MinHash scan, W1024/k13, H512 | 90.0% (85.3–94.0) | 0.95 | 62.7 | 116.2 |
+| LSH, W1024/k13, H512, r1 | 90.0% (85.3–94.0) | 6.05 | 69.0 | 290.5 |
+| LSH, W1024/k13, H512, r2 | 51.0% (42.4–60.0) | 2.54 | 65.1 | 203.3 |
+| Linclust, W1024 | 18.1% (12.0–25.1) | 0.07 | — | — |
+| Full sets, W4096/k13 | 96.7% (94.0–98.7) | 0.80 | 12.0 | 238.8 |
+
+All tabulated settings use half-window stride; W4096 scores each entire context once.
+Cold-stage sums add feature, uncached sketch, and index construction to query time, excluding cache/prediction serialization.
+Linclust's unprofiled FASTA export prevents a complete comparable cold-stage figure; its query time is conditional on clustering already having run.
+Index MB are decimal bytes for both target species' postings or signatures plus bucket arrays; they exclude shared window metadata and are not process memory.
+
+<p align="center">
+  <img src="figures/568/index-frontier.svg" alt="Development comparison of full sets, MinHash scans, and LSH: larger sketches preserve more recall, while permissive LSH buckets increase lookup time and selective buckets lose recall." />
+</p>
+
+_Development query time against prepared indexes, with W and k fixed within each panel.
+MinHash signatures contain 32, 128, or 512 affine64 permutation minima; LSH crosses those sizes with one, two, or four rows per band and rescores the retrieved signatures.
+Error bars use the same grouped bootstrap; runtime uncertainty was not estimated.
+The full exact baseline matrix, including other window/k settings, determines the recall–runtime frontier._
+
+At W255/k9, full-, half-, and quarter-window strides gave 95.7%, 97.1%, and 97.1% held-out recall, with 90,086, 169,817, and 331,134 total input windows and 5.35, 11.67, and 33.25 seconds of query work.
+The frozen scale union reached 96.7% while paying both retrieval costs.
+For W1024/k13, masking raised recall from 95.2% to 96.7% and cut query time from 1.27 to 0.49 seconds, but increased the injected shuffled-decoy share of top-ten candidates from 0.54% to 7.84%.
+Unmasked W255/k9 had a 0.64% shuffled-decoy share; its species-pair recalls were 97.2% for human/mouse, 100% for human/armadillo, and 94.3% for mouse/armadillo.
+The 24 known pairs in majority-repeat query contexts had 83.3% recall, with a wide 66.7–96.0% interval.
+
+A separate global-edit-distance gate, allowing at most 30% edits across the best-scoring full window in either orientation, reduced held-out recall at ten candidates to 31.0% at W255 and 13.8% at W1024.
+The C=100 profiles made 40,800 strand-specific alignment calls per setting and took 7.41 or 6.35 seconds after approximately 11 seconds of feature preparation.
+They did not backfill candidates and are not a general ceiling on local alignment sensitivity.
+
+Synthetic controls planted 32–1,024 bp tracts in independent 4,096 bp flanks, with target-branch substitution probabilities of 0%, 15%, or 30% and indel probabilities of 0% or 3%.
+At k=9, W255 recovered 67.1% of the 216 designated pairs at ten candidates, versus 53.2% for whole-context scoring.
+For 32 bp tracts, the corresponding recalls were 41.7% and 22.2%; at W255, increasing the target-branch substitution probability from 0% to 30% reduced aggregate recall from 100% to 34.7%.
+The mouse/armadillo pair accumulated independent mutations on both branches, so this probability is not its pairwise divergence.
+Adding ten similarly mutated target copies per locus reduced W255/k9 recovery of the designated partner at one candidate from 62.5% to 9.3%.
+Those copies are competing homologs, so the result demonstrates partner ambiguity rather than validated false-positive retrieval.
+
+## Limitations
+
+These are projected homology controls, not labels of evolutionary constraint or conservation across each entire context.
+The target universe is small and enriched for known partners; unannotated genomic hits are unresolved, so shuffled-decoy contamination is not validated precision.
+The background contexts do not provide an unbiased set of independently annotated query homologs for a conservation-enrichment test.
+GC and repeat fractions were closely matched, but three-mer richness largely saturated in these long contexts and did not provide a strong complexity control.
+The study did not stratify by annotated repeat family, and the duplicated synthetic tracts are paralog-like competitors rather than curated biological paralogs.
+
+The synthetic mutation grid has two replicates per setting and serves as a mechanism check.
+The real benchmark covers three mammals and partly reuses the earlier control cohort; it does not establish a result for distant species or whole genomes.
+Timings describe these implementations on one 16-vCPU EC2 worker, with a single timing per setting; runtime variation and production scaling were not measured.
+The MinHash scan used eight threads, while exact sparse scoring and Python LSH orchestration used one.
+Peak Python memory and external MMseqs2 memory were measured separately, and cached construction was separated from query time.
+No genome-scale index, conservation selector, or training comparison was run.
+
+## Related questions
+
+- [Which genomic regions to train on, and how to find them?](../questions/training-regions.md)
+
+## Research record
+
+- [Experiment #568](https://github.com/Open-Athena/marin-dna/issues/568)

--- a/docs/research/experiments/figures/568/index-frontier.svg
+++ b/docs/research/experiments/figures/568/index-frontier.svg
@@ -1,0 +1,826 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="720pt" height="360pt" viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-09-11T22:18:24.789617</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.2, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 360
+L 720 360
+L 720 0
+L 0 0
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 45.997349 326.715864
+L 356.4 326.715864
+L 356.4 16.313214
+L 45.997349 16.313214
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="mc3e7cb0d4e" d="M 0 0
+L 0 3.5
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mc3e7cb0d4e" x="93.162662" y="326.715864" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="93.162662" y="342.073286" transform="rotate(-0 93.162662 342.073286)">1</text>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#mc3e7cb0d4e" x="191.082828" y="326.715864" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="191.082828" y="342.073286" transform="rotate(-0 191.082828 342.073286)">10</text>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#mc3e7cb0d4e" x="289.002995" y="326.715864" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="289.002995" y="342.073286" transform="rotate(-0 289.002995 342.073286)">100</text>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <defs>
+       <path id="m1710dfac6c" d="M 0 0
+L 0 2
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m1710dfac6c" x="54.19631" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="63.685755" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="71.439196" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="77.994636" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="83.673217" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="88.682081" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="122.639569" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="139.882455" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="152.116477" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="161.605921" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="169.359362" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="175.914803" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="181.593384" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="186.602247" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="220.559736" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="237.802621" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="250.036643" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="259.526088" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="267.279528" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="273.834969" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="279.51355" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="284.522414" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="318.479902" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="335.722788" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="347.956809" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_4">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="201.198675" y="357.074146" transform="rotate(-0 201.198675 357.074146)">Query wall time (s)</text>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_29">
+      <defs>
+       <path id="m8dea749581" d="M 0 0
+L -3.5 0
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m8dea749581" x="45.997349" y="326.715864" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.997349" y="330.894575" transform="rotate(-0 38.997349 330.894575)">0</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m8dea749581" x="45.997349" y="265.249993" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.997349" y="269.428704" transform="rotate(-0 38.997349 269.428704)">20</text>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#m8dea749581" x="45.997349" y="203.784122" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.997349" y="207.962832" transform="rotate(-0 38.997349 207.962832)">40</text>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m8dea749581" x="45.997349" y="142.31825" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.997349" y="146.496961" transform="rotate(-0 38.997349 146.496961)">60</text>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#m8dea749581" x="45.997349" y="80.852379" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.997349" y="85.03109" transform="rotate(-0 38.997349 85.03109)">80</text>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m8dea749581" x="45.997349" y="19.386507" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="38.997349" y="23.565218" transform="rotate(-0 38.997349 23.565218)">100</text>
+     </g>
+    </g>
+    <g id="text_11">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="11.358521" y="171.514539" transform="rotate(-90 11.358521 171.514539)">Known-pair recall at C=10 (%)</text>
+    </g>
+   </g>
+   <g id="LineCollection_1">
+    <path d="M 205.884488 37.163283
+L 205.884488 21.589193
+" clip-path="url(#p5aaf595626)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+   </g>
+   <g id="LineCollection_2">
+    <path d="M 171.188954 61.743071
+L 171.188954 34.69119
+" clip-path="url(#p5aaf595626)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.5"/>
+    <path d="M 150.753416 132.502133
+L 150.753416 88.563964
+" clip-path="url(#p5aaf595626)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.5"/>
+    <path d="M 197.905212 40.509661
+L 197.905212 21.741074
+" clip-path="url(#p5aaf595626)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.5"/>
+   </g>
+   <g id="LineCollection_3">
+    <path d="M 258.3107 61.743071
+L 258.3107 34.69119
+" clip-path="url(#p5aaf595626)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 141.472095 98.982781
+L 141.472095 56.213142
+" clip-path="url(#p5aaf595626)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 110.254641 270.638963
+L 110.254641 223.095238
+" clip-path="url(#p5aaf595626)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 195.76677 132.502133
+L 195.76677 88.563964
+" clip-path="url(#p5aaf595626)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 88.631292 164.394021
+L 88.631292 118.781253
+" clip-path="url(#p5aaf595626)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 60.106561 302.310684
+L 60.106561 265.249993
+" clip-path="url(#p5aaf595626)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 342.290789 40.509661
+L 342.290789 21.741074
+" clip-path="url(#p5aaf595626)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 204.197446 47.133839
+L 204.197446 26.344254
+" clip-path="url(#p5aaf595626)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 167.289061 243.007443
+L 167.289061 190.115447
+" clip-path="url(#p5aaf595626)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+   </g>
+   <g id="line2d_35">
+    <defs>
+     <path id="m93f7e6b8ac" d="M 0 3
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132
+C 2.683901 1.55874 3 0.795609 3 0
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
+C 1.55874 -2.683901 0.795609 -3 0 -3
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132
+C -2.683901 -1.55874 -3 -0.795609 -3 0
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132
+C -1.55874 2.683901 -0.795609 3 0 3
+z
+" style="stroke: #1f77b4"/>
+    </defs>
+    <g clip-path="url(#p5aaf595626)">
+     <use xlink:href="#m93f7e6b8ac" x="205.884488" y="28.359627" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="line2d_36">
+    <defs>
+     <path id="me396965dfb" d="M 0 3
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132
+C 2.683901 1.55874 3 0.795609 3 0
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
+C 1.55874 -2.683901 0.795609 -3 0 -3
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132
+C -2.683901 -1.55874 -3 -0.795609 -3 0
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132
+C -1.55874 2.683901 -0.795609 3 0 3
+z
+" style="stroke: #ff7f0e"/>
+    </defs>
+    <g clip-path="url(#p5aaf595626)">
+     <use xlink:href="#me396965dfb" x="171.188954" y="47.427507" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#me396965dfb" x="150.753416" y="110.239346" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#me396965dfb" x="197.905212" y="30.602907" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+    </g>
+   </g>
+   <g id="line2d_37">
+    <defs>
+     <path id="m6fe8dd9fab" d="M 0 3
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132
+C 2.683901 1.55874 3 0.795609 3 0
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
+C 1.55874 -2.683901 0.795609 -3 0 -3
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132
+C -2.683901 -1.55874 -3 -0.795609 -3 0
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132
+C -1.55874 2.683901 -0.795609 3 0 3
+z
+" style="stroke: #2ca02c"/>
+    </defs>
+    <g clip-path="url(#p5aaf595626)">
+     <use xlink:href="#m6fe8dd9fab" x="258.3107" y="47.427507" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m6fe8dd9fab" x="141.472095" y="76.590147" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m6fe8dd9fab" x="110.254641" y="247.079425" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m6fe8dd9fab" x="195.76677" y="110.239346" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m6fe8dd9fab" x="88.631292" y="141.645266" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m6fe8dd9fab" x="60.106561" y="285.215185" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m6fe8dd9fab" x="342.290789" y="30.602907" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m6fe8dd9fab" x="204.197446" y="36.211107" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m6fe8dd9fab" x="167.289061" y="216.795145" style="fill: #2ca02c; stroke: #2ca02c"/>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 45.997349 326.715864
+L 45.997349 16.313214
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 356.4 326.715864
+L 356.4 16.313214
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 45.997349 326.715864
+L 356.4 326.715864
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 45.997349 16.313214
+L 356.4 16.313214
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_12">
+    <text style="font-size: 13.2px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="201.198675" y="10.313214" transform="rotate(-0 201.198675 10.313214)">W=255, k=9</text>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 406.597109 326.715864
+L 716.99976 326.715864
+L 716.99976 16.313214
+L 406.597109 16.313214
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_29">
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#mc3e7cb0d4e" x="419.10197" y="326.715864" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="419.10197" y="342.073286" transform="rotate(-0 419.10197 342.073286)">0.2</text>
+     </g>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#mc3e7cb0d4e" x="547.553593" y="326.715864" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="547.553593" y="342.073286" transform="rotate(-0 547.553593 342.073286)">1.0</text>
+     </g>
+    </g>
+    <g id="xtick_31">
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#mc3e7cb0d4e" x="676.005215" y="326.715864" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="676.005215" y="342.073286" transform="rotate(-0 676.005215 342.073286)">5.0</text>
+     </g>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="451.46274" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_33">
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="474.423073" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_34">
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="492.23249" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_35">
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="506.783843" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_36">
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="519.086837" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_37">
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="529.744175" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_38">
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="539.144614" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_39">
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="602.874695" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_40">
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="635.235466" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_41">
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="658.195798" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_42">
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="690.556569" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_43">
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="702.859563" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_44">
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#m1710dfac6c" x="713.516901" y="326.715864" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_16">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="561.798435" y="357.074146" transform="rotate(-0 561.798435 357.074146)">Query wall time (s)</text>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_7">
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#m8dea749581" x="406.597109" y="326.715864" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="399.597109" y="330.894575" transform="rotate(-0 399.597109 330.894575)">0</text>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#m8dea749581" x="406.597109" y="265.249993" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="399.597109" y="269.428704" transform="rotate(-0 399.597109 269.428704)">20</text>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#m8dea749581" x="406.597109" y="203.784122" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="399.597109" y="207.962832" transform="rotate(-0 399.597109 207.962832)">40</text>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#m8dea749581" x="406.597109" y="142.31825" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="399.597109" y="146.496961" transform="rotate(-0 399.597109 146.496961)">60</text>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#m8dea749581" x="406.597109" y="80.852379" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="399.597109" y="85.03109" transform="rotate(-0 399.597109 85.03109)">80</text>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_59">
+      <g>
+       <use xlink:href="#m8dea749581" x="406.597109" y="19.386507" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="399.597109" y="23.565218" transform="rotate(-0 399.597109 23.565218)">100</text>
+     </g>
+    </g>
+    <g id="text_23">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="371.958281" y="171.514539" transform="rotate(-90 371.958281 171.514539)">Known-pair recall at C=10 (%)</text>
+    </g>
+   </g>
+   <g id="LineCollection_4">
+    <path d="M 577.535372 51.448938
+L 577.535372 28.491722
+" clip-path="url(#p64b47052c6)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+   </g>
+   <g id="LineCollection_5">
+    <path d="M 478.915925 105.616577
+L 478.915925 63.791509
+" clip-path="url(#p64b47052c6)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.5"/>
+    <path d="M 420.706321 178.010557
+L 420.706321 126.07849
+" clip-path="url(#p64b47052c6)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.5"/>
+    <path d="M 555.046248 61.059578
+L 555.046248 35.026758
+" clip-path="url(#p64b47052c6)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.5"/>
+   </g>
+   <g id="LineCollection_6">
+    <path d="M 580.535744 105.616577
+L 580.535744 63.791509
+" clip-path="url(#p64b47052c6)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 530.597494 257.959926
+L 530.597494 209.906842
+" clip-path="url(#p64b47052c6)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 507.558485 325.65975
+L 507.558485 317.507494
+" clip-path="url(#p64b47052c6)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 487.767704 178.010557
+L 487.767704 126.07849
+" clip-path="url(#p64b47052c6)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 440.635247 296.522103
+L 440.635247 260.44927
+" clip-path="url(#p64b47052c6)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 424.144897 326.715864
+L 424.144897 319.031942
+" clip-path="url(#p64b47052c6)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 702.890549 61.059578
+L 702.890549 35.026758
+" clip-path="url(#p64b47052c6)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 641.182595 177.353392
+L 641.182595 125.362148
+" clip-path="url(#p64b47052c6)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 611.050359 322.496254
+L 611.050359 301.373585
+" clip-path="url(#p64b47052c6)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+   </g>
+   <g id="line2d_60">
+    <g clip-path="url(#p64b47052c6)">
+     <use xlink:href="#m93f7e6b8ac" x="577.535372" y="39.576027" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="line2d_61">
+    <g clip-path="url(#p64b47052c6)">
+     <use xlink:href="#me396965dfb" x="478.915925" y="84.441627" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#me396965dfb" x="420.706321" y="151.740026" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#me396965dfb" x="555.046248" y="47.427507" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+    </g>
+   </g>
+   <g id="line2d_62">
+    <g clip-path="url(#p64b47052c6)">
+     <use xlink:href="#m6fe8dd9fab" x="580.535744" y="84.441627" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m6fe8dd9fab" x="530.597494" y="234.741385" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m6fe8dd9fab" x="507.558485" y="322.229304" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m6fe8dd9fab" x="487.767704" y="151.740026" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m6fe8dd9fab" x="440.635247" y="279.606985" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m6fe8dd9fab" x="424.144897" y="323.350944" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m6fe8dd9fab" x="702.890549" y="47.427507" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m6fe8dd9fab" x="641.182595" y="151.740026" style="fill: #2ca02c; stroke: #2ca02c"/>
+     <use xlink:href="#m6fe8dd9fab" x="611.050359" y="313.256185" style="fill: #2ca02c; stroke: #2ca02c"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 406.597109 326.715864
+L 406.597109 16.313214
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 716.99976 326.715864
+L 716.99976 16.313214
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 406.597109 326.715864
+L 716.99976 326.715864
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 406.597109 16.313214
+L 716.99976 16.313214
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_24">
+    <text style="font-size: 13.2px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="561.798435" y="10.313214" transform="rotate(-0 561.798435 10.313214)">W=1024, k=13</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_12">
+     <path d="M 597.880072 321.215864
+L 709.29976 321.215864
+Q 711.49976 321.215864 711.49976 319.015864
+L 711.49976 254.112427
+Q 711.49976 251.912427 709.29976 251.912427
+L 597.880072 251.912427
+Q 595.680072 251.912427 595.680072 254.112427
+L 595.680072 319.015864
+Q 595.680072 321.215864 597.880072 321.215864
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_25">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="632.961479" y="264.670708" transform="rotate(-0 632.961479 264.670708)">Method</text>
+    </g>
+    <g id="LineCollection_7">
+     <path d="M 611.080072 282.821568
+L 611.080072 271.821568
+" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    </g>
+    <g id="line2d_63"/>
+    <g id="line2d_64">
+     <g>
+      <use xlink:href="#m93f7e6b8ac" x="611.080072" y="277.321568" style="fill: #1f77b4; stroke: #1f77b4"/>
+     </g>
+    </g>
+    <g id="text_26">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="630.880072" y="281.171568" transform="rotate(-0 630.880072 281.171568)">Full sets</text>
+    </g>
+    <g id="LineCollection_8">
+     <path d="M 611.080072 299.322427
+L 611.080072 288.322427
+" style="fill: none; stroke: #ff7f0e; stroke-width: 1.5"/>
+    </g>
+    <g id="line2d_65"/>
+    <g id="line2d_66">
+     <g>
+      <use xlink:href="#me396965dfb" x="611.080072" y="293.822427" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     </g>
+    </g>
+    <g id="text_27">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="630.880072" y="297.672427" transform="rotate(-0 630.880072 297.672427)">MinHash scan</text>
+    </g>
+    <g id="LineCollection_9">
+     <path d="M 611.080072 315.823286
+L 611.080072 304.823286
+" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    </g>
+    <g id="line2d_67"/>
+    <g id="line2d_68">
+     <g>
+      <use xlink:href="#m6fe8dd9fab" x="611.080072" y="310.323286" style="fill: #2ca02c; stroke: #2ca02c"/>
+     </g>
+    </g>
+    <g id="text_28">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="630.880072" y="314.173286" transform="rotate(-0 630.880072 314.173286)">LSH</text>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p5aaf595626">
+   <rect x="45.997349" y="16.313214" width="310.402651" height="310.402651"/>
+  </clipPath>
+  <clipPath id="p64b47052c6">
+   <rect x="406.597109" y="16.313214" width="310.402651" height="310.402651"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/research/experiments/figures/568/window-screen.svg
+++ b/docs/research/experiments/figures/568/window-screen.svg
@@ -1,0 +1,463 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="432pt" height="360pt" viewBox="0 0 432 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-09-11T22:18:24.532176</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.2, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 360
+L 432 360
+L 432 0
+L 0 0
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 63.515638 323.998901
+L 368.484362 323.998901
+L 368.484362 19.030178
+L 63.515638 19.030178
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="mf39df40a8f" d="M 0 0
+L 0 3.5
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mf39df40a8f" x="77.377853" y="323.998901" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="77.377853" y="339.356323" transform="rotate(-0 77.377853 339.356323)">64</text>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#mf39df40a8f" x="146.688927" y="323.998901" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="146.688927" y="339.356323" transform="rotate(-0 146.688927 339.356323)">128</text>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#mf39df40a8f" x="215.608631" y="323.998901" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="215.608631" y="339.356323" transform="rotate(-0 215.608631 339.356323)">255</text>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mf39df40a8f" x="285.11558" y="323.998901" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="285.11558" y="339.356323" transform="rotate(-0 285.11558 339.356323)">511</text>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#mf39df40a8f" x="354.622147" y="323.998901" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="354.622147" y="339.356323" transform="rotate(-0 354.622147 339.356323)">1024</text>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <defs>
+       <path id="m7f3f78dd34" d="M 0 0
+L 0 2
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m7f3f78dd34" x="70.92434" y="323.998901" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m7f3f78dd34" x="86.338598" y="323.998901" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m7f3f78dd34" x="99.691035" y="323.998901" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m7f3f78dd34" x="111.468719" y="323.998901" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m7f3f78dd34" x="191.31529" y="323.998901" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m7f3f78dd34" x="231.859669" y="323.998901" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m7f3f78dd34" x="260.626364" y="323.998901" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m7f3f78dd34" x="282.939545" y="323.998901" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m7f3f78dd34" x="301.170742" y="323.998901" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m7f3f78dd34" x="316.585" y="323.998901" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m7f3f78dd34" x="329.937437" y="323.998901" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m7f3f78dd34" x="341.715121" y="323.998901" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_6">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="216" y="354.357182" transform="rotate(-0 216 354.357182)">Window length (bp)</text>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_18">
+      <defs>
+       <path id="me73a84fd86" d="M 0 0
+L -3.5 0
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#me73a84fd86" x="63.515638" y="323.998901" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="56.515638" y="328.177612" transform="rotate(-0 56.515638 328.177612)">0</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#me73a84fd86" x="63.515638" y="263.609054" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="56.515638" y="267.787765" transform="rotate(-0 56.515638 267.787765)">20</text>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#me73a84fd86" x="63.515638" y="203.219208" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="56.515638" y="207.397919" transform="rotate(-0 56.515638 207.397919)">40</text>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#me73a84fd86" x="63.515638" y="142.829362" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="56.515638" y="147.008073" transform="rotate(-0 56.515638 147.008073)">60</text>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#me73a84fd86" x="63.515638" y="82.439516" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="56.515638" y="86.618227" transform="rotate(-0 56.515638 86.618227)">80</text>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#me73a84fd86" x="63.515638" y="22.04967" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="56.515638" y="26.228381" transform="rotate(-0 56.515638 26.228381)">100</text>
+     </g>
+    </g>
+    <g id="text_13">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="28.87681" y="171.514539" transform="rotate(-90 28.87681 171.514539)">Known-pair recall at C=10 (%)</text>
+    </g>
+   </g>
+   <g id="LineCollection_1">
+    <path d="M 77.377853 56.738926
+L 77.377853 32.382533
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 146.688927 45.944933
+L 146.688927 25.520351
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 215.608631 39.515244
+L 215.608631 24.213795
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 285.11558 43.473468
+L 285.11558 26.377921
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    <path d="M 354.622147 52.461823
+L 354.622147 28.833785
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+   </g>
+   <g id="LineCollection_2">
+    <path d="M 77.377853 70.485212
+L 77.377853 41.347177
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.5"/>
+    <path d="M 146.688927 61.834938
+L 146.688927 35.826821
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.5"/>
+    <path d="M 215.608631 58.072858
+L 215.608631 33.530629
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.5"/>
+    <path d="M 285.11558 57.328961
+L 285.11558 32.265997
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.5"/>
+    <path d="M 354.622147 53.550814
+L 354.622147 30.995488
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.5"/>
+   </g>
+   <g id="LineCollection_3">
+    <path d="M 77.377853 82.638612
+L 77.377853 49.087386
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 146.688927 72.211529
+L 146.688927 43.3604
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 215.608631 69.784975
+L 215.608631 41.201386
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 285.11558 69.784975
+L 285.11558 41.201386
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    <path d="M 354.622147 68.849429
+L 354.622147 40.142318
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+   </g>
+   <g id="LineCollection_4">
+    <path d="M 77.377853 98.557426
+L 77.377853 59.936836
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #d62728; stroke-width: 1.5"/>
+    <path d="M 146.688927 93.407669
+L 146.688927 55.721187
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #d62728; stroke-width: 1.5"/>
+    <path d="M 215.608631 92.367355
+L 215.608631 54.720244
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #d62728; stroke-width: 1.5"/>
+    <path d="M 285.11558 93.892763
+L 285.11558 55.599584
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #d62728; stroke-width: 1.5"/>
+    <path d="M 354.622147 93.892763
+L 354.622147 55.599584
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #d62728; stroke-width: 1.5"/>
+   </g>
+   <g id="line2d_24">
+    <path d="M 77.377853 44.08976
+L 146.688927 35.273724
+L 215.608631 30.865706
+L 285.11558 34.171719
+L 354.622147 39.681742
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_25">
+    <path d="M 77.377853 55.109805
+L 146.688927 48.497778
+L 215.608631 45.191764
+L 285.11558 44.08976
+L 354.622147 41.885751
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_26">
+    <path d="M 77.377853 65.027845
+L 146.688927 57.313814
+L 215.608631 55.109805
+L 285.11558 55.109805
+L 354.622147 54.0078
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #2ca02c; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_27">
+    <path d="M 77.377853 78.251899
+L 146.688927 73.843881
+L 215.608631 72.741876
+L 285.11558 73.843881
+L 354.622147 73.843881
+" clip-path="url(#pe71cb9796c)" style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 63.515638 323.998901
+L 63.515638 19.030178
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 368.484362 323.998901
+L 368.484362 19.030178
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 63.515638 323.998901
+L 368.484362 323.998901
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 63.515638 19.030178
+L 368.484362 19.030178
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_14">
+    <text style="font-size: 13.2px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="216" y="13.030178" transform="rotate(-0 216 13.030178)">Full k-mer sets on development loci</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_7">
+     <path d="M 285.482487 318.498901
+L 360.784362 318.498901
+Q 362.984362 318.498901 362.984362 316.298901
+L 362.984362 234.894604
+Q 362.984362 232.694604 360.784362 232.694604
+L 285.482487 232.694604
+Q 283.282487 232.694604 283.282487 234.894604
+L 283.282487 316.298901
+Q 283.282487 318.498901 285.482487 318.498901
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_15">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="287.682487" y="245.452885" transform="rotate(-0 287.682487 245.452885)">k-mer length</text>
+    </g>
+    <g id="LineCollection_5">
+     <path d="M 311.734674 263.603744
+L 311.734674 252.603744
+" style="fill: none; stroke: #1f77b4; stroke-width: 1.5"/>
+    </g>
+    <g id="line2d_28">
+     <path d="M 300.734674 258.103744
+L 322.734674 258.103744
+" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+    </g>
+    <g id="line2d_29"/>
+    <g id="text_16">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="331.534674" y="261.953744" transform="rotate(-0 331.534674 261.953744)">9</text>
+    </g>
+    <g id="LineCollection_6">
+     <path d="M 311.734674 280.104604
+L 311.734674 269.104604
+" style="fill: none; stroke: #ff7f0e; stroke-width: 1.5"/>
+    </g>
+    <g id="line2d_30">
+     <path d="M 300.734674 274.604604
+L 322.734674 274.604604
+" style="fill: none; stroke: #ff7f0e; stroke-width: 1.5; stroke-linecap: square"/>
+    </g>
+    <g id="line2d_31"/>
+    <g id="text_17">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="331.534674" y="278.454604" transform="rotate(-0 331.534674 278.454604)">13</text>
+    </g>
+    <g id="LineCollection_7">
+     <path d="M 311.734674 296.605463
+L 311.734674 285.605463
+" style="fill: none; stroke: #2ca02c; stroke-width: 1.5"/>
+    </g>
+    <g id="line2d_32">
+     <path d="M 300.734674 291.105463
+L 322.734674 291.105463
+" style="fill: none; stroke: #2ca02c; stroke-width: 1.5; stroke-linecap: square"/>
+    </g>
+    <g id="line2d_33"/>
+    <g id="text_18">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="331.534674" y="294.955463" transform="rotate(-0 331.534674 294.955463)">17</text>
+    </g>
+    <g id="LineCollection_8">
+     <path d="M 311.734674 313.106322
+L 311.734674 302.106322
+" style="fill: none; stroke: #d62728; stroke-width: 1.5"/>
+    </g>
+    <g id="line2d_34">
+     <path d="M 300.734674 307.606322
+L 322.734674 307.606322
+" style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
+    </g>
+    <g id="line2d_35"/>
+    <g id="text_19">
+     <text style="font-size: 11px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="331.534674" y="311.456322" transform="rotate(-0 331.534674 311.456322)">21</text>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pe71cb9796c">
+   <rect x="63.515638" y="19.030178" width="304.968723" height="304.968723"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/research/questions/training-regions.md
+++ b/docs/research/questions/training-regions.md
@@ -38,7 +38,7 @@ The workflow placed every retained tile in one database and lacked distributed s
 This argues against further tuning of unordered short-window clustering for this purpose, while leaving targeted local alignment and methods with positional, syntenic, or anchor evidence as distinct directions.
 
 The [local k-mer follow-up](../experiments/568-kmer-conservation.md) recovered 97.1% of held-out mammalian homology pairs at ten unique candidate loci using complete k-mer sets, showing that local sequence similarity survives even when the earlier clustering recipe misses it.
-The tested MinHash/LSH settings did not improve the recall–runtime frontier over exact indexes, denser tiling and a two-scale union did not raise aggregate held-out recall, and strict full-window verification discarded most recovered pairs.
+The tested MinHash/LSH settings did not improve the recall–runtime frontier over exact indexes, quarter-window stride at W255/k9 and a two-scale union did not raise aggregate held-out recall over the selected half-stride representation, and strict full-window verification discarded most recovered pairs.
 This separates useful homology retrieval from a viable conservation selector: the study stopped before enrichment or training, and its homology-enriched candidate universe could not support an unbiased conservation-enrichment claim.
 
 The leading hypothesis is that increasing the density of constrained or correctly annotated sequence improves functional-VEP sample efficiency at fixed compute.
@@ -96,8 +96,6 @@ It should retain a background arm so gains on functional VEP can be weighed agai
   All four loss-ranked half-token objectives harmed Mendelian missense-plus-splicing AUPRC, while pure final-checkpoint teacher KL beat uniform CE at step 200 within the paired evaluation records; one seed, privileged later-lineage supervision, and unmatched per-step compute limit the inference.
 - [Anchor-free clustering of mammalian genome windows](../experiments/521-linclust-conservation.md) tested Linclust, exhaustive alignment controls, longer windows, hash ensembles, denser seeds, DECIPHER, and a source-aware seed graph against projected homology.
   The tested symmetric short-window recipes missed too many known pairs or admitted too many genomic decoys, and the single-database workflow failed at the exact 20-genome scale without a distributed path to all animals or eukaryotes, so this path was stopped without a phyloP selector or training run.
-
-
 - [Local k-mer retrieval of mammalian homologs](../experiments/568-kmer-conservation.md) found strong complete-set similarity on a bounded human/mouse/armadillo fixture, recovering 97.1% of held-out pairs at ten unique candidate loci.
   Sampled MinHash/LSH settings failed to improve the recall–runtime frontier over exact indexes, and projected homology, weak complexity controls, and independently sampled backgrounds did not establish conservation enrichment or training value.
 

--- a/docs/research/questions/training-regions.md
+++ b/docs/research/questions/training-regions.md
@@ -1,7 +1,7 @@
 # Which genomic regions to train on, and how to find them?
 
 > [!NOTE]
-> **TL;DR:** Targeted or conservation-selected corpora often improve functional prediction at current scales, and absolute loss or entropy can proxy conservation; hard loss-ranked token selection and anchor-free clustering of short mammalian genome windows both failed as practical selectors, while same-lineage teacher distillation outperformed uniform once and repeat downweighting remains untested.
+> **TL;DR:** Targeted or conservation-selected corpora often improve functional prediction at current scales, and absolute loss or entropy can proxy conservation; neither hard loss-ranked selection nor tested clustering/LSH pipelines produced a practical selector, despite strong homology retrieval with complete k-mer sets, while same-lineage teacher distillation outperformed uniform once and repeat downweighting remains untested.
 
 ## Question
 
@@ -36,6 +36,10 @@ On a projected three-species control in a five-million-window background, the be
 Extending windows from 255 to 511 bp reduced matched-anchor exhaustive recall, alternative seed and graph recipes traded away precision or recall, and monolithic Linclust segfaulted on the exact 298.5-million-window 20-genome panel.
 The workflow placed every retained tile in one database and lacked distributed sharding or cross-shard reconciliation, so it supplied no path from the mammalian proof of concept to all-animal or all-eukaryote coverage.
 This argues against further tuning of unordered short-window clustering for this purpose, while leaving targeted local alignment and methods with positional, syntenic, or anchor evidence as distinct directions.
+
+The [local k-mer follow-up](../experiments/568-kmer-conservation.md) recovered 97.1% of held-out mammalian homology pairs at ten unique candidate loci using complete k-mer sets, showing that local sequence similarity survives even when the earlier clustering recipe misses it.
+The tested MinHash/LSH settings did not improve the recall–runtime frontier over exact indexes, denser tiling and a two-scale union did not raise aggregate held-out recall, and strict full-window verification discarded most recovered pairs.
+This separates useful homology retrieval from a viable conservation selector: the study stopped before enrichment or training, and its homology-enriched candidate universe could not support an unbiased conservation-enrichment claim.
 
 The leading hypothesis is that increasing the density of constrained or correctly annotated sequence improves functional-VEP sample efficiency at fixed compute.
 Whole-genome data may become more useful at larger scale, under weighting that prevents easy background from dominating, or for mutation-process, repeat, phylogeny, and regional-context tasks.
@@ -93,6 +97,10 @@ It should retain a background arm so gains on functional VEP can be weighed agai
 - [Anchor-free clustering of mammalian genome windows](../experiments/521-linclust-conservation.md) tested Linclust, exhaustive alignment controls, longer windows, hash ensembles, denser seeds, DECIPHER, and a source-aware seed graph against projected homology.
   The tested symmetric short-window recipes missed too many known pairs or admitted too many genomic decoys, and the single-database workflow failed at the exact 20-genome scale without a distributed path to all animals or eukaryotes, so this path was stopped without a phyloP selector or training run.
 
+
+- [Local k-mer retrieval of mammalian homologs](../experiments/568-kmer-conservation.md) found strong complete-set similarity on a bounded human/mouse/armadillo fixture, recovering 97.1% of held-out pairs at ten unique candidate loci.
+  Sampled MinHash/LSH settings failed to improve the recall–runtime frontier over exact indexes, and projected homology, weak complexity controls, and independently sampled backgrounds did not establish conservation enrichment or training value.
+
 </details>
 
 <details>
@@ -104,6 +112,7 @@ It should retain a background arm so gains on functional VEP can be weighed agai
 - Measure the footprint tradeoff across Mendelian and complex-trait VEP, region-matched likelihood gaps, frozen probes, and at least one outcome expected to benefit from neutral sequence.
 - Ablate the current 100-fold repeat downweighting across model and token scales while holding footprint and sampling fixed.
 - Compare conservation or whole-genome alignment with direct annotation, targeted local alignment, and learned single-sequence selection only after the target distribution and leakage contract are fixed.
-- Do not revisit symmetric clustering of independently tiled 255 bp whole genomes without materially new positional, syntenic, or candidate-representation evidence; the bounded 511 bp projected-center diagnostic provides no reason to lengthen the window.
+- Use the complete-set k-mer signal as a bounded retrieval baseline when testing positional, syntenic, or local-alignment evidence; preserve unique-locus budgets and provide an unbiased conservation-enrichment cohort before treating retrieval as a selector.
+- Do not scale the tested symmetric clustering or MinHash/LSH recipes without a measured improvement over those baselines; longer or denser windows alone did not resolve the observed limitations.
 
 </details>


### PR DESCRIPTION
Complete local k-mer sets recovered 204/210 held-out mammalian homology pairs at ten unique candidate loci, but the tested MinHash/LSH settings did not improve the recall–runtime frontier over exact indexes.
This adds the bounded study's interpretation, figures, and training-regions synthesis, including limits on complexity controls, conservation inference, and scaling.
The indexed selector path stops before enrichment or training under the experiment's advancement gate.

Related to [#568](https://github.com/Open-Athena/marin-dna/issues/568).
The [published selection](https://github.com/Open-Athena/marin-dna/blob/f577dbe82a9b4e4a2631f9ee9bb202ef534bd30b/experiments/kmer_conservation/config/frozen_selection.json) predates held-out evaluation, and the [final result matrix](https://github.com/Open-Athena/marin-dna/blob/74e51fdfa6f387d7e5191e3f05bd6d22f29bd770/.agents/artifacts/issue-568-kmer-conservation/final/metrics.csv) remains on the permanent experiment branch.

Validation: 26 experiment tests pass; artifact audits cover 76 real, 22 synthetic, and five duplicate-challenge prediction files.
Pinned repository pre-commit checks pass on the four documentation files; relative links and SVG XML pass, and the rendered figures were inspected.
Independent review of the published interpretation found no actionable issues at `4b6a77cc`; all PR checks pass.
